### PR TITLE
fix: setting NI syncvars make them dirty

### DIFF
--- a/Assets/Mirage/Weaver/Processors/FieldReferenceComparator.cs
+++ b/Assets/Mirage/Weaver/Processors/FieldReferenceComparator.cs
@@ -7,7 +7,7 @@ namespace Mirage.Weaver
     {
         public bool Equals(FieldReference x, FieldReference y)
         {
-            return x.FullName == y.FullName;
+            return x.DeclaringType.FullName == y.DeclaringType.FullName && x.Name == y.Name;
         }
 
         public int GetHashCode(FieldReference obj) => obj.FullName.GetHashCode();


### PR DESCRIPTION
When replacing uses of NetworkIdentities
we have to make sure to match them by name only
because the type changes to NetworkIdentitySyncVar