### PR TITLE
refactor: removing sendasync from networkconnection

### DIFF
--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -1,9 +1,8 @@
-using Cysharp.Threading.Tasks;
 using UnityEngine.Events;
 
 namespace Mirage
 {
-    public interface INetworkClient
+    public interface INetworkClient : IMessageSender
     {
 
         /// <summary>
@@ -38,9 +37,5 @@ namespace Mirage
         bool IsLocalClient { get; }
 
         void Disconnect();
-
-        void Send<T>(T message, int channelId = Channel.Reliable);
-
-        UniTask SendAsync<T>(T message, int channelId = Channel.Reliable);
     }
 }

--- a/Assets/Mirage/Runtime/INetworkConnection.cs
+++ b/Assets/Mirage/Runtime/INetworkConnection.cs
@@ -4,10 +4,16 @@ using Cysharp.Threading.Tasks;
 
 namespace Mirage
 {
-    /// <summary>
-    /// An object that can send and receive messages
-    /// </summary>
-    public interface IMessageHandler
+    public interface IMessageSender
+    {
+        void Send<T>(T msg, int channelId = Channel.Reliable);
+
+        UniTask SendAsync<T>(T msg, int channelId = Channel.Reliable);
+
+        UniTask SendAsync(ArraySegment<byte> segment, int channelId = Channel.Reliable);
+    }
+
+    public interface IMessageReceiver
     {
         void RegisterHandler<T>(Action<INetworkConnection, T> handler);
 
@@ -17,14 +23,15 @@ namespace Mirage
 
         void ClearHandlers();
 
-        void Send<T>(T msg, int channelId = Channel.Reliable);
-
-        UniTask SendAsync<T>(T msg, int channelId = Channel.Reliable);
-
-        UniTask SendAsync(ArraySegment<byte> segment, int channelId = Channel.Reliable);
-
+        /// <summary>
+        /// ProcessMessages loop, should loop unitil object is closed
+        /// </summary>
+        /// <returns></returns>
         UniTask ProcessMessagesAsync();
+    }
 
+    public interface INotifySender
+    {
         /// <summary>
         /// Sends a message, but notify when it is delivered or lost
         /// </summary>
@@ -32,7 +39,9 @@ namespace Mirage
         /// <param name="msg">message to send</param>
         /// <param name="token">a arbitrary object that the sender will receive with their notification</param>
         void SendNotify<T>(T msg, object token, int channelId = Channel.Unreliable);
-
+    }
+    public interface INotifyReceiver
+    {
         /// <summary>
         /// Raised when a message is delivered
         /// </summary>
@@ -42,6 +51,14 @@ namespace Mirage
         /// Raised when a message is lost
         /// </summary>
         event Action<INetworkConnection, object> NotifyLost;
+    }
+
+    /// <summary>
+    /// An object that can send and receive messages
+    /// </summary>
+    public interface IMessageHandler : IMessageSender, IMessageReceiver, INotifySender, INotifyReceiver
+    {
+
     }
 
     /// <summary>

--- a/Assets/Mirage/Runtime/INetworkConnection.cs
+++ b/Assets/Mirage/Runtime/INetworkConnection.cs
@@ -11,9 +11,7 @@ namespace Mirage
     {
         void Send<T>(T msg, int channelId = Channel.Reliable);
 
-        UniTask SendAsync<T>(T msg, int channelId = Channel.Reliable);
-
-        UniTask SendAsync(ArraySegment<byte> segment, int channelId = Channel.Reliable);
+        void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable);
     }
 
     /// <summary>

--- a/Assets/Mirage/Runtime/INetworkConnection.cs
+++ b/Assets/Mirage/Runtime/INetworkConnection.cs
@@ -37,7 +37,7 @@ namespace Mirage
     }
 
     /// <summary>
-    /// An object that can send nofity messages
+    /// An object that can send notify messages
     /// </summary>
     public interface INotifySender
     {
@@ -51,7 +51,7 @@ namespace Mirage
     }
 
     /// <summary>
-    /// An object that can receive nofity messages
+    /// An object that can receive notify messages
     /// </summary>
     public interface INotifyReceiver
     {

--- a/Assets/Mirage/Runtime/INetworkConnection.cs
+++ b/Assets/Mirage/Runtime/INetworkConnection.cs
@@ -4,6 +4,9 @@ using Cysharp.Threading.Tasks;
 
 namespace Mirage
 {
+    /// <summary>
+    /// An object that can send messages
+    /// </summary>
     public interface IMessageSender
     {
         void Send<T>(T msg, int channelId = Channel.Reliable);
@@ -13,6 +16,9 @@ namespace Mirage
         UniTask SendAsync(ArraySegment<byte> segment, int channelId = Channel.Reliable);
     }
 
+    /// <summary>
+    /// An object that can receive messages
+    /// </summary>
     public interface IMessageReceiver
     {
         void RegisterHandler<T>(Action<INetworkConnection, T> handler);
@@ -30,6 +36,9 @@ namespace Mirage
         UniTask ProcessMessagesAsync();
     }
 
+    /// <summary>
+    /// An object that can send nofity messages
+    /// </summary>
     public interface INotifySender
     {
         /// <summary>
@@ -40,6 +49,10 @@ namespace Mirage
         /// <param name="token">a arbitrary object that the sender will receive with their notification</param>
         void SendNotify<T>(T msg, object token, int channelId = Channel.Unreliable);
     }
+
+    /// <summary>
+    /// An object that can receive nofity messages
+    /// </summary>
     public interface INotifyReceiver
     {
         /// <summary>
@@ -54,7 +67,7 @@ namespace Mirage
     }
 
     /// <summary>
-    /// An object that can send and receive messages
+    /// An object that can send and receive messages and notify messages
     /// </summary>
     public interface IMessageHandler : IMessageSender, IMessageReceiver, INotifySender, INotifyReceiver
     {

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -241,7 +241,7 @@ namespace Mirage
                 payload = writer.ToArraySegment()
             };
 
-            Client.SendAsync(message, channelId).Forget();
+            Client.Send(message, channelId);
         }
 
         private void ValidateServerRpc(Type invokeClass, string cmdName, bool requireAuthority)
@@ -284,7 +284,7 @@ namespace Mirage
                 payload = writer.ToArraySegment()
             };
 
-            Client.SendAsync(message, channelId).Forget();
+            Client.Send(message, channelId);
 
             return task;
         }

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -253,19 +253,14 @@ namespace Mirage
         /// <param name="message"></param>
         /// <param name="channelId"></param>
         /// <returns>True if message was sent.</returns>
-        public UniTask SendAsync<T>(T message, int channelId = Channel.Reliable)
-        {
-            return Connection.SendAsync(message, channelId);
-        }
-
         public void Send<T>(T message, int channelId = Channel.Reliable)
         {
             Connection.Send(message, channelId);
         }
 
-        public UniTask SendAsync(ArraySegment<byte> segment, int channelId = Channel.Reliable)
+        public void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable)
         {
-            return Connection.SendAsync(segment, channelId);
+            Connection.Send(segment, channelId);
         }
 
         internal void Update()

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -260,7 +260,12 @@ namespace Mirage
 
         public void Send<T>(T message, int channelId = Channel.Reliable)
         {
-            Connection.SendAsync(message, channelId).Forget();
+            Connection.Send(message, channelId);
+        }
+
+        public UniTask SendAsync(ArraySegment<byte> segment, int channelId = Channel.Reliable)
+        {
+            return Connection.SendAsync(segment, channelId);
         }
 
         internal void Update()

--- a/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
@@ -221,15 +221,12 @@ namespace Mirage.Weaver
                 method.Is(typeof(MessagePacker), nameof(MessagePacker.GetId)) ||
                 method.Is(typeof(MessagePacker), nameof(MessagePacker.Unpack)) ||
                 method.Is<IMessageSender>(nameof(IMessageSender.Send)) ||
-                method.Is<IMessageSender>(nameof(IMessageSender.SendAsync)) ||
                 method.Is<IMessageSender>(nameof(IMessageReceiver.RegisterHandler)) ||
                 method.Is<IMessageSender>(nameof(IMessageReceiver.UnregisterHandler)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.Send)) ||
-                method.Is<NetworkConnection>(nameof(NetworkConnection.SendAsync)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.RegisterHandler)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.UnregisterHandler)) ||
                 method.Is<NetworkClient>(nameof(NetworkClient.Send)) ||
-                method.Is<NetworkClient>(nameof(NetworkClient.SendAsync)) ||
                 method.Is<NetworkServer>(nameof(NetworkServer.SendToAll)) ||
                 method.Is<INetworkServer>(nameof(INetworkServer.SendToAll));
         }

--- a/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
@@ -220,11 +220,10 @@ namespace Mirage.Weaver
                 method.Is(typeof(MessagePacker), nameof(MessagePacker.Pack)) ||
                 method.Is(typeof(MessagePacker), nameof(MessagePacker.GetId)) ||
                 method.Is(typeof(MessagePacker), nameof(MessagePacker.Unpack)) ||
-                method.Is<IMessageHandler>(nameof(IMessageHandler.Send)) ||
-                method.Is<IMessageHandler>(nameof(IMessageHandler.SendAsync)) ||
-                method.Is<IMessageHandler>(nameof(IMessageHandler.RegisterHandler)) ||
-                method.Is<IMessageHandler>(nameof(IMessageHandler.UnregisterHandler)) ||
-                method.Is<IMessageHandler>(nameof(IMessageHandler.Send)) ||
+                method.Is<IMessageSender>(nameof(IMessageSender.Send)) ||
+                method.Is<IMessageSender>(nameof(IMessageSender.SendAsync)) ||
+                method.Is<IMessageSender>(nameof(IMessageReceiver.RegisterHandler)) ||
+                method.Is<IMessageSender>(nameof(IMessageReceiver.UnregisterHandler)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.Send)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.SendAsync)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.RegisterHandler)) ||

--- a/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
@@ -228,8 +228,6 @@ namespace Mirage.Weaver
                 method.Is<NetworkConnection>(nameof(NetworkConnection.SendAsync)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.RegisterHandler)) ||
                 method.Is<NetworkConnection>(nameof(NetworkConnection.UnregisterHandler)) ||
-                method.Is<INetworkClient>(nameof(INetworkClient.Send)) ||
-                method.Is<INetworkClient>(nameof(INetworkClient.SendAsync)) ||
                 method.Is<NetworkClient>(nameof(NetworkClient.Send)) ||
                 method.Is<NetworkClient>(nameof(NetworkClient.SendAsync)) ||
                 method.Is<NetworkServer>(nameof(NetworkServer.SendToAll)) ||


### PR DESCRIPTION
- all uses of send use forget
- no use case for wait to see if message was sent

BREAKING CHANGE: NetworkConnection.SendAsync has been removed

requires: 
- [ ] https://github.com/MirageNet/Mirage/pull/670
- [ ] https://github.com/MirageNet/Mirage/pull/671