### PR TITLE
docs: remove sponsor link

### DIFF
--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -4,5 +4,3 @@
   href: Articles/
 - name: API Reference
   href: xref:Mirage
-- name: Sponsor Us!
-  href: https://github.com/sponsors/vis2k


### PR DESCRIPTION
Removes "Sponsor Us!" link which is unrelated to Mirage.