### PR TITLE
fix: stopping `: ` being at the start of all log messages

### DIFF
--- a/Assets/Mirage/Runtime/LogFactory.cs
+++ b/Assets/Mirage/Runtime/LogFactory.cs
@@ -40,12 +40,12 @@ namespace Mirage
     {
         public static void LogError(this ILogger logger, object message)
         {
-            logger.LogError(null, message);
+            logger.Log(LogType.Error, message);
         }
 
         public static void LogWarning(this ILogger logger, object message)
         {
-            logger.LogWarning(null, message);
+            logger.Log(LogType.Warning, message);
         }
 
         public static bool LogEnabled(this ILogger logger) => logger.IsLogTypeAllowed(LogType.Log);

--- a/Assets/Tests/Editor/LogFactoryTests.cs
+++ b/Assets/Tests/Editor/LogFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿using NSubstitute;
+using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -43,8 +43,59 @@ namespace Mirage
 
             ILogHandler mockHandler = Substitute.For<ILogHandler>();
             logger.logHandler = mockHandler;
-            logger.Log("This message be logged");
-            mockHandler.Received().LogFormat(LogType.Log, null, "{0}", "This message be logged");
+            const string msg = "This message be logged";
+            logger.Log(msg);
+            mockHandler.Received().LogFormat(LogType.Log, null, "{0}", msg);
+        }
+
+        [Test]
+        public void LogWarningIgnore()
+        {
+            ILogger logger = LogFactory.GetLogger<LogFactoryTests>();
+            logger.filterLogType = LogType.Error;
+
+            ILogHandler mockHandler = Substitute.For<ILogHandler>();
+            logger.logHandler = mockHandler;
+            logger.LogWarning("This message should not be logged");
+            mockHandler.DidNotReceiveWithAnyArgs().LogFormat(default, null, null);
+        }
+
+        [Test]
+        public void LogWarningFull()
+        {
+            ILogger logger = LogFactory.GetLogger<LogFactoryTests>();
+            logger.filterLogType = LogType.Warning;
+
+            ILogHandler mockHandler = Substitute.For<ILogHandler>();
+            logger.logHandler = mockHandler;
+            const string msg = "This message be logged";
+            logger.LogWarning(msg);
+            mockHandler.Received().LogFormat(LogType.Warning, null, "{0}", msg);
+        }
+
+        [Test]
+        public void LogErrorIgnore()
+        {
+            ILogger logger = LogFactory.GetLogger<LogFactoryTests>();
+            logger.filterLogType = LogType.Exception;
+
+            ILogHandler mockHandler = Substitute.For<ILogHandler>();
+            logger.logHandler = mockHandler;
+            logger.LogError("This message should not be logged");
+            mockHandler.DidNotReceiveWithAnyArgs().LogFormat(default, null, null);
+        }
+
+        [Test]
+        public void LogErrorFull()
+        {
+            ILogger logger = LogFactory.GetLogger<LogFactoryTests>();
+            logger.filterLogType = LogType.Error;
+
+            ILogHandler mockHandler = Substitute.For<ILogHandler>();
+            logger.logHandler = mockHandler;
+            const string msg = "This message be logged";
+            logger.LogError(msg);
+            mockHandler.Received().LogFormat(LogType.Error, null, "{0}", msg);
         }
     }
 }


### PR DESCRIPTION
when using `LogError(null, msg)` it uses the first arg as a tag for the message like `tag: msg`, but if the tag is null is still adds the colon leading the the log being `: msg`