### PR TITLE
refactor: spawnobjects throws exception instead of returning false

### DIFF
--- a/Assets/Mirage/Runtime/IServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/IServerObjectManager.cs
@@ -34,6 +34,6 @@ namespace Mirage
 
         void UnSpawn(GameObject obj);
 
-        bool SpawnObjects();
+        void SpawnObjects();
     }
 }

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -702,15 +702,18 @@ namespace Mirage
 
         /// <summary>
         /// This causes NetworkIdentity objects in a scene to be spawned on a server.
-        /// <para>NetworkIdentity objects in a scene are disabled by default. Calling SpawnObjects() causes these scene objects to be enabled and spawned. It is like calling NetworkServer.Spawn() for each of them.</para>
+        /// <para>
+        ///     NetworkIdentity objects in a scene are disabled by default.
+        ///     Calling SpawnObjects() causes these scene objects to be enabled and spawned.
+        ///     It is like calling NetworkServer.Spawn() for each of them.
+        /// </para>
         /// </summary>
-        /// <param name="client">The client associated to the objects.</param>
-        /// <returns>Success if objects where spawned.</returns>
-        public bool SpawnObjects()
+        /// <exception cref="InvalidOperationException">Thrown when server is not active</exception>
+        public void SpawnObjects()
         {
             // only if server active
             if (!Server || !Server.Active)
-                return false;
+                throw new InvalidOperationException("Server was not active");
 
             NetworkIdentity[] identities = Resources.FindObjectsOfTypeAll<NetworkIdentity>();
             Array.Sort(identities, new NetworkIdentityComparer());
@@ -725,8 +728,6 @@ namespace Mirage
                     Spawn(identity.gameObject);
                 }
             }
-
-            return true;
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -708,7 +708,7 @@ namespace Mirage
         ///     It is like calling NetworkServer.Spawn() for each of them.
         /// </para>
         /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown when server is not active</exception>
+        /// <exception cref="T:InvalidOperationException">Thrown when server is not active</exception>
         public void SpawnObjects()
         {
             // only if server active

--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -87,6 +87,7 @@ namespace Mirage.Tests.ClientServer
         {
             serverIdentity.sceneId = 42;
             serverIdentity.gameObject.SetActive(false);
+            serverObjectManager.SpawnObjects();
             Assert.That(serverIdentity.gameObject.activeSelf, Is.True);
         }
 
@@ -95,6 +96,7 @@ namespace Mirage.Tests.ClientServer
         {
             serverIdentity.sceneId = 0;
             serverIdentity.gameObject.SetActive(false);
+            serverObjectManager.SpawnObjects();
             Assert.That(serverIdentity.gameObject.activeSelf, Is.False);
         }
 

--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -87,7 +87,6 @@ namespace Mirage.Tests.ClientServer
         {
             serverIdentity.sceneId = 42;
             serverIdentity.gameObject.SetActive(false);
-            Assert.That(serverObjectManager.SpawnObjects(), Is.True);
             Assert.That(serverIdentity.gameObject.activeSelf, Is.True);
         }
 
@@ -96,7 +95,6 @@ namespace Mirage.Tests.ClientServer
         {
             serverIdentity.sceneId = 0;
             serverIdentity.gameObject.SetActive(false);
-            Assert.That(serverObjectManager.SpawnObjects(), Is.True);
             Assert.That(serverIdentity.gameObject.activeSelf, Is.False);
         }
 
@@ -260,7 +258,12 @@ namespace Mirage.Tests.ClientServer
 
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);
 
-            Assert.That(serverObjectManager.SpawnObjects(), Is.False);
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                serverObjectManager.SpawnObjects();
+            });
+
+            Assert.That(exception, Has.Message.EqualTo("Server was not active"));
         });
     }
 }

--- a/Assets/Tests/Runtime/Host/HostSetup.cs
+++ b/Assets/Tests/Runtime/Host/HostSetup.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Cysharp.Threading.Tasks;
+using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -28,6 +29,9 @@ namespace Mirage.Tests.Host
         public IEnumerator SetupHost() => UniTask.ToCoroutine(async () =>
         {
             networkManagerGo = new GameObject();
+            // set gameobject name to test name (helps with debugging)
+            networkManagerGo.name = TestContext.CurrentContext.Test.MethodName;
+
             networkManagerGo.AddComponent<MockTransport>();
             sceneManager = networkManagerGo.AddComponent<NetworkSceneManager>();
             serverObjectManager = networkManagerGo.AddComponent<ServerObjectManager>();

--- a/Assets/Tests/Runtime/Host/PlayerSpawnerTest.cs
+++ b/Assets/Tests/Runtime/Host/PlayerSpawnerTest.cs
@@ -1,5 +1,8 @@
+using System.Collections;
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Mirage.Tests.Host
 {
@@ -36,16 +39,19 @@ namespace Mirage.Tests.Host
             Object.Destroy(player);
         }
 
-        [Test]
-        public void DontAutoSpawnTest()
+        [UnityTest]
+        public IEnumerator DontAutoSpawnTest() => UniTask.ToCoroutine(async () =>
         {
             bool invokeAddPlayerMessage = false;
             server.LocalConnection.RegisterHandler<AddPlayerMessage>(msg => invokeAddPlayerMessage = true);
 
             sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity");
+            // wait for messages to be processed
+            await UniTask.Yield();
 
             Assert.That(invokeAddPlayerMessage, Is.False);
-        }
+
+        });
 
         [Test]
         public void ManualSpawnTest()


### PR DESCRIPTION
ServerObjectManager.SpawnObjects now throw InvalidOperationException is server is not set or is not active

BREAKING CHANGE: SpawnObjects throws Exception instead of returning false