### PR TITLE
docs: support mermaid diagrams

### DIFF
--- a/doc/templates/partials/head.tmpl.partial
+++ b/doc/templates/partials/head.tmpl.partial
@@ -18,4 +18,6 @@
   {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}
   {{#_enableSearch}}<meta property="docfx:rel" content="{{_rel}}">{{/_enableSearch}}
   {{#_enableNewTab}}<meta property="docfx:newtab" content="true">{{/_enableNewTab}}
+  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <script>mermaid.initialize({startOnLoad:true});</script>
 </head>


### PR DESCRIPTION
With this change we can now easily add mermaid diagrams to documentation.
Add a diagram like this:

```html
<div class="mermaid">
    graph TD
    A[Client] --> B[Load Balancer]
    B --> C[Server1]
    B --> D[Server2]
</div>
```

This generates the corresponding svg for that diagram.

You an use the [mermaid live editor](https://mermaid-js.github.io/mermaid-live-editor)
for easy diagram composition and examples.