### PR TITLE
refactor: move LocalPlayer to ClientObjectManager

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -39,6 +39,11 @@ namespace Mirage
         [SerializeField] SpawnEvent _unSpawned = new SpawnEvent();
         public SpawnEvent UnSpawned => _unSpawned;
 
+        /// <summary>
+        /// NetworkIdentity of the localPlayer
+        /// </summary>
+        public NetworkIdentity LocalPlayer => Client.Connection?.Identity;
+
         [Header("Prefabs")]
         /// <summary>
         /// List of prefabs that will be registered with the spawning system.
@@ -578,7 +583,7 @@ namespace Mirage
 
         void CheckForLocalPlayer(NetworkIdentity identity)
         {
-            if (identity && identity == Client.LocalPlayer)
+            if (identity && identity == LocalPlayer)
             {
                 // Set isLocalPlayer to true on this NetworkIdentity and trigger OnStartLocalPlayer in all scripts on the same GO
                 identity.ConnectionToServer = Client.Connection;

--- a/Assets/Mirage/Runtime/IClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/IClientObjectManager.cs
@@ -24,6 +24,11 @@ namespace Mirage
         /// </summary>
         SpawnEvent UnSpawned { get; }
 
+        /// <summary>
+        /// NetworkIdentity of the localPlayer
+        /// </summary>
+        NetworkIdentity LocalPlayer { get; }
+
         NetworkIdentity GetPrefab(Guid assetId);
 
         void RegisterPrefab(NetworkIdentity identity);

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -27,11 +27,6 @@ namespace Mirage
         INetworkConnection Connection { get; }
 
         /// <summary>
-        /// NetworkIdentity of the localPlayer
-        /// </summary>
-        NetworkIdentity LocalPlayer { get; }
-
-        /// <summary>
         /// active is true while a client is connecting/connected
         /// (= while the network is active)
         /// </summary>

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -59,11 +59,6 @@ namespace Mirage
         /// </summary>
         public INetworkConnection Connection { get; internal set; }
 
-        /// <summary>
-        /// NetworkIdentity of the localPlayer
-        /// </summary>
-        public NetworkIdentity LocalPlayer => Connection?.Identity;
-
         internal ConnectState connectState = ConnectState.Disconnected;
 
         /// <summary>

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -129,7 +129,7 @@ namespace Mirage
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool IsLocalPlayer => Client != null && Client.LocalPlayer == this;
+        public bool IsLocalPlayer => Client != null && ClientObjectManager.LocalPlayer == this;
 
         /// <summary>
         /// This returns true if this object is the authoritative player object on the client.

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -129,7 +129,7 @@ namespace Mirage
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool IsLocalPlayer => Client != null && ClientObjectManager.LocalPlayer == this;
+        public bool IsLocalPlayer => ClientObjectManager != null && ClientObjectManager.LocalPlayer == this;
 
         /// <summary>
         /// This returns true if this object is the authoritative player object on the client.

--- a/Assets/Mirage/Samples~/Tanks/Scripts/TankGameManager.cs
+++ b/Assets/Mirage/Samples~/Tanks/Scripts/TankGameManager.cs
@@ -144,10 +144,10 @@ namespace Mirage.Examples.Tanks
         void FindLocalTank()
         {
             //Check to see if the player is loaded in yet
-            if (NetworkManager.Client.LocalPlayer == null)
+            if (NetworkManager.ClientObjectManager.LocalPlayer == null)
                 return;
 
-            LocalPlayer = NetworkManager.Client.LocalPlayer.GetComponent<Tank>();
+            LocalPlayer = NetworkManager.ClientObjectManager.LocalPlayer.GetComponent<Tank>();
         }
 
         void UpdateStats()


### PR DESCRIPTION
This object layer ref should not exist on the NetworkClient. This is a breaking change.