### PR TITLE
feat: make networkscenemanager optional again

### DIFF
--- a/Assets/Mirage/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirage/Runtime/PlayerSpawner.cs
@@ -68,6 +68,7 @@ namespace Mirage
             if (Client != null && SceneManager != null)
             {
                 SceneManager.ClientSceneChanged.RemoveListener(OnClientSceneChanged);
+                Client.Authenticated.RemoveListener(c => Client.Send(new AddPlayerMessage()));
             }
             if (Server != null)
             {

--- a/Assets/Mirage/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirage/Runtime/PlayerSpawner.cs
@@ -65,7 +65,7 @@ namespace Mirage
 
         void OnDestroy()
         {
-            if (Client != null)
+            if (Client != null && SceneManager != null)
             {
                 SceneManager.ClientSceneChanged.RemoveListener(OnClientSceneChanged);
             }

--- a/Assets/Mirage/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirage/Runtime/PlayerSpawner.cs
@@ -35,7 +35,15 @@ namespace Mirage
             }
             if (Client != null)
             {
-                SceneManager.ClientSceneChanged.AddListener(OnClientSceneChanged);
+                if(SceneManager != null)
+                {
+                    SceneManager.ClientSceneChanged.AddListener(OnClientSceneChanged);
+                }
+                else
+                {
+                    Client.Authenticated.AddListener(c => Client.Send(new AddPlayerMessage()));
+                }
+
                 if(ClientObjectManager != null)
                 {
                     ClientObjectManager.RegisterPrefab(PlayerPrefab);

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -67,8 +67,12 @@ namespace Mirage
                 Server.OnStartHost.AddListener(StartedHost);
                 Server.Authenticated.AddListener(OnAuthenticated);
                 Server.Stopped.AddListener(OnServerStopped);
-                NetworkSceneManager.ServerChangeScene.AddListener(OnServerChangeScene);
-                NetworkSceneManager.ServerSceneChanged.AddListener(OnServerSceneChanged);
+
+                if(NetworkSceneManager != null)
+                {
+                    NetworkSceneManager.ServerChangeScene.AddListener(OnServerChangeScene);
+                    NetworkSceneManager.ServerSceneChanged.AddListener(OnServerSceneChanged);
+                }
             }
         }
 


### PR DESCRIPTION
fix: #586

I used the Tanks example and just deleted the NetworkSceneManager component and hit play. After these changes everything works as normal.