### PR TITLE
refactor: replacing version enum with assembly version

### DIFF
--- a/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
+++ b/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
@@ -59,11 +59,6 @@ namespace Mirage
         private static string firstStartUpKey = string.Empty;
         private const string firstTimeMirageKey = "MirageWelcome";
 
-        private static string GetVersion()
-        {
-            return typeof(NetworkIdentity).Assembly.GetName().Version.ToString();
-        }
-
         #region Handle visibility
 
         private static bool ShowChangeLog
@@ -92,7 +87,7 @@ namespace Mirage
         private static void ShowWindowOnFirstStart()
         {
             EditorApplication.update -= ShowWindowOnFirstStart;
-            firstStartUpKey = GetVersion();
+            firstStartUpKey = MirageVersion.Version;
 
             if ((!EditorPrefs.GetBool(firstTimeMirageKey, false) || !EditorPrefs.GetBool(firstStartUpKey, false)) && firstStartUpKey != "MirageUnknown")
             {
@@ -135,7 +130,7 @@ namespace Mirage
 
             //set the version text
             Label versionText = root.Q<Label>("VersionText");
-            versionText.text = "v" + GetVersion();
+            versionText.text = "v" + MirageVersion.Version;
 
             #region Page buttons
 

--- a/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
+++ b/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
@@ -87,7 +87,7 @@ namespace Mirage
         private static void ShowWindowOnFirstStart()
         {
             EditorApplication.update -= ShowWindowOnFirstStart;
-            firstStartUpKey = MirageVersion.Version;
+            firstStartUpKey = Version.Current;
 
             if ((!EditorPrefs.GetBool(firstTimeMirageKey, false) || !EditorPrefs.GetBool(firstStartUpKey, false)) && firstStartUpKey != "MirageUnknown")
             {
@@ -130,7 +130,7 @@ namespace Mirage
 
             //set the version text
             Label versionText = root.Q<Label>("VersionText");
-            versionText.text = "v" + MirageVersion.Version;
+            versionText.text = "v" + Version.Current;
 
             #region Page buttons
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -162,7 +162,7 @@ namespace Mirage
             initialized = true;
 
             Application.quitting += Disconnect;
-            if (logger.LogEnabled()) logger.Log($"NetworkServer Created, Mirage version: {MirageVersion.Version}");
+            if (logger.LogEnabled()) logger.Log($"NetworkServer Created, Mirage version: {Version.Current}");
 
 
             //Make sure connections are cleared in case any old connections references exist from previous sessions

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -162,7 +162,8 @@ namespace Mirage
             initialized = true;
 
             Application.quitting += Disconnect;
-            if (logger.LogEnabled()) logger.Log("NetworkServer Created version " + Version.Current);
+            if (logger.LogEnabled()) logger.Log($"NetworkServer Created, Mirage version: {MirageVersion.Version}");
+
 
             //Make sure connections are cleared in case any old connections references exist from previous sessions
             connections.Clear();

--- a/Assets/Mirage/Runtime/UNetwork.cs
+++ b/Assets/Mirage/Runtime/UNetwork.cs
@@ -9,9 +9,9 @@ namespace Mirage
         ClientRpc
     }
 
-    public enum Version
+    public static class MirageVersion
     {
-        Current = 1
+        public static readonly string Version = typeof(MirageVersion).Assembly.GetName().Version.ToString();
     }
 
     /// <summary>

--- a/Assets/Mirage/Runtime/UNetwork.cs
+++ b/Assets/Mirage/Runtime/UNetwork.cs
@@ -9,9 +9,9 @@ namespace Mirage
         ClientRpc
     }
 
-    public static class MirageVersion
+    public static class Version
     {
-        public static readonly string Version = typeof(MirageVersion).Assembly.GetName().Version.ToString();
+        public static readonly string Current = typeof(NetworkIdentity).Assembly.GetName().Version.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
BREAKING CHANGE: Version.Current now returns Mirage's assembly version