### PR TITLE
fix: mirage icon missing in welcome window

### DIFF
--- a/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
+++ b/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
@@ -2,7 +2,7 @@
     <Style src="WelcomeWindow.uss" />
     <ui:VisualElement name="Banner">
         <ui:Label name="VersionText" text="Placeholder" />
-        <ui:Image name="Icon" style="background-image: resource('MirageIcon.png');" />
+        <ui:Image name="Icon" style="background-image: resource('MirageIcon');" />
     </ui:VisualElement>
     <ui:Label name="Title" text="Welcome to Mirage!" />
     <ui:Box name="ColumnContainer">


### PR DESCRIPTION
File format should not be included in the resource

before:
![missing image](https://user-images.githubusercontent.com/51044010/108953147-4a189480-769d-11eb-80a0-b31137affc15.png)

after:
![fix missing image](https://user-images.githubusercontent.com/51044010/108953194-6288af00-769d-11eb-838c-8e2076b177d9.png)
