### PR TITLE
fix: invoking started event when Listening is false

### DIFF
--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -204,6 +204,11 @@ namespace Mirage
                     Transport.Connected.AddListener(TransportConnected);
                     await Transport.ListenAsync();
                 }
+                else
+                {
+                    // if not listening then call started events right away
+                    NotListeningStarted();
+                }
             }
             catch (Exception ex)
             {
@@ -215,6 +220,14 @@ namespace Mirage
                 Transport.Started.RemoveListener(TransportStarted);
                 Cleanup();
             }
+        }
+
+        private void NotListeningStarted()
+        {
+            logger.Log("Server started but not Listening");
+            Active = true;
+            // (useful for loading & spawning stuff from database etc.)
+            Started?.Invoke();
         }
 
         private void TransportStarted()


### PR DESCRIPTION
when Listening is false the transport will never call the TransportStarted function so NetworkServer will never set Active or call Started.