### PR TITLE
fix: networkproximitychecker not invoking rebuildobservers

### DIFF
--- a/Assets/Mirage/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirage/Components/NetworkProximityChecker.cs
@@ -33,7 +33,7 @@ namespace Mirage
         [Tooltip("Enable to force this object to be hidden from players.")]
         public bool ForceHidden;
 
-        public void Start()
+        public void Awake()
         {
             NetIdentity.OnStartServer.AddListener(() => {
                 InvokeRepeating(nameof(RebuildObservers), 0, VisibilityUpdateInterval);


### PR DESCRIPTION
Saw this behavior while testing the Additive Scenes sample.

The proximity checks never seem to fire because the InvokeRepeating(RebuildObservers) is added in an OnStartServer listener which its self is added on Start() which appears to be called after OnStartServer.

Other OnStartServer.AddListener calls appear to be in Awake and applying the same here appears to resolve the issue.