### PR TITLE
fix: disabling welcome window before unity 2020.1

### DIFF
--- a/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
+++ b/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
@@ -101,7 +101,7 @@ namespace Mirage
 #if UNITY_2020_1_OR_NEWER
                 OpenWindow();
 #else
-                if (logger.LogEnabled()) logger.Log($"WelcomeWindow not supported in {Application.unityVersion}, it is only supproted in Unity 2020.1 or newer");
+                if (logger.LogEnabled()) logger.Log($"WelcomeWindow not supported in {Application.unityVersion}, it is only supported in Unity 2020.1 or newer");
 #endif
             }
         }

--- a/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
+++ b/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
@@ -98,7 +98,11 @@ namespace Mirage
             {
                 EditorPrefs.SetString(screenToOpenKey, ShowChangeLog ? "ChangeLog" : "Welcome");
 
+#if UNITY_2020_1_OR_NEWER
                 OpenWindow();
+#else
+                if (logger.LogEnabled()) logger.Log($"WelcomeWindow not supported in {Application.unityVersion}, it is only supproted in Unity 2020.1 or newer");
+#endif
             }
         }
 


### PR DESCRIPTION
adding UNITY_2020_1_OR_NEWER before opening welcome window because UIElements gives errors in ealier versions