### PR TITLE
fix: welcome window icon not being found

### DIFF
--- a/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
+++ b/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
@@ -2,7 +2,7 @@
     <Style src="WelcomeWindow.uss" />
     <ui:VisualElement name="Banner">
         <ui:Label name="VersionText" text="Placeholder" />
-        <ui:Image name="Icon" style="background-image: url(&apos;/Assets/Mirage/Editor/WelcomeWindow/Resources/MirageIcon.png&apos;);" />
+        <ui:Image name="Icon" style="background-image: url(&apos;/Packages/com.miragenet.mirage/Editor/WelcomeWindow/Resources/MirageIcon.png&apos;);" />
     </ui:VisualElement>
     <ui:Label name="Title" text="Welcome to Mirage!" />
     <ui:Box name="ColumnContainer">

--- a/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
+++ b/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
@@ -2,7 +2,7 @@
     <Style src="WelcomeWindow.uss" />
     <ui:VisualElement name="Banner">
         <ui:Label name="VersionText" text="Placeholder" />
-        <ui:Image name="Icon" style="background-image: url(&apos;/Packages/com.miragenet.mirage/Editor/WelcomeWindow/Resources/MirageIcon.png&apos;);" />
+        <ui:Image name="Icon" style="background-image: resource('MirageIcon.png');" />
     </ui:VisualElement>
     <ui:Label name="Title" text="Welcome to Mirage!" />
     <ui:Box name="ColumnContainer">


### PR DESCRIPTION
Currently, the welcome window tries to find the icon in Assets/Mirage. The uxml url is now changed to reference the icon from the packages folder.