### PR TITLE
style: renaming NumPlayers to NumberOfPlayers

### DIFF
--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -109,7 +109,7 @@ namespace Mirage
         /// Number of active player objects across all connections on the server.
         /// <para>This is only valid on the host / server.</para>
         /// </summary>
-        public int NumPlayers => connections.Count(kv => kv.Identity != null);
+        public int NumberOfPlayers => connections.Count(kv => kv.Identity != null);
 
         /// <summary>
         /// A list of local connections on the server.

--- a/Assets/Mirage/Samples~/Pong/Scripts/PaddleSpawner.cs
+++ b/Assets/Mirage/Samples~/Pong/Scripts/PaddleSpawner.cs
@@ -13,12 +13,12 @@ namespace Mirage.Examples.Pong
         public override void OnServerAddPlayer(INetworkConnection conn)
         {
             // add player at correct spawn position
-            Transform start = Server.NumPlayers == 0 ? leftRacketSpawn : rightRacketSpawn;
+            Transform start = Server.NumberOfPlayers == 0 ? leftRacketSpawn : rightRacketSpawn;
             NetworkIdentity player = Instantiate(PlayerPrefab, start.position, start.rotation);
             ServerObjectManager.AddPlayerForConnection(conn, player.gameObject);
 
             // spawn ball if two players
-            if (Server.NumPlayers == 2)
+            if (Server.NumberOfPlayers == 2)
             {
                 ball = Instantiate(ballPrefab);
                 ServerObjectManager.Spawn(ball);

--- a/Assets/Tests/Performance/Runtime/HeadlessBenchmark/Scripts/HeadlessBenchmark.cs
+++ b/Assets/Tests/Performance/Runtime/HeadlessBenchmark/Scripts/HeadlessBenchmark.cs
@@ -52,7 +52,7 @@ namespace Mirage.HeadlessBenchmark
                 long messages = messageCount - previousMessageCount;
 
 #if UNITY_EDITOR
-                Debug.LogFormat("{0} FPS {1} messages {2} clients", frames, messages, server.NumPlayers);
+                Debug.LogFormat("{0} FPS {1} messages {2} clients", frames, messages, server.NumberOfPlayers);
 #else
                 Console.WriteLine("{0} FPS {1} messages {2} clients", frames, messages, server.NumPlayers);
 #endif

--- a/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
@@ -114,7 +114,7 @@ namespace Mirage.Tests.ClientServer
         [Test]
         public void NumPlayersTest()
         {
-            Assert.That(server.NumPlayers, Is.EqualTo(1));
+            Assert.That(server.NumberOfPlayers, Is.EqualTo(1));
         }
 
         [Test]


### PR DESCRIPTION
BREAKING CHANGE: Use NetworkServer.NumberOfPlayers instead of NetworkServer.NumPlayers