### PR TITLE
feat: adding component that allows mirror transports to be used

### DIFF
--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor.meta
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3301f814d14ed8e48a01defbc57175bc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransport.cs
@@ -19,6 +19,10 @@ namespace Mirror
     /// </remarks>
     public abstract class MirrorTransport : MonoBehaviour
     {
+        public static class Channels
+        {
+            public const int DefaultReliable = 0;
+        }
         /// <summary>
         /// Is this transport available in the current platform?
         /// <para>Some transports might only be available in mobile</para>
@@ -173,7 +177,7 @@ namespace Mirror
         /// </summary>
         /// <param name="channelId">channel id</param>
         /// <returns>the size in bytes that can be sent via the provided channel</returns>
-        public abstract int GetMaxPacketSize(int channelId = 0);
+        public abstract int GetMaxPacketSize(int channelId = Channels.DefaultReliable);
 
         /// <summary>
         /// Shut down the transport, both as client and server

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransport.cs
@@ -1,0 +1,214 @@
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Mirror
+{
+    // UnityEvent definitions
+    [Serializable] public class ClientDataReceivedEvent : UnityEvent<ArraySegment<byte>, int> { }
+    [Serializable] public class UnityEventException : UnityEvent<Exception> { }
+    [Serializable] public class UnityEventInt : UnityEvent<int> { }
+    [Serializable] public class ServerDataReceivedEvent : UnityEvent<int, ArraySegment<byte>, int> { }
+    [Serializable] public class UnityEventIntException : UnityEvent<int, Exception> { }
+
+    /// <summary>
+    /// Abstract transport layer component
+    /// </summary>
+    /// <remarks>
+    /// note: Not all transports need a port, so add it to yours if needed.
+    /// </remarks>
+    public abstract class MirrorTransport : MonoBehaviour
+    {
+        /// <summary>
+        /// Is this transport available in the current platform?
+        /// <para>Some transports might only be available in mobile</para>
+        /// <para>Many will not work in webgl</para>
+        /// <para>Example usage: return Application.platform == RuntimePlatform.WebGLPlayer</para>
+        /// </summary>
+        /// <returns>True if this transport works in the current platform</returns>
+        public abstract bool Available();
+
+        #region Client
+        /// <summary>
+        /// Notify subscribers when when this client establish a successful connection to the server
+        /// </summary>
+        [HideInInspector] public UnityEvent OnClientConnected = new UnityEvent();
+
+        /// <summary>
+        /// Notify subscribers when this client receive data from the server
+        /// </summary>
+        // Note: we provide channelId for NetworkDiagnostics.
+        [HideInInspector] public ClientDataReceivedEvent OnClientDataReceived = new ClientDataReceivedEvent();
+
+        /// <summary>
+        /// Notify subscribers when this client encounters an error communicating with the server
+        /// </summary>
+        [HideInInspector] public UnityEventException OnClientError = new UnityEventException();
+
+        /// <summary>
+        /// Notify subscribers when this client disconnects from the server
+        /// </summary>
+        [HideInInspector] public UnityEvent OnClientDisconnected = new UnityEvent();
+
+        /// <summary>
+        /// Determines if we are currently connected to the server
+        /// </summary>
+        /// <returns>True if a connection has been established to the server</returns>
+        public abstract bool ClientConnected();
+
+        /// <summary>
+        /// Establish a connection to a server
+        /// </summary>
+        /// <param name="address">The IP address or FQDN of the server we are trying to connect to</param>
+        public abstract void ClientConnect(string address);
+
+        /// <summary>
+        /// Establish a connection to a server
+        /// </summary>
+        /// <param name="uri">The address of the server we are trying to connect to</param>
+        public virtual void ClientConnect(Uri uri)
+        {
+            // By default, to keep backwards compatibility, just connect to the host
+            // in the uri
+            ClientConnect(uri.Host);
+        }
+
+        /// <summary>
+        /// Send data to the server
+        /// </summary>
+        /// <param name="channelId">The channel to use.  0 is the default channel,
+        /// but some transports might want to provide unreliable, encrypted, compressed, or any other feature
+        /// as new channels</param>
+        /// <param name="segment">The data to send to the server. Will be recycled after returning, so either use it directly or copy it internally. This allows for allocation-free sends!</param>
+        public abstract void ClientSend(int channelId, ArraySegment<byte> segment);
+
+        /// <summary>
+        /// Disconnect this client from the server
+        /// </summary>
+        public abstract void ClientDisconnect();
+
+        #endregion
+
+        #region Server
+
+
+        /// <summary>
+        /// Retrieves the address of this server.
+        /// Useful for network discovery
+        /// </summary>
+        /// <returns>the url at which this server can be reached</returns>
+        public abstract Uri ServerUri();
+
+        /// <summary>
+        /// Notify subscribers when a client connects to this server
+        /// </summary>
+        [HideInInspector] public UnityEventInt OnServerConnected = new UnityEventInt();
+
+        /// <summary>
+        /// Notify subscribers when this server receives data from the client
+        /// </summary>
+        // Note: we provide channelId for NetworkDiagnostics.
+        [HideInInspector] public ServerDataReceivedEvent OnServerDataReceived = new ServerDataReceivedEvent();
+
+        /// <summary>
+        /// Notify subscribers when this server has some problem communicating with the client
+        /// </summary>
+        [HideInInspector] public UnityEventIntException OnServerError = new UnityEventIntException();
+
+        /// <summary>
+        /// Notify subscribers when a client disconnects from this server
+        /// </summary>
+        [HideInInspector] public UnityEventInt OnServerDisconnected = new UnityEventInt();
+
+        /// <summary>
+        /// Determines if the server is up and running
+        /// </summary>
+        /// <returns>true if the transport is ready for connections from clients</returns>
+        public abstract bool ServerActive();
+
+        /// <summary>
+        /// Start listening for clients
+        /// </summary>
+        public abstract void ServerStart();
+
+        /// <summary>
+        /// Send data to a client.
+        /// </summary>
+        /// <param name="connectionId">The client connection id to send the data to</param>
+        /// <param name="channelId">The channel to be used.  Transports can use channels to implement
+        /// other features such as unreliable, encryption, compression, etc...</param>
+        /// <param name="data"></param>
+        public abstract void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment);
+
+        /// <summary>
+        /// Disconnect a client from this server.  Useful to kick people out.
+        /// </summary>
+        /// <param name="connectionId">the id of the client to disconnect</param>
+        /// <returns>true if the client was kicked</returns>
+        public abstract bool ServerDisconnect(int connectionId);
+
+        /// <summary>
+        /// Get the client address
+        /// </summary>
+        /// <param name="connectionId">id of the client</param>
+        /// <returns>address of the client</returns>
+        public abstract string ServerGetClientAddress(int connectionId);
+
+        /// <summary>
+        /// Stop listening for clients and disconnect all existing clients
+        /// </summary>
+        public abstract void ServerStop();
+
+        #endregion
+
+        /// <summary>
+        /// The maximum packet size for a given channel.  Unreliable transports
+        /// usually can only deliver small packets. Reliable fragmented channels
+        /// can usually deliver large ones.
+        ///
+        /// GetMaxPacketSize needs to return a value at all times. Even if the
+        /// Transport isn't running, or isn't Available(). This is because
+        /// Fallback and Multiplex transports need to find the smallest possible
+        /// packet size at runtime.
+        /// </summary>
+        /// <param name="channelId">channel id</param>
+        /// <returns>the size in bytes that can be sent via the provided channel</returns>
+        public abstract int GetMaxPacketSize(int channelId = 0);
+
+        /// <summary>
+        /// Shut down the transport, both as client and server
+        /// </summary>
+        public abstract void Shutdown();
+
+        // block Update() to force Transports to use LateUpdate to avoid race
+        // conditions. messages should be processed after all the game state
+        // was processed in Update.
+        // -> in other words: use LateUpdate!
+        // -> uMMORPG 480 CCU stress test: when bot machine stops, it causes
+        //    'Observer not ready for ...' log messages when using Update
+        // -> occupying a public Update() function will cause Warnings if a
+        //    transport uses Update.
+        //
+        // IMPORTANT: set script execution order to >1000 to call Transport's
+        //            LateUpdate after all others. Fixes race condition where
+        //            e.g. in uSurvival Transport would apply Cmds before
+        //            ShoulderRotation.LateUpdate, resulting in projectile
+        //            spawns at the point before shoulder rotation.
+#pragma warning disable UNT0001 // Empty Unity message
+        public void Update() { }
+#pragma warning restore UNT0001 // Empty Unity message
+
+        /// <summary>
+        /// called when quitting the application by closing the window / pressing stop in the editor
+        /// <para>virtual so that inheriting classes' OnApplicationQuit() can call base.OnApplicationQuit() too</para>
+        /// </summary>
+        public virtual void OnApplicationQuit()
+        {
+            // stop transport (e.g. to shut down threads)
+            // (when pressing Stop in the Editor, Unity keeps threads alive
+            //  until we press Start again. so if Transports use threads, we
+            //  really want them to end now and not after next start)
+            Shutdown();
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransport.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f5415dc4f1019d43bb605744790cdc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -128,6 +128,18 @@ namespace Mirror.TransportAdaptor
             {
                 connected = true;
             });
+            inner.OnClientDataReceived.AddListener((data, channel) =>
+            {
+                clientConnection.OnData(data, channel);
+            });
+            inner.OnClientDisconnected.AddListener(() =>
+            {
+                clientConnection.MarkAsClosed();
+            });
+            inner.OnClientError.AddListener((ex) =>
+            {
+                Debug.LogException(ex);
+            });
 
             // todo is host name enough for this?
             inner.ClientConnect(uri.Host);
@@ -167,7 +179,10 @@ namespace Mirror.TransportAdaptor
             });
             inner.OnServerDisconnected.AddListener((id) =>
             {
-                serverConnections.MarkAsClosed();
+                if (serverConnections.TryGetValue(id, out ServerAdaptorConnection conn))
+                {
+                    conn.MarkAsClosed();
+                }
                 serverConnections.Remove(id);
             });
             inner.OnServerError.AddListener((id, ex) =>

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace Mirror.TransportAdaptor
+{
+    public class AdaptorConnection : IConnection
+    {
+        public void Disconnect()
+        {
+            throw new NotImplementedException();
+        }
+
+        public EndPoint GetEndPointAddress()
+        {
+            throw new NotImplementedException();
+        }
+
+        public UniTask<int> ReceiveAsync(MemoryStream buffer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public UniTask SendAsync(ArraySegment<byte> data, int channel = 0)
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public class MirrorTransportAdaptor : Transport
+    {
+        [SerializeField] MirrorTransport inner;
+        [SerializeField] string scheme;
+
+        private AdaptorConnection clientConnection;
+
+        public override IEnumerable<string> Scheme { get { yield return scheme; } }
+        public override bool Supported => inner.Available();
+
+        public override async UniTask<IConnection> ConnectAsync(Uri uri)
+        {
+            bool connected = false;
+            inner.OnClientConnected.AddListener(() =>
+            {
+                connected = true;
+            });
+
+            // todo is host name enough for this?
+            inner.ClientConnect(uri.Host);
+
+            while (!connected)
+            {
+                await UniTask.Yield();
+            }
+
+            clientConnection = new AdaptorConnection();
+            return clientConnection;
+        }
+
+        public override void Disconnect()
+        {
+            clientConnection?.Disconnect();
+        }
+
+        public override UniTask ListenAsync()
+        {
+            inner.ServerStart();
+        }
+
+        public override IEnumerable<Uri> ServerUri()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -101,7 +101,7 @@ namespace Mirror.TransportAdaptor
         internal void OnData(ArraySegment<byte> data, int channel)
         {
             dataQueue.Enqueue((data, channel));
-            dataAvailable.TrySetResult();
+            dataAvailable?.TrySetResult();
         }
     }
     public class MirrorTransportAdaptor : Transport

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -170,7 +170,9 @@ namespace Mirror.TransportAdaptor
         {
             inner.OnServerConnected.AddListener((id) =>
             {
-                serverConnections.Add(id, new ServerAdaptorConnection(id, this));
+                var conn = new ServerAdaptorConnection(id, this);
+                serverConnections.Add(id, conn);
+                Connected?.Invoke(conn);
             });
             inner.OnServerDataReceived.AddListener((id, data, channel) =>
             {
@@ -199,6 +201,7 @@ namespace Mirror.TransportAdaptor
             listenCompletionSource = new UniTaskCompletionSource();
             serverConnections = new Dictionary<int, ServerAdaptorConnection>();
             inner.ServerStart();
+            Started?.Invoke();
             return listenCompletionSource.Task;
         }
 

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -15,8 +15,6 @@ namespace Mirror.TransportAdaptor
 
         public override void Disconnect() => transport.ServerDisconnect(id);
 
-        public override EndPoint GetEndPointAddress() => throw new NotImplementedException();
-
         public override UniTask SendAsync(ArraySegment<byte> data, int channel = 0)
         {
             transport.ServerSend(id, channel, data);
@@ -30,8 +28,6 @@ namespace Mirror.TransportAdaptor
         }
 
         public override void Disconnect() => transport.ClientDisconnect();
-
-        public override EndPoint GetEndPointAddress() => throw new NotImplementedException();
 
         public override UniTask SendAsync(ArraySegment<byte> data, int channel = 0)
         {
@@ -56,8 +52,8 @@ namespace Mirror.TransportAdaptor
         }
 
         public abstract void Disconnect();
-        public abstract EndPoint GetEndPointAddress();
         public abstract UniTask SendAsync(ArraySegment<byte> data, int channel = 0);
+        public virtual EndPoint GetEndPointAddress() => null;
 
         Queue<(ArraySegment<byte> data, int channel)> dataQueue = new Queue<(ArraySegment<byte> data, int channel)>();
         private AutoResetUniTaskCompletionSource dataAvailable;
@@ -70,9 +66,9 @@ namespace Mirror.TransportAdaptor
 
             (ArraySegment<byte> data, int channel) = dataQueue.Dequeue();
 
-            buffer.SetLength(data.Count);
             buffer.Write(data.Array, data.Offset, data.Count);
-            buffer.Position = data.Count;
+            buffer.Position = 0;
+            buffer.SetLength(data.Count);
 
             return channel;
         }
@@ -202,6 +198,7 @@ namespace Mirror.TransportAdaptor
             serverConnections = new Dictionary<int, ServerAdaptorConnection>();
             inner.ServerStart();
             Started?.Invoke();
+
             return listenCompletionSource.Task;
         }
 

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -96,6 +96,7 @@ namespace Mirror.TransportAdaptor
 
         internal void OnData(ArraySegment<byte> data, int channel)
         {
+            // todo copy to a new buffer, inner transport might re-use the ArraySegment for other data 
             dataQueue.Enqueue((data, channel));
             dataAvailable?.TrySetResult();
         }

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -68,8 +68,6 @@ namespace Mirror.TransportAdaptor
 
             ThrowIfClosed();
 
-            throw new NotImplementedException();
-
             (ArraySegment<byte> data, int channel) = dataQueue.Dequeue();
 
             buffer.SetLength(data.Count);

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs
@@ -123,7 +123,6 @@ namespace Mirror.TransportAdaptor
         public override async UniTask<IConnection> ConnectAsync(Uri uri)
         {
             bool connected = false;
-            // todo what about other client events
             inner.OnClientConnected.AddListener(() =>
             {
                 connected = true;

--- a/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/MirrorTransportAdaptor/MirrorTransportAdaptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eab04de68f654a54880c75991ec70638
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This will allow mirror transports to be used without needing to convert the transport. This is not meant to be optimal but will allow transports to work. This will help people who want to migrate to NG without completely changing transports (in cases where an NG alternative is not available) 

Will be made into an addon once the other transport changes have been made