### PR TITLE
fix: remove sponsor tab in welcome window

### DIFF
--- a/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
+++ b/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
@@ -13,7 +13,6 @@
             <ui:Button name="FaqButton" text="FAQ" class="light-selected-tab dark-selected-tab" />
             <ui:Button name="BestPracticesButton" text="Best Practices" class="light-selected-tab dark-selected-tab" />
             <ui:Button name="ChangeLogButton" text="Change Log" class="light-selected-tab dark-selected-tab" />
-            <ui:Button name="SponsorButton" text="Sponsor Us" style="display: none;" />
             <ui:Button name="DiscordButton" text="Discord" class="light-selected-tab dark-selected-tab" />
         </ui:VisualElement>
         <ui:VisualElement name="Spacer" />
@@ -47,12 +46,6 @@
                 <ui:Label name="Description" text="The FAQ page holds commonly asked questions. Currently, the FAQ page contains answers to: &#10;&#10;   1. Syncing custom data types &#10;   2. How to connect &#10;   3. Host migration &#10;   4. Server lists and matchmaking" style="-unity-text-align: upper-left;" />
                 <ui:VisualElement name="Spacer" />
                 <ui:Button name="Redirect" text="Open FAQ" class="redirect" />
-            </ui:VisualElement>
-            <ui:VisualElement name="Sponsor" style="flex-grow: 0; width: 100%; height: 100%; display: none;">
-                <ui:Label name="Header" text="Sponsor Us" />
-                <ui:Label name="Description" text="Sponsoring will give you access to Mirage PRO which gives you special access to tools and priority support" style="-unity-text-align: upper-left;" />
-                <ui:VisualElement name="Spacer" />
-                <ui:Button name="Redirect" text="Sponsor Us" class="redirect" />
             </ui:VisualElement>
             <ui:VisualElement name="Discord" style="flex-grow: 0; width: 100%; height: 100%; display: none;">
                 <ui:Label name="Header" text="Discord" />

--- a/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
+++ b/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
@@ -31,7 +31,6 @@ namespace Mirage
         private const string ChangelogUrl = "https://github.com/MirageNet/Mirage/blob/master/Assets/Mirage/CHANGELOG.md";
         private const string BestPracticesUrl = "https://miragenet.github.io/Mirage/Articles/Guides/BestPractices.html";
         private const string FaqUrl = "https://miragenet.github.io/Mirage/Articles/Guides/FAQ.html";
-        private const string SponsorUrl = "";
         private const string DiscordInviteUrl = "https://discord.gg/DTBPBYvexy";
 
         private readonly List<Package> Packages = new List<Package>()
@@ -143,7 +142,6 @@ namespace Mirage
             ConfigureTab("QuickStartButton", "QuickStart", QuickStartUrl);
             ConfigureTab("BestPracticesButton", "BestPractices", BestPracticesUrl);
             ConfigureTab("FaqButton", "Faq", FaqUrl);
-            ConfigureTab("SponsorButton", "Sponsor", SponsorUrl);
             ConfigureTab("DiscordButton", "Discord", DiscordInviteUrl);
             ConfigurePackagesTab();
 


### PR DESCRIPTION
When launching the welcome window in my project, the tab was visible. This PR will remove it since it is useless.