### PR TITLE
ci: remove license activation request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,8 @@ on:
     paths-ignore:
       - 'doc/**'
       - '*.md'
-  
+
+jobs:
   CI:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,26 +9,6 @@ on:
       - 'doc/**'
       - '*.md'
   
-jobs:
-  requestActivationFile:
-    runs-on: ubuntu-latest
-    if: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Request manual activation file
-        uses: MirageNet/unity-runner@3.1.0
-        id: getManualLicenseFile
-        with:
-            entrypoint: /request_activation.sh
-
-      - name: Expose as artifact
-        uses: actions/upload-artifact@v1
-        with:
-            name: Manual Activation File
-            path: ${{ steps.getManualLicenseFile.outputs.filePath }}
-    
   CI:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is unnecessary and it does nothing,  I can create a manual license request from unity-runner and import the license here.