### PR TITLE
refactor: load and stores use field references

### DIFF
--- a/Assets/Mirage/Weaver/Processors/FieldReferenceComparator.cs
+++ b/Assets/Mirage/Weaver/Processors/FieldReferenceComparator.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace Mirage.Weaver
+{
+    internal class FieldReferenceComparator : IEqualityComparer<FieldReference>
+    {
+        public bool Equals(FieldReference x, FieldReference y)
+        {
+            return x.FullName == y.FullName;
+        }
+
+        public int GetHashCode(FieldReference obj) => obj.FullName.GetHashCode();
+    }
+}

--- a/Assets/Mirage/Weaver/Processors/FieldReferenceComparator.cs.meta
+++ b/Assets/Mirage/Weaver/Processors/FieldReferenceComparator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31a7f2629dc8c4af9b7f6a123affdb97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
We load and store field references,  so use that.