### PR TITLE
style: renaming NetworkScenePath to ActiveScenePath

### DIFF
--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -60,7 +60,7 @@ namespace Mirage
         /// <summary>
         /// The path of the current active scene.
         /// <para>If using additive scenes this will be the first scene.</para>
-        /// <para>Value from <see cref="SceneManager.GetActiveScene()"/> </para>
+        /// <para>Value from SceneManager.GetActiveScene() </para>
         /// </summary>
         /// <remarks>
         /// <para>New clients that connect to a server will automatically load this scene.</para>

--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -58,13 +58,15 @@ namespace Mirage
         public ClientSceneChangeEvent ServerSceneChanged => _serverSceneChanged;
 
         /// <summary>
-        /// The path of the current network scene.
+        /// The path of the current active scene.
+        /// <para>If using additive scenes this will be the first scene.</para>
+        /// <para>Value from <see cref="SceneManager.GetActiveScene()"/> </para>
         /// </summary>
         /// <remarks>
         /// <para>New clients that connect to a server will automatically load this scene.</para>
         /// <para>This is used to make sure that all scene changes are initialized by Mirage.</para>
         /// </remarks>
-        public string NetworkScenePath => SceneManager.GetActiveScene().path;
+        public string ActiveScenePath => SceneManager.GetActiveScene().path;
 
         internal AsyncOperation asyncOperation;
 
@@ -124,7 +126,7 @@ namespace Mirage
                 throw new ArgumentNullException(msg.scenePath, "ClientSceneMessage: " + msg.scenePath + " cannot be empty or null");
             }
 
-            if (logger.LogEnabled()) logger.Log("ClientSceneMessage: changing scenes from: " + NetworkScenePath + " to:" + msg.scenePath);
+            if (logger.LogEnabled()) logger.Log("ClientSceneMessage: changing scenes from: " + ActiveScenePath + " to:" + msg.scenePath);
 
             // Let client prepare for scene change
             OnClientChangeScene(msg.scenePath, msg.sceneOperation);
@@ -218,12 +220,12 @@ namespace Mirage
         {
             logger.Log("NetworkSceneManager.OnServerAuthenticated");
 
-            conn.Send(new SceneMessage { scenePath = NetworkScenePath, additiveScenes = additiveSceneList.ToArray() });
+            conn.Send(new SceneMessage { scenePath = ActiveScenePath, additiveScenes = additiveSceneList.ToArray() });
             conn.Send(new SceneReadyMessage());
         }
 
         /// <summary>
-        /// This causes the server to switch scenes and sets the NetworkScenePath.
+        /// This causes the server to switch scenes and sets the ActiveScenePath.
         /// <para>Clients that connect to this server will automatically switch to this scene. This automatically sets clients to be not-ready. The clients must call Ready() again to participate in the new scene.</para>
         /// </summary>
         /// <param name="scenePath"></param>
@@ -280,7 +282,7 @@ namespace Mirage
             {
                 case SceneOperation.Normal:
                     //Scene is already active.
-                    if (NetworkScenePath.Equals(scenePath))
+                    if (ActiveScenePath.Equals(scenePath))
                     {
                         FinishLoadScene(scenePath, sceneOperation);
                     }
@@ -331,7 +333,7 @@ namespace Mirage
         void OnAsyncComplete(AsyncOperation asyncOperation)
         {
             //This is only called in a normal scene change
-            FinishLoadScene(NetworkScenePath, SceneOperation.Normal);
+            FinishLoadScene(ActiveScenePath, SceneOperation.Normal);
         }
 
         internal void FinishLoadScene(string scenePath, SceneOperation sceneOperation)

--- a/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
@@ -71,7 +71,7 @@ namespace Mirage.Tests.ClientServer
 
             await AsyncUtil.WaitUntilWithTimeout(() => clientSceneManager.asyncOperation.isDone);
 
-            Assert.That(clientSceneManager.NetworkScenePath, Is.EqualTo("Assets/Mirror/Tests/Runtime/testScene.unity"));
+            Assert.That(clientSceneManager.ActiveScenePath, Is.EqualTo("Assets/Mirror/Tests/Runtime/testScene.unity"));
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         });
@@ -79,7 +79,7 @@ namespace Mirage.Tests.ClientServer
         [Test]
         public void NetworkSceneNameStringValueTest()
         {
-            Assert.That(clientSceneManager.NetworkScenePath.Equals(SceneManager.GetActiveScene().path));
+            Assert.That(clientSceneManager.ActiveScenePath.Equals(SceneManager.GetActiveScene().path));
         }
 
         [Test]

--- a/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
@@ -54,7 +54,7 @@ namespace Mirage.Tests.Host
             await AsyncUtil.WaitUntilWithTimeout(() => !client.Active);
 
             sceneManager.ServerSceneChanged.AddListener(func1);
-            
+
             sceneManager.FinishLoadScene("test", SceneOperation.Normal);
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
@@ -72,10 +72,10 @@ namespace Mirage.Tests.Host
 
             sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity");
 
-            await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.NetworkScenePath.Equals("Assets/Mirror/Tests/Runtime/testScene.unity"));
+            await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.ActiveScenePath.Equals("Assets/Mirror/Tests/Runtime/testScene.unity"));
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
-            Assert.That(sceneManager.NetworkScenePath, Is.EqualTo("Assets/Mirror/Tests/Runtime/testScene.unity"));
+            Assert.That(sceneManager.ActiveScenePath, Is.EqualTo("Assets/Mirror/Tests/Runtime/testScene.unity"));
             Assert.That(invokeClientSceneMessage, Is.True);
             Assert.That(invokeNotReadyMessage, Is.True);
         });


### PR DESCRIPTION
BREAKING CHANGE: Use NetworkSceneManager.ActiveScenePath instead of NetworkSceneManager.NetworkScenePath