### PR TITLE
feat: optional dontdestroyonload for networkscenemanager

### DIFF
--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -26,6 +26,11 @@ namespace Mirage
         [FormerlySerializedAs("server")]
         public NetworkServer Server;
 
+        /// <summary>
+        /// Sets the NetworksSceneManagers GameObject to DontDestroyOnLoad. Default = true.
+        /// </summary>
+        public bool DontDestroy = true;
+
         [Header("Events")]
         /// <summary>
         /// Event fires when the Client starts changing scene.
@@ -65,7 +70,8 @@ namespace Mirage
 
         public void Start()
         {
-            DontDestroyOnLoad(gameObject);
+            if(DontDestroy)
+                DontDestroyOnLoad(gameObject);
 
             if (Client != null)
             {


### PR DESCRIPTION
related to #587.

Without cutting any deeper I am ok with adding the option but defaulting it to enabled for now. I still think the current behavior is what most people would use. If not its a simple check box to change it :)

!!!NOTE: If you disable the DDOL setting for NetworkSceneManager and do a Normal (non additive) scene change you will need to take extra steps to ensure your Network containing GameObject is not destroyed in that operation!!!