### PR TITLE
refactor: renaming NetworkConnection to NetworkPlayer

### DIFF
--- a/Assets/Mirage/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/BasicAuthenticator.cs
@@ -26,13 +26,13 @@ namespace Mirage.Authenticators
             public string Message;
         }
 
-        public override void OnServerAuthenticate(INetworkConnection conn)
+        public override void OnServerAuthenticate(INetworkPlayer conn)
         {
             // wait for AuthRequestMessage from client
             conn.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage);
         }
 
-        public override void OnClientAuthenticate(INetworkConnection conn)
+        public override void OnClientAuthenticate(INetworkPlayer conn)
         {
             conn.RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage);
 
@@ -45,7 +45,7 @@ namespace Mirage.Authenticators
             conn.Send(authRequestMessage);
         }
 
-        public void OnAuthRequestMessage(INetworkConnection conn, AuthRequestMessage msg)
+        public void OnAuthRequestMessage(INetworkPlayer conn, AuthRequestMessage msg)
         {
             if (logger.LogEnabled()) logger.LogFormat(LogType.Log, "Authentication Request: {0} {1}", msg.AuthUsername, msg.AuthPassword);
 
@@ -80,13 +80,13 @@ namespace Mirage.Authenticators
             }
         }
 
-        public IEnumerator DelayedDisconnect(INetworkConnection conn, float waitTime)
+        public IEnumerator DelayedDisconnect(INetworkPlayer conn, float waitTime)
         {
             yield return new WaitForSeconds(waitTime);
             conn.Disconnect();
         }
 
-        public void OnAuthResponseMessage(INetworkConnection conn, AuthResponseMessage msg)
+        public void OnAuthResponseMessage(INetworkPlayer conn, AuthResponseMessage msg)
         {
             if (msg.Code == 100)
             {

--- a/Assets/Mirage/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/TimeoutAuthenticator.cs
@@ -24,21 +24,21 @@ namespace Mirage.Authenticators
             Authenticator.OnServerAuthenticated += HandleServerAuthenticated;
         }
 
-        private readonly HashSet<INetworkConnection> pendingAuthentication = new HashSet<INetworkConnection>();
+        private readonly HashSet<INetworkPlayer> pendingAuthentication = new HashSet<INetworkPlayer>();
 
-        private void HandleServerAuthenticated(INetworkConnection connection)
+        private void HandleServerAuthenticated(INetworkPlayer connection)
         {
             pendingAuthentication.Remove(connection);
             base.OnClientAuthenticate(connection);
         }
 
-        private void HandleClientAuthenticated(INetworkConnection connection)
+        private void HandleClientAuthenticated(INetworkPlayer connection)
         {
             pendingAuthentication.Remove(connection);
             base.OnServerAuthenticate(connection);
         }
 
-        public override void OnClientAuthenticate(INetworkConnection conn)
+        public override void OnClientAuthenticate(INetworkPlayer conn)
         {
             pendingAuthentication.Add(conn);
             Authenticator.OnClientAuthenticate(conn);
@@ -47,7 +47,7 @@ namespace Mirage.Authenticators
                 StartCoroutine(BeginAuthentication(conn));
         }
 
-        public override void OnServerAuthenticate(INetworkConnection conn)
+        public override void OnServerAuthenticate(INetworkPlayer conn)
         {
             pendingAuthentication.Add(conn);
             Authenticator.OnServerAuthenticate(conn);
@@ -55,7 +55,7 @@ namespace Mirage.Authenticators
                 StartCoroutine(BeginAuthentication(conn));
         }
 
-        IEnumerator BeginAuthentication(INetworkConnection conn)
+        IEnumerator BeginAuthentication(INetworkPlayer conn)
         {
             if (logger.LogEnabled()) logger.Log($"Authentication countdown started {conn} {Timeout}");
 

--- a/Assets/Mirage/Components/LobbyReady.cs
+++ b/Assets/Mirage/Components/LobbyReady.cs
@@ -11,7 +11,7 @@ namespace Mirage
 
         // just a cached memory area where we can collect connections
         // for broadcasting messages
-        private static readonly List<INetworkConnection> connectionsCache = new List<INetworkConnection>();
+        private static readonly List<INetworkPlayer> connectionsCache = new List<INetworkPlayer>();
 
         public void SetAllClientsNotReady()
         {
@@ -36,7 +36,7 @@ namespace Mirage
                 }
             }
 
-            NetworkConnection.Send(connectionsCache, msg, channelId);
+            NetworkPlayer.Send(connectionsCache, msg, channelId);
         }
     }
 }

--- a/Assets/Mirage/Components/NetworkMatchChecker.cs
+++ b/Assets/Mirage/Components/NetworkMatchChecker.cs
@@ -105,7 +105,7 @@ namespace Mirage
         /// </summary>
         /// <param name="conn">Network connection of a player.</param>
         /// <returns>True if the player can see this object.</returns>
-        public override bool OnCheckObserver(INetworkConnection conn)
+        public override bool OnCheckObserver(INetworkPlayer conn)
         {
             // Not Visible if not in a match
             if (MatchId == Guid.Empty)
@@ -125,7 +125,7 @@ namespace Mirage
         /// </summary>
         /// <param name="observers">The new set of observers for this object.</param>
         /// <param name="initialize">True if the set of observers is being built for the first time.</param>
-        public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
+        public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize)
         {
             if (currentMatch == Guid.Empty) return;
 

--- a/Assets/Mirage/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirage/Components/NetworkProximityChecker.cs
@@ -58,7 +58,7 @@ namespace Mirage
 
         /// <param name="conn">Network connection of a player.</param>
         /// <returns>True if the player can see this object.</returns>
-        public override bool OnCheckObserver(INetworkConnection conn)
+        public override bool OnCheckObserver(INetworkPlayer conn)
         {
             if (ForceHidden)
                 return false;
@@ -72,7 +72,7 @@ namespace Mirage
         /// </summary>
         /// <param name="observers">The new set of observers for this object.</param>
         /// <param name="initialize">True if the set of observers is being built for the first time.</param>
-        public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
+        public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize)
         {
             // if force hidden then return without adding any observers.
             if (ForceHidden)
@@ -88,7 +88,7 @@ namespace Mirage
             //    magnitude faster. if we have 10k monsters and run a sphere
             //    cast 10k times, we will see a noticeable lag even with physics
             //    layers. but checking to every connection is fast.
-            foreach (INetworkConnection conn in Server.connections)
+            foreach (INetworkPlayer conn in Server.connections)
             {
                 // check distance
                 if (conn != null && conn.Identity != null && Vector3.Distance(conn.Identity.transform.position, position) < VisibilityRange)

--- a/Assets/Mirage/Components/NetworkSceneChecker.cs
+++ b/Assets/Mirage/Components/NetworkSceneChecker.cs
@@ -88,7 +88,7 @@ namespace Mirage
         /// </summary>
         /// <param name="conn">Network connection of a player.</param>
         /// <returns>True if the player can see this object.</returns>
-        public override bool OnCheckObserver(INetworkConnection conn)
+        public override bool OnCheckObserver(INetworkPlayer conn)
         {
             if (forceHidden)
                 return false;
@@ -102,7 +102,7 @@ namespace Mirage
         /// </summary>
         /// <param name="observers">The new set of observers for this object.</param>
         /// <param name="initialize">True if the set of observers is being built for the first time.</param>
-        public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
+        public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize)
         {
             // If forceHidden then return without adding any observers.
             if (forceHidden)

--- a/Assets/Mirage/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirage/Editor/NetworkInformationPreview.cs
@@ -181,7 +181,7 @@ namespace Mirage
                 observerRect.x += 20;
                 observerRect.y += observerRect.height;
 
-                foreach (INetworkConnection conn in identity.observers)
+                foreach (INetworkPlayer conn in identity.observers)
                 {
 
                     GUI.Label(observerRect, conn.Address + ":" + conn, styles.ComponentName);

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -94,7 +94,7 @@ namespace Mirage
             }
         }
 
-        void OnClientConnected(INetworkConnection conn)
+        void OnClientConnected(INetworkPlayer conn)
         {
             RegisterSpawnPrefabs();
 
@@ -593,7 +593,7 @@ namespace Mirage
             }
         }
 
-        private void OnServerRpcReply(INetworkConnection connection, ServerRpcReply reply)
+        private void OnServerRpcReply(INetworkPlayer connection, ServerRpcReply reply)
         {
             // find the callback that was waiting for this and invoke it.
             if (callbacks.TryGetValue(reply.replyId, out Action<NetworkReader> action))

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -23,7 +23,7 @@ namespace Mirage
         /// <summary>
         /// The NetworkConnection object this client is using.
         /// </summary>
-        INetworkConnection Connection { get; }
+        INetworkPlayer Connection { get; }
 
         /// <summary>
         /// active is true while a client is connecting/connected

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -19,7 +19,7 @@ namespace Mirage
     /// </summary>
     public interface IMessageReceiver
     {
-        void RegisterHandler<T>(Action<INetworkConnection, T> handler);
+        void RegisterHandler<T>(Action<INetworkPlayer, T> handler);
 
         void RegisterHandler<T>(Action<T> handler);
 
@@ -56,12 +56,12 @@ namespace Mirage
         /// <summary>
         /// Raised when a message is delivered
         /// </summary>
-        event Action<INetworkConnection, object> NotifyDelivered;
+        event Action<INetworkPlayer, object> NotifyDelivered;
 
         /// <summary>
         /// Raised when a message is lost
         /// </summary>
-        event Action<INetworkConnection, object> NotifyLost;
+        event Action<INetworkPlayer, object> NotifyLost;
     }
 
     /// <summary>
@@ -98,7 +98,7 @@ namespace Mirage
     /// A connection to a remote endpoint.
     /// May be from the server to client or from client to server
     /// </summary>
-    public interface INetworkConnection : IMessageHandler, IVisibilityTracker, IObjectOwner
+    public interface INetworkPlayer : IMessageHandler, IVisibilityTracker, IObjectOwner
     {
         bool IsReady { get; set; }
         EndPoint Address { get; }

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs.meta
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 11ea41db366624109af1f0834bcdde2f
+guid: c64de93bde68fe54bb856572ff53ee64
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -40,7 +40,7 @@ namespace Mirage
         /// <summary>
         /// The connection to the host mode client (if any).
         /// </summary>
-        INetworkConnection LocalConnection { get; }
+        INetworkPlayer LocalConnection { get; }
 
         /// <summary>
         /// The host client for this server 
@@ -60,9 +60,9 @@ namespace Mirage
 
         void Disconnect();
 
-        void AddConnection(INetworkConnection conn);
+        void AddConnection(INetworkPlayer conn);
 
-        void RemoveConnection(INetworkConnection conn);
+        void RemoveConnection(INetworkPlayer conn);
 
         void SendToAll<T>(T msg, int channelId = Channel.Reliable);
     }

--- a/Assets/Mirage/Runtime/IServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/IServerObjectManager.cs
@@ -16,19 +16,19 @@ namespace Mirage
         /// </summary>
         SpawnEvent UnSpawned { get; }
 
-        bool AddPlayerForConnection(INetworkConnection conn, GameObject player);
+        bool AddPlayerForConnection(INetworkPlayer conn, GameObject player);
 
-        bool AddPlayerForConnection(INetworkConnection conn, GameObject player, Guid assetId);
+        bool AddPlayerForConnection(INetworkPlayer conn, GameObject player, Guid assetId);
 
-        bool ReplacePlayerForConnection(INetworkConnection conn, NetworkClient client, GameObject player, bool keepAuthority = false);
+        bool ReplacePlayerForConnection(INetworkPlayer conn, NetworkClient client, GameObject player, bool keepAuthority = false);
 
-        bool ReplacePlayerForConnection(INetworkConnection conn, NetworkClient client, GameObject player, Guid assetId, bool keepAuthority = false);
+        bool ReplacePlayerForConnection(INetworkPlayer conn, NetworkClient client, GameObject player, Guid assetId, bool keepAuthority = false);
 
         void Spawn(GameObject obj, GameObject ownerPlayer);
 
-        void Spawn(GameObject obj, INetworkConnection ownerConnection = null);
+        void Spawn(GameObject obj, INetworkPlayer ownerConnection = null);
 
-        void Spawn(GameObject obj, Guid assetId, INetworkConnection ownerConnection = null);
+        void Spawn(GameObject obj, Guid assetId, INetworkPlayer ownerConnection = null);
 
         void Destroy(GameObject obj);
 

--- a/Assets/Mirage/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirage/Runtime/NetworkAuthenticator.cs
@@ -12,17 +12,17 @@ namespace Mirage
         /// <summary>
         /// Notify subscribers on the server when a client is authenticated
         /// </summary>
-        public event Action<INetworkConnection> OnServerAuthenticated;
+        public event Action<INetworkPlayer> OnServerAuthenticated;
 
         /// <summary>
         /// Notify subscribers on the client when the client is authenticated
         /// </summary>
-        public event Action<INetworkConnection> OnClientAuthenticated;
+        public event Action<INetworkPlayer> OnClientAuthenticated;
 
         #region server
 
         // This will get more code in the near future
-        internal void OnServerAuthenticateInternal(INetworkConnection conn)
+        internal void OnServerAuthenticateInternal(INetworkPlayer conn)
         {
             OnServerAuthenticate(conn);
         }
@@ -31,7 +31,7 @@ namespace Mirage
         /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
         /// </summary>
         /// <param name="conn">Connection to client.</param>
-        public virtual void OnServerAuthenticate(INetworkConnection conn)
+        public virtual void OnServerAuthenticate(INetworkPlayer conn)
         {
             OnServerAuthenticated?.Invoke(conn);
         }
@@ -41,7 +41,7 @@ namespace Mirage
         #region client
 
         // This will get more code in the near future
-        internal void OnClientAuthenticateInternal(INetworkConnection conn)
+        internal void OnClientAuthenticateInternal(INetworkPlayer conn)
         {
             OnClientAuthenticate(conn);
         }
@@ -50,7 +50,7 @@ namespace Mirage
         /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
         /// </summary>
         /// <param name="conn">Connection of the client.</param>
-        public virtual void OnClientAuthenticate(INetworkConnection conn)
+        public virtual void OnClientAuthenticate(INetworkPlayer conn)
         {
             OnClientAuthenticated?.Invoke(conn);
         }

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -107,14 +107,14 @@ namespace Mirage
         public ClientObjectManager ClientObjectManager => NetIdentity.ClientObjectManager;
 
         /// <summary>
-        /// The <see cref="NetworkConnection">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the client.
+        /// The <see cref="NetworkPlayer">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the client.
         /// </summary>
-        public INetworkConnection ConnectionToServer => NetIdentity.ConnectionToServer;
+        public INetworkPlayer ConnectionToServer => NetIdentity.ConnectionToServer;
 
         /// <summary>
-        /// The <see cref="NetworkConnection">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the server.
+        /// The <see cref="NetworkPlayer">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the server.
         /// </summary>
-        public INetworkConnection ConnectionToClient => NetIdentity.ConnectionToClient;
+        public INetworkPlayer ConnectionToClient => NetIdentity.ConnectionToClient;
 
         /// <summary>
         /// Returns the appropriate NetworkTime instance based on if this NetworkBehaviour is running as a Server or Client.
@@ -321,7 +321,7 @@ namespace Mirage
             NetIdentity.SendToObservers(message, includeOwner, channelId);
         }
 
-        protected internal void SendTargetRpcInternal(INetworkConnection conn, Type invokeClass, string rpcName, NetworkWriter writer, int channelId)
+        protected internal void SendTargetRpcInternal(INetworkPlayer conn, Type invokeClass, string rpcName, NetworkWriter writer, int channelId)
         {
             // this was in Weaver before
             if (!Server || !Server.Active)

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -12,7 +12,7 @@ namespace Mirage
     /// Event fires from a <see cref="NetworkClient">NetworkClient</see> or <see cref="NetworkServer">NetworkServer</see> during a new connection, a new authentication, or a disconnection.
     /// <para>INetworkConnection - connection creating the event</para>
     /// </summary>
-    [Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkConnection> { }
+    [Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkPlayer> { }
 
     public enum ConnectState
     {
@@ -62,7 +62,7 @@ namespace Mirage
         /// <summary>
         /// The NetworkConnection object this client is using.
         /// </summary>
-        public INetworkConnection Connection { get; internal set; }
+        public INetworkPlayer Connection { get; internal set; }
 
         internal ConnectState connectState = ConnectState.Disconnected;
 
@@ -184,9 +184,9 @@ namespace Mirage
         /// <summary>
         /// Creates a new INetworkConnection based on the provided IConnection.
         /// </summary>
-        public virtual INetworkConnection GetNewConnection(IConnection connection)
+        public virtual INetworkPlayer GetNewConnection(IConnection connection)
         {
-            return new NetworkConnection(connection);
+            return new NetworkPlayer(connection);
         }
 
         void InitializeAuthEvents()
@@ -230,7 +230,7 @@ namespace Mirage
             }
         }
 
-        internal void OnAuthenticated(INetworkConnection conn)
+        internal void OnAuthenticated(INetworkPlayer conn)
         {
             Authenticated?.Invoke(conn);
         }

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs.meta
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d4b1f9235d2a797499e5db45abf5627b
+guid: b5fd0c843eaf6e84f93b7069be632136
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -103,7 +103,7 @@ namespace Mirage
 
         #region Client
 
-        void RegisterClientMessages(INetworkConnection connection)
+        void RegisterClientMessages(INetworkPlayer connection)
         {
             connection.RegisterHandler<SceneMessage>(ClientSceneMessage);
             if (!Client.IsLocalClient)
@@ -113,7 +113,7 @@ namespace Mirage
             }
         }
 
-        void OnClientAuthenticated(INetworkConnection conn)
+        void OnClientAuthenticated(INetworkPlayer conn)
         {
             logger.Log("NetworkSceneManager.OnClientAuthenticated");
             RegisterClientMessages(conn);
@@ -125,7 +125,7 @@ namespace Mirage
                 Client.Authenticated?.RemoveListener(OnClientAuthenticated);
         }
 
-        internal void ClientSceneMessage(INetworkConnection conn, SceneMessage msg)
+        internal void ClientSceneMessage(INetworkPlayer conn, SceneMessage msg)
         {
             if (!Client.IsConnected)
             {
@@ -153,7 +153,7 @@ namespace Mirage
             ApplyOperationAsync(msg.scenePath, msg.sceneOperation).Forget();
         }
 
-        internal void ClientSceneReadyMessage(INetworkConnection conn, SceneReadyMessage msg)
+        internal void ClientSceneReadyMessage(INetworkPlayer conn, SceneReadyMessage msg)
         {
             logger.Log("ClientSceneReadyMessage");
 
@@ -162,7 +162,7 @@ namespace Mirage
                 clientLoadingOperation.allowSceneActivation = true;
         }
 
-        internal void ClientNotReadyMessage(INetworkConnection conn, NotReadyMessage msg)
+        internal void ClientNotReadyMessage(INetworkPlayer conn, NotReadyMessage msg)
         {
             logger.Log("NetworkSceneManager.OnClientNotReadyMessageInternal");
 
@@ -226,7 +226,7 @@ namespace Mirage
         #region Server
 
         // called after successful authentication
-        void OnServerAuthenticated(INetworkConnection conn)
+        void OnServerAuthenticated(INetworkPlayer conn)
         {
             logger.Log("NetworkSceneManager.OnServerAuthenticated");
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -93,7 +93,7 @@ namespace Mirage
         // original HLAPI has .localConnections list with only m_LocalConnection in it
         // (for backwards compatibility because they removed the real localConnections list a while ago)
         // => removed it for easier code. use .localConnection now!
-        public INetworkConnection LocalConnection { get; private set; }
+        public INetworkPlayer LocalConnection { get; private set; }
 
         /// <summary>
         /// The host client for this server 
@@ -114,7 +114,7 @@ namespace Mirage
         /// <summary>
         /// A list of local connections on the server.
         /// </summary>
-        public readonly HashSet<INetworkConnection> connections = new HashSet<INetworkConnection>();
+        public readonly HashSet<INetworkPlayer> connections = new HashSet<INetworkPlayer>();
 
         /// <summary>
         /// <para>Checks if the server has been started.</para>
@@ -145,8 +145,8 @@ namespace Mirage
             // make a copy,  during disconnect, it is possible that connections
             // are modified, so it throws
             // System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
-            var connectionscopy = new HashSet<INetworkConnection>(connections);
-            foreach (INetworkConnection conn in connectionscopy)
+            var connectionscopy = new HashSet<INetworkPlayer>(connections);
+            foreach (INetworkPlayer conn in connectionscopy)
             {
                 conn.Disconnect();
             }
@@ -240,7 +240,7 @@ namespace Mirage
 
         private void TransportConnected(IConnection connection)
         {
-            INetworkConnection networkConnectionToClient = GetNewConnection(connection);
+            INetworkPlayer networkConnectionToClient = GetNewConnection(connection);
             ConnectionAcceptedAsync(networkConnectionToClient).Forget();
         }
 
@@ -302,9 +302,9 @@ namespace Mirage
         /// <summary>
         /// Creates a new INetworkConnection based on the provided IConnection.
         /// </summary>
-        public virtual INetworkConnection GetNewConnection(IConnection connection)
+        public virtual INetworkPlayer GetNewConnection(IConnection connection)
         {
-            return new NetworkConnection(connection);
+            return new NetworkPlayer(connection);
         }
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace Mirage
         /// <para>This connection will use the callbacks registered with the server.</para>
         /// </summary>
         /// <param name="conn">Network connection to add.</param>
-        public void AddConnection(INetworkConnection conn)
+        public void AddConnection(INetworkPlayer conn)
         {
             if (!connections.Contains(conn))
             {
@@ -327,7 +327,7 @@ namespace Mirage
         /// This removes an external connection added with AddExternalConnection().
         /// </summary>
         /// <param name="connectionId">The id of the connection to remove.</param>
-        public void RemoveConnection(INetworkConnection conn)
+        public void RemoveConnection(INetworkPlayer conn)
         {
             connections.Remove(conn);
         }
@@ -344,7 +344,7 @@ namespace Mirage
                 throw new InvalidOperationException("Local Connection already exists");
             }
 
-            INetworkConnection conn = GetNewConnection(tconn);
+            INetworkPlayer conn = GetNewConnection(tconn);
             LocalConnection = conn;
             LocalClient = client;
 
@@ -361,10 +361,10 @@ namespace Mirage
         public void SendToAll<T>(T msg, int channelId = Channel.Reliable)
         {
             if (logger.LogEnabled()) logger.Log("Server.SendToAll id:" + typeof(T));
-            NetworkConnection.Send(connections, msg, channelId);
+            NetworkPlayer.Send(connections, msg, channelId);
         }
 
-        async UniTaskVoid ConnectionAcceptedAsync(INetworkConnection conn)
+        async UniTaskVoid ConnectionAcceptedAsync(INetworkPlayer conn)
         {
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + conn);
 
@@ -402,7 +402,7 @@ namespace Mirage
         }
 
         //called once a client disconnects from the server
-        void OnDisconnected(INetworkConnection connection)
+        void OnDisconnected(INetworkPlayer connection)
         {
             if (logger.LogEnabled()) logger.Log("Server disconnect client:" + connection);
 
@@ -417,7 +417,7 @@ namespace Mirage
                 LocalConnection = null;
         }
 
-        internal void OnAuthenticated(INetworkConnection conn)
+        internal void OnAuthenticated(INetworkPlayer conn)
         {
             if (logger.LogEnabled()) logger.Log("Server authenticate client:" + conn);
 

--- a/Assets/Mirage/Runtime/NetworkTime.cs
+++ b/Assets/Mirage/Runtime/NetworkTime.cs
@@ -68,7 +68,7 @@ namespace Mirage
         // executed at the server when we receive a ping message
         // reply with a pong containing the time from the client
         // and time from the server
-        internal void OnServerPing(INetworkConnection conn, NetworkPingMessage msg)
+        internal void OnServerPing(INetworkPlayer conn, NetworkPingMessage msg)
         {
             if (logger.LogEnabled()) logger.Log("OnPingServerMessage  conn=" + conn);
 

--- a/Assets/Mirage/Runtime/NetworkVisibility.cs
+++ b/Assets/Mirage/Runtime/NetworkVisibility.cs
@@ -18,7 +18,7 @@ namespace Mirage
         /// </summary>
         /// <param name="conn">Network connection of a player.</param>
         /// <returns>True if the player can see this object.</returns>
-        public abstract bool OnCheckObserver(INetworkConnection conn);
+        public abstract bool OnCheckObserver(INetworkPlayer conn);
 
         /// <summary>
         /// Callback used by the visibility system to (re)construct the set of observers that can see this object.
@@ -26,7 +26,7 @@ namespace Mirage
         /// </summary>
         /// <param name="observers">The new set of observers for this object.</param>
         /// <param name="initialize">True if the set of observers is being built for the first time.</param>
-        public abstract void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize);
+        public abstract void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize);
 
         /// <summary>
         /// Callback used by the visibility system for objects on a host.

--- a/Assets/Mirage/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirage/Runtime/PlayerSpawner.cs
@@ -81,7 +81,7 @@ namespace Mirage
             }
         }
 
-        private void OnServerAuthenticated(INetworkConnection connection)
+        private void OnServerAuthenticated(INetworkPlayer connection)
         {
             // wait for client to send us an AddPlayerMessage
             connection.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerInternal);
@@ -103,7 +103,7 @@ namespace Mirage
             Client.Send(new AddPlayerMessage());
         }
 
-        void OnServerAddPlayerInternal(INetworkConnection conn, AddPlayerMessage msg)
+        void OnServerAddPlayerInternal(INetworkPlayer conn, AddPlayerMessage msg)
         {
             logger.Log("PlayerSpawner.OnServerAddPlayer");
 
@@ -120,7 +120,7 @@ namespace Mirage
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public virtual void OnServerAddPlayer(INetworkConnection conn)
+        public virtual void OnServerAddPlayer(INetworkPlayer conn)
         {
             Transform startPos = GetStartPosition();
             NetworkIdentity player = startPos != null

--- a/Assets/Mirage/Runtime/RemoteCallHelper.cs
+++ b/Assets/Mirage/Runtime/RemoteCallHelper.cs
@@ -10,8 +10,8 @@ namespace Mirage.RemoteCalls
     /// </summary>
     /// <param name="obj"></param>
     /// <param name="reader"></param>
-    public delegate void CmdDelegate(NetworkBehaviour obj, NetworkReader reader, INetworkConnection senderConnection, int replyId);
-    public delegate UniTask<T> RequestDelegate<T>(NetworkBehaviour obj, NetworkReader reader, INetworkConnection senderConnection, int replyId);
+    public delegate void CmdDelegate(NetworkBehaviour obj, NetworkReader reader, INetworkPlayer senderConnection, int replyId);
+    public delegate UniTask<T> RequestDelegate<T>(NetworkBehaviour obj, NetworkReader reader, INetworkPlayer senderConnection, int replyId);
 
     /// <summary>
     /// Stub Skeleton for RPC
@@ -30,7 +30,7 @@ namespace Mirage.RemoteCalls
                     this.invokeFunction == invokeFunction;
         }
 
-        internal void Invoke(NetworkReader reader, NetworkBehaviour invokingType, INetworkConnection senderConnection = null, int replyId = 0)
+        internal void Invoke(NetworkReader reader, NetworkBehaviour invokingType, INetworkPlayer senderConnection = null, int replyId = 0)
         {
             if (invokeClass.IsInstanceOfType(invokingType))
             {
@@ -105,7 +105,7 @@ namespace Mirage.RemoteCalls
 
         public static void RegisterRequestDelegate<T>(Type invokeClass, string cmdName, RequestDelegate<T> func, bool cmdRequireAuthority = true)
         {
-            async UniTaskVoid Wrapper(NetworkBehaviour obj, NetworkReader reader, INetworkConnection senderConnection, int replyId)
+            async UniTaskVoid Wrapper(NetworkBehaviour obj, NetworkReader reader, INetworkPlayer senderConnection, int replyId)
             {
                 /// invoke the serverRpc and send a reply message
                 T result = await func(obj, reader, senderConnection, replyId);
@@ -123,7 +123,7 @@ namespace Mirage.RemoteCalls
                 }
             }
 
-            void CmdWrapper(NetworkBehaviour obj, NetworkReader reader, INetworkConnection senderConnection, int replyId)
+            void CmdWrapper(NetworkBehaviour obj, NetworkReader reader, INetworkPlayer senderConnection, int replyId)
             {
                 Wrapper(obj, reader, senderConnection, replyId).Forget();
             }

--- a/Assets/Mirage/Samples~/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
+++ b/Assets/Mirage/Samples~/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
@@ -36,7 +36,7 @@ namespace Mirage.Examples.Additive
             GameObject target = null;
             float distance = 100f;
 
-            foreach (INetworkConnection networkConnection in NetIdentity.observers)
+            foreach (INetworkPlayer networkConnection in NetIdentity.observers)
             {
                 GameObject tempTarget = networkConnection.Identity.gameObject;
                 float tempDistance = Vector3.Distance(tempTarget.transform.position, transform.position);

--- a/Assets/Mirage/Samples~/Chat/Scripts/ChatNetworkManager.cs
+++ b/Assets/Mirage/Samples~/Chat/Scripts/ChatNetworkManager.cs
@@ -22,18 +22,18 @@ namespace Mirage.Examples.Chat
             public string name;
         }
 
-        public void OnServerAuthenticated(INetworkConnection conn)
+        public void OnServerAuthenticated(INetworkPlayer conn)
         {
             conn.RegisterHandler<CreatePlayerMessage>(OnCreatePlayer);
         }
 
-        public void OnClientAuthenticated(INetworkConnection conn)
+        public void OnClientAuthenticated(INetworkPlayer conn)
         {
             // tell the server to create a player with this name
             conn.Send(new CreatePlayerMessage { name = PlayerName });
         }
 
-        private void OnCreatePlayer(INetworkConnection connection, CreatePlayerMessage createPlayerMessage)
+        private void OnCreatePlayer(INetworkPlayer connection, CreatePlayerMessage createPlayerMessage)
         {
             // create a gameobject using the name supplied by client
             GameObject playergo = Instantiate(playerPrefab).gameObject;

--- a/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
+++ b/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
@@ -35,7 +35,7 @@ namespace Mirage.Examples.MultipleAdditiveScenes
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public void OnServerAddPlayer(INetworkConnection conn)
+        public void OnServerAddPlayer(INetworkPlayer conn)
         {
             // This delay is really for the host player that loads too fast for the server to have subscene loaded
             StartCoroutine(AddPlayerDelayed(conn));
@@ -43,7 +43,7 @@ namespace Mirage.Examples.MultipleAdditiveScenes
 
         int playerId = 1;
 
-        IEnumerator AddPlayerDelayed(INetworkConnection conn)
+        IEnumerator AddPlayerDelayed(INetworkPlayer conn)
         {
             yield return new WaitForSeconds(.5f);
             conn.Send(new SceneMessage { scenePath = gameScene, sceneOperation = SceneOperation.LoadAdditive });

--- a/Assets/Mirage/Samples~/Pong/Scripts/PaddleSpawner.cs
+++ b/Assets/Mirage/Samples~/Pong/Scripts/PaddleSpawner.cs
@@ -10,7 +10,7 @@ namespace Mirage.Examples.Pong
 
         GameObject ball;
 
-        public override void OnServerAddPlayer(INetworkConnection conn)
+        public override void OnServerAddPlayer(INetworkPlayer conn)
         {
             // add player at correct spawn position
             Transform start = Server.NumberOfPlayers == 0 ? leftRacketSpawn : rightRacketSpawn;
@@ -26,7 +26,7 @@ namespace Mirage.Examples.Pong
         }
 
 
-        public void OnServerDisconnect(INetworkConnection conn)
+        public void OnServerDisconnect(INetworkPlayer conn)
         {
             // destroy ball
             if (ball != null)

--- a/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
@@ -54,7 +54,7 @@ namespace Mirage.Weaver
                 MethodAttributes.Family | MethodAttributes.HideBySig);
 
             _ = rpc.AddParam<NetworkReader>("reader");
-            _ = rpc.AddParam<INetworkConnection>("senderConnection");
+            _ = rpc.AddParam<INetworkPlayer>("senderConnection");
             _ = rpc.AddParam<int>("replyId");
 
             ILProcessor worker = rpc.Body.GetILProcessor();

--- a/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
@@ -223,9 +223,9 @@ namespace Mirage.Weaver
                 method.Is<IMessageSender>(nameof(IMessageSender.Send)) ||
                 method.Is<IMessageSender>(nameof(IMessageReceiver.RegisterHandler)) ||
                 method.Is<IMessageSender>(nameof(IMessageReceiver.UnregisterHandler)) ||
-                method.Is<NetworkConnection>(nameof(NetworkConnection.Send)) ||
-                method.Is<NetworkConnection>(nameof(NetworkConnection.RegisterHandler)) ||
-                method.Is<NetworkConnection>(nameof(NetworkConnection.UnregisterHandler)) ||
+                method.Is<NetworkPlayer>(nameof(NetworkPlayer.Send)) ||
+                method.Is<NetworkPlayer>(nameof(NetworkPlayer.RegisterHandler)) ||
+                method.Is<NetworkPlayer>(nameof(NetworkPlayer.UnregisterHandler)) ||
                 method.Is<NetworkClient>(nameof(NetworkClient.Send)) ||
                 method.Is<NetworkServer>(nameof(NetworkServer.SendToAll)) ||
                 method.Is<INetworkServer>(nameof(INetworkServer.SendToAll));

--- a/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
@@ -31,12 +31,12 @@ namespace Mirage.Weaver
         public bool HasNetworkConnectionParameter(MethodDefinition md)
         {
             return md.Parameters.Count > 0 &&
-                   md.Parameters[0].ParameterType.Is<INetworkConnection>();
+                   md.Parameters[0].ParameterType.Is<INetworkPlayer>();
         }
 
         public static bool IsNetworkConnection(TypeReference type)
         {
-            return type.Resolve().ImplementsInterface<INetworkConnection>();
+            return type.Resolve().ImplementsInterface<INetworkPlayer>();
         }
 
         public bool WriteArguments(ILProcessor worker, MethodDefinition method, VariableDefinition writer, RemoteCallType callType)

--- a/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
@@ -150,7 +150,7 @@ namespace Mirage.Weaver
                 userCodeFunc.ReturnType);
 
             _ = cmd.AddParam<NetworkReader>("reader");
-            _ = cmd.AddParam<INetworkConnection>("senderConnection");
+            _ = cmd.AddParam<INetworkPlayer>("senderConnection");
             _ = cmd.AddParam<int>("replyId");
 
 

--- a/Assets/Tests/Common/LocalConnections.cs
+++ b/Assets/Tests/Common/LocalConnections.cs
@@ -3,11 +3,11 @@ namespace Mirage.Tests
 
     public static class LocalConnections
     {
-        public static (NetworkConnection, NetworkConnection) PipedConnections()
+        public static (NetworkPlayer, NetworkPlayer) PipedConnections()
         {
             (IConnection c1, IConnection c2) = PipeConnection.CreatePipe();
-            var toServer = new NetworkConnection(c2);
-            var toClient = new NetworkConnection(c1);
+            var toServer = new NetworkPlayer(c2);
+            var toClient = new NetworkPlayer(c1);
 
             return (toServer, toClient);
         }

--- a/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
@@ -15,8 +15,8 @@ namespace Mirage
 
         class SetHostVisibilityExceptionNetworkBehaviour : NetworkVisibility
         {
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize) { }
-            public override bool OnCheckObserver(INetworkConnection conn) { return true; }
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize) { }
+            public override bool OnCheckObserver(INetworkPlayer conn) { return true; }
             public override void OnSetHostVisibility(bool visible)
             {
                 throw new Exception("some exception");
@@ -26,8 +26,8 @@ namespace Mirage
         class SetHostVisibilityNetworkBehaviour : NetworkVisibility
         {
             public int called;
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize) { }
-            public override bool OnCheckObserver(INetworkConnection conn) { return true; }
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize) { }
+            public override bool OnCheckObserver(INetworkPlayer conn) { return true; }
             public override void OnSetHostVisibility(bool visible)
             {
                 ++called;
@@ -38,9 +38,9 @@ namespace Mirage
         class CheckObserverExceptionNetworkBehaviour : NetworkVisibility
         {
             public int called;
-            public INetworkConnection valuePassed;
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize) { }
-            public override bool OnCheckObserver(INetworkConnection conn)
+            public INetworkPlayer valuePassed;
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize) { }
+            public override bool OnCheckObserver(INetworkPlayer conn)
             {
                 ++called;
                 valuePassed = conn;
@@ -52,8 +52,8 @@ namespace Mirage
         class CheckObserverTrueNetworkBehaviour : NetworkVisibility
         {
             public int called;
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize) { }
-            public override bool OnCheckObserver(INetworkConnection conn)
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize) { }
+            public override bool OnCheckObserver(INetworkPlayer conn)
             {
                 ++called;
                 return true;
@@ -64,8 +64,8 @@ namespace Mirage
         class CheckObserverFalseNetworkBehaviour : NetworkVisibility
         {
             public int called;
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize) { }
-            public override bool OnCheckObserver(INetworkConnection conn)
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize) { }
+            public override bool OnCheckObserver(INetworkPlayer conn)
             {
                 ++called;
                 return false;
@@ -131,9 +131,9 @@ namespace Mirage
 
         class RebuildObserversNetworkBehaviour : NetworkVisibility
         {
-            public INetworkConnection observer;
-            public override bool OnCheckObserver(INetworkConnection conn) { return true; }
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
+            public INetworkPlayer observer;
+            public override bool OnCheckObserver(INetworkPlayer conn) { return true; }
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize)
             {
                 observers.Add(observer);
             }
@@ -142,8 +142,8 @@ namespace Mirage
 
         class RebuildEmptyObserversNetworkBehaviour : NetworkVisibility
         {
-            public override bool OnCheckObserver(INetworkConnection conn) { return true; }
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize) { }
+            public override bool OnCheckObserver(INetworkPlayer conn) { return true; }
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize) { }
             public int hostVisibilityCalled;
             public bool hostVisibilityValue;
             public override void OnSetHostVisibility(bool visible)
@@ -271,7 +271,7 @@ namespace Mirage
         public void SetClientOwner()
         {
             // SetClientOwner
-            (_, NetworkConnection original) = PipedConnections();
+            (_, NetworkPlayer original) = PipedConnections();
             identity.SetClientOwner(original);
             Assert.That(identity.ConnectionToClient, Is.EqualTo(original));
         }
@@ -280,11 +280,11 @@ namespace Mirage
         public void SetOverrideClientOwner()
         {
             // SetClientOwner
-            (_, NetworkConnection original) = PipedConnections();
+            (_, NetworkPlayer original) = PipedConnections();
             identity.SetClientOwner(original);
 
             // setting it when it's already set shouldn't overwrite the original
-            (_, NetworkConnection overwrite) = PipedConnections();
+            (_, NetworkPlayer overwrite) = PipedConnections();
             // will log a warning
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -301,10 +301,10 @@ namespace Mirage
             identity.StartServer();
 
             // add an observer connection
-            INetworkConnection connection = Substitute.For<INetworkConnection>();
+            INetworkPlayer connection = Substitute.For<INetworkPlayer>();
             identity.observers.Add(connection);
 
-            INetworkConnection connection2 = Substitute.For<INetworkConnection>();
+            INetworkPlayer connection2 = Substitute.For<INetworkPlayer>();
             // RemoveObserverInternal with invalid connection should do nothing
             identity.RemoveObserverInternal(connection2);
             Assert.That(identity.observers, Is.EquivalentTo(new[] { connection }));
@@ -516,7 +516,7 @@ namespace Mirage
             // add component
             gameObject.AddComponent<CheckObserverExceptionNetworkBehaviour>();
 
-            var connection = new NetworkConnection(tconn42);
+            var connection = new NetworkPlayer(tconn42);
 
             // should catch the exception internally and not throw it
             Assert.Throws<Exception>(() =>
@@ -533,7 +533,7 @@ namespace Mirage
             var gameObjectTrue = new GameObject();
             NetworkIdentity identityTrue = gameObjectTrue.AddComponent<NetworkIdentity>();
             CheckObserverTrueNetworkBehaviour compTrue = gameObjectTrue.AddComponent<CheckObserverTrueNetworkBehaviour>();
-            var connection = new NetworkConnection(tconn42);
+            var connection = new NetworkPlayer(tconn42);
             Assert.That(identityTrue.OnCheckObserver(connection), Is.True);
             Assert.That(compTrue.called, Is.EqualTo(1));
         }
@@ -547,7 +547,7 @@ namespace Mirage
             var gameObjectFalse = new GameObject();
             NetworkIdentity identityFalse = gameObjectFalse.AddComponent<NetworkIdentity>();
             CheckObserverFalseNetworkBehaviour compFalse = gameObjectFalse.AddComponent<CheckObserverFalseNetworkBehaviour>();
-            var connection = new NetworkConnection(tconn42);
+            var connection = new NetworkPlayer(tconn42);
             Assert.That(identityFalse.OnCheckObserver(connection), Is.False);
             Assert.That(compFalse.called, Is.EqualTo(1));
         }
@@ -710,8 +710,8 @@ namespace Mirage
         {
             identity.Server = server;
             // create some connections
-            var connection1 = new NetworkConnection(tconn42);
-            var connection2 = new NetworkConnection(tconn43);
+            var connection1 = new NetworkPlayer(tconn42);
+            var connection2 = new NetworkPlayer(tconn43);
 
             // call OnStartServer so that observers dict is created
             identity.StartServer();
@@ -733,8 +733,8 @@ namespace Mirage
             identity.StartServer();
 
             // add some observers
-            identity.observers.Add(new NetworkConnection(tconn42));
-            identity.observers.Add(new NetworkConnection(tconn43));
+            identity.observers.Add(new NetworkPlayer(tconn42));
+            identity.observers.Add(new NetworkPlayer(tconn43));
 
             // call ClearObservers
             identity.ClearObservers();
@@ -747,9 +747,9 @@ namespace Mirage
         {
             // creates .observers and generates a netId
             identity.StartServer();
-            identity.ConnectionToClient = new NetworkConnection(tconn42);
-            identity.ConnectionToServer = new NetworkConnection(tconn43);
-            identity.observers.Add(new NetworkConnection(tconn42));
+            identity.ConnectionToClient = new NetworkPlayer(tconn42);
+            identity.ConnectionToServer = new NetworkPlayer(tconn43);
+            identity.observers.Add(new NetworkPlayer(tconn42));
 
             // mark for reset and reset
             identity.Reset();
@@ -763,10 +763,10 @@ namespace Mirage
         {
             // add components
             RebuildObserversNetworkBehaviour comp = gameObject.AddComponent<RebuildObserversNetworkBehaviour>();
-            comp.observer = new NetworkConnection(tconn42);
+            comp.observer = new NetworkPlayer(tconn42);
 
             // get new observers
-            var observers = new HashSet<INetworkConnection>();
+            var observers = new HashSet<INetworkPlayer>();
             bool result = identity.GetNewObservers(observers, true);
             Assert.That(result, Is.True);
             Assert.That(observers.Count, Is.EqualTo(1));
@@ -778,9 +778,9 @@ namespace Mirage
         {
             // get new observers. no observer components so it should just clear
             // it and not do anything else
-            var observers = new HashSet<INetworkConnection>
+            var observers = new HashSet<INetworkPlayer>
             {
-                new NetworkConnection(tconn42)
+                new NetworkPlayer(tconn42)
             };
             identity.GetNewObservers(observers, true);
             Assert.That(observers.Count, Is.EqualTo(0));
@@ -790,7 +790,7 @@ namespace Mirage
         public void GetNewObserversFalseIfNoComponents()
         {
             // get new observers. no observer components so it should be false
-            var observers = new HashSet<INetworkConnection>();
+            var observers = new HashSet<INetworkPlayer>();
             bool result = identity.GetNewObservers(observers, true);
             Assert.That(result, Is.False);
         }
@@ -805,7 +805,7 @@ namespace Mirage
             gameObject.AddComponent<RebuildEmptyObserversNetworkBehaviour>();
 
             // add own player connection that isn't ready
-            (_, NetworkConnection connection) = PipedConnections();
+            (_, NetworkPlayer connection) = PipedConnections();
             identity.ConnectionToClient = connection;
 
             // call OnStartServer so that observers dict is created
@@ -823,7 +823,7 @@ namespace Mirage
             // add a proximity checker
             // one with a ready connection, one with no ready connection, one with null connection
             RebuildObserversNetworkBehaviour comp = gameObject.AddComponent<RebuildObserversNetworkBehaviour>();
-            comp.observer = Substitute.For<INetworkConnection>();
+            comp.observer = Substitute.For<INetworkPlayer>();
             comp.observer.IsReady.Returns(true);
 
             // rebuild observers should add all component's ready observers
@@ -838,7 +838,7 @@ namespace Mirage
             // add a proximity checker
             // one with a ready connection, one with no ready connection, one with null connection
             RebuildObserversNetworkBehaviour comp = gameObject.AddComponent<RebuildObserversNetworkBehaviour>();
-            comp.observer = Substitute.For<INetworkConnection>();
+            comp.observer = Substitute.For<INetworkPlayer>();
             comp.observer.IsReady.Returns(false);
 
             // rebuild observers should add all component's ready observers
@@ -849,9 +849,9 @@ namespace Mirage
         [Test]
         public void RebuildObserversAddsReadyServerConnectionsIfNotImplemented()
         {
-            INetworkConnection readyConnection = Substitute.For<INetworkConnection>();
+            INetworkPlayer readyConnection = Substitute.For<INetworkPlayer>();
             readyConnection.IsReady.Returns(true);
-            INetworkConnection notReadyConnection = Substitute.For<INetworkConnection>();
+            INetworkPlayer notReadyConnection = Substitute.For<INetworkPlayer>();
             notReadyConnection.IsReady.Returns(false);
 
             // add some server connections

--- a/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformance.cs
+++ b/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformance.cs
@@ -28,7 +28,7 @@ namespace Mirage.Tests.Performance
         {
             gameObject = new GameObject();
             identity = gameObject.AddComponent<NetworkIdentity>();
-            identity.ConnectionToClient = Substitute.For<INetworkConnection>();
+            identity.ConnectionToClient = Substitute.For<INetworkPlayer>();
             identity.observers.Add(identity.ConnectionToClient);
             health = gameObject.AddComponent<Health>();
             health.syncMode = SyncMode.Owner;

--- a/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformanceWithMultipleBehaviour.cs
+++ b/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformanceWithMultipleBehaviour.cs
@@ -20,7 +20,7 @@ namespace Mirage.Tests.Performance
         {
             gameObject = new GameObject();
             identity = gameObject.AddComponent<NetworkIdentity>();
-            identity.ConnectionToClient = Substitute.For<INetworkConnection>();
+            identity.ConnectionToClient = Substitute.For<INetworkPlayer>();
             identity.observers.Add(identity.ConnectionToClient);
             health = new Health[healthCount];
             for (int i = 0; i < healthCount; i++)

--- a/Assets/Tests/Runtime/ClientServer/ClientServerSetup.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerSetup.cs
@@ -33,8 +33,8 @@ namespace Mirage.Tests.ClientServer
         protected GameObject playerPrefab;
 
         protected Transport testTransport;
-        protected INetworkConnection connectionToServer;
-        protected INetworkConnection connectionToClient;
+        protected INetworkPlayer connectionToServer;
+        protected INetworkPlayer connectionToClient;
 
         public virtual void ExtraSetup() { }
 

--- a/Assets/Tests/Runtime/ClientServer/NetworkAuthenticatorTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkAuthenticatorTest.cs
@@ -10,8 +10,8 @@ namespace Mirage.Tests.ClientServer
         NetworkAuthenticator serverAuthenticator;
         NetworkAuthenticator clientAuthenticator;
 
-        Action<INetworkConnection> serverMockMethod;
-        Action<INetworkConnection> clientMockMethod;
+        Action<INetworkPlayer> serverMockMethod;
+        Action<INetworkPlayer> clientMockMethod;
 
 
         class NetworkAuthenticationImpl : NetworkAuthenticator { };
@@ -23,43 +23,43 @@ namespace Mirage.Tests.ClientServer
             server.authenticator = serverAuthenticator;
             client.authenticator = clientAuthenticator;
 
-            serverMockMethod = Substitute.For<Action<INetworkConnection>>();
+            serverMockMethod = Substitute.For<Action<INetworkPlayer>>();
             serverAuthenticator.OnServerAuthenticated += serverMockMethod;
 
-            clientMockMethod = Substitute.For<Action<INetworkConnection>>();
+            clientMockMethod = Substitute.For<Action<INetworkPlayer>>();
             clientAuthenticator.OnClientAuthenticated += clientMockMethod;
         }
 
         [Test]
         public void OnServerAuthenticateTest()
         {
-            serverAuthenticator.OnServerAuthenticate(Substitute.For<INetworkConnection>());
+            serverAuthenticator.OnServerAuthenticate(Substitute.For<INetworkPlayer>());
 
-            serverMockMethod.Received().Invoke(Arg.Any<INetworkConnection>());
+            serverMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }
 
         [Test]
         public void OnServerAuthenticateInternalTest()
         {
-            serverAuthenticator.OnServerAuthenticateInternal(Substitute.For<INetworkConnection>());
+            serverAuthenticator.OnServerAuthenticateInternal(Substitute.For<INetworkPlayer>());
 
-            serverMockMethod.Received().Invoke(Arg.Any<INetworkConnection>());
+            serverMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }
 
         [Test]
         public void OnClientAuthenticateTest()
         {
-            clientAuthenticator.OnClientAuthenticate(Substitute.For<INetworkConnection>());
+            clientAuthenticator.OnClientAuthenticate(Substitute.For<INetworkPlayer>());
 
-            clientMockMethod.Received().Invoke(Arg.Any<INetworkConnection>());
+            clientMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }
 
         [Test]
         public void OnClientAuthenticateInternalTest()
         {
-            clientAuthenticator.OnClientAuthenticateInternal(Substitute.For<INetworkConnection>());
+            clientAuthenticator.OnClientAuthenticateInternal(Substitute.For<INetworkPlayer>());
 
-            clientMockMethod.Received().Invoke(Arg.Any<INetworkConnection>());
+            clientMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }
 
         [Test]
@@ -77,13 +77,13 @@ namespace Mirage.Tests.ClientServer
         [Test]
         public void NetworkClientCallsAuthenticator()
         {
-            clientMockMethod.Received().Invoke(Arg.Any<INetworkConnection>());
+            clientMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }
 
         [Test]
         public void NetworkServerCallsAuthenticator()
         {
-            clientMockMethod.Received().Invoke(Arg.Any<INetworkConnection>());
+            clientMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }
     }
 }

--- a/Assets/Tests/Runtime/Host/NetworkClientTest.cs
+++ b/Assets/Tests/Runtime/Host/NetworkClientTest.cs
@@ -39,7 +39,7 @@ namespace Mirage.Tests.Host
         [Test]
         public void ConnectionClearHandlersTest()
         {
-            var clientConn = client.Connection as NetworkConnection;
+            var clientConn = client.Connection as NetworkPlayer;
 
             Assert.That(clientConn.messageHandlers.Count > 0);
 

--- a/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
@@ -79,7 +79,7 @@ namespace Mirage.Tests.Host
             // test the callback too
             int callbackCalled = 0;
 
-            void Callback(INetworkConnection conn, NetworkIdentity networkIdentity, bool state)
+            void Callback(INetworkPlayer conn, NetworkIdentity networkIdentity, bool state)
             {
                 ++callbackCalled;
                 Assert.That(networkIdentity, Is.EqualTo(testIdentity));
@@ -141,7 +141,7 @@ namespace Mirage.Tests.Host
             // another connection
             Assert.Throws<InvalidOperationException>(() =>
             {
-                testIdentity.AssignClientAuthority(new NetworkConnection(Substitute.For<IConnection>()));
+                testIdentity.AssignClientAuthority(new NetworkPlayer(Substitute.For<IConnection>()));
             });
         }
 

--- a/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
@@ -17,7 +17,7 @@ namespace Mirage.Tests.Host
         [Test]
         public void SetClientReadyAndNotReadyTest()
         {
-            (_, NetworkConnection connection) = PipedConnections();
+            (_, NetworkPlayer connection) = PipedConnections();
             Assert.That(connection.IsReady, Is.False);
 
             serverObjectManager.SetClientReady(connection);
@@ -31,12 +31,12 @@ namespace Mirage.Tests.Host
         public void SetAllClientsNotReadyTest()
         {
             // add first ready client
-            (_, NetworkConnection first) = PipedConnections();
+            (_, NetworkPlayer first) = PipedConnections();
             first.IsReady = true;
             server.connections.Add(first);
 
             // add second ready client
-            (_, NetworkConnection second) = PipedConnections();
+            (_, NetworkPlayer second) = PipedConnections();
             second.IsReady = true;
             server.connections.Add(second);
 
@@ -74,7 +74,7 @@ namespace Mirage.Tests.Host
         {
             // add connection
 
-            NetworkConnection connectionToClient = Substitute.For<NetworkConnection>(Substitute.For<IConnection>());
+            NetworkPlayer connectionToClient = Substitute.For<NetworkPlayer>(Substitute.For<IConnection>());
 
             NetworkIdentity identity = new GameObject().AddComponent<NetworkIdentity>();
 

--- a/Assets/Tests/Runtime/MockComponent.cs
+++ b/Assets/Tests/Runtime/MockComponent.cs
@@ -42,10 +42,10 @@ namespace Mirage.Tests
 
         public int targetRpcArg1;
         public string targetRpcArg2;
-        public INetworkConnection targetRpcConn;
+        public INetworkPlayer targetRpcConn;
 
         [ClientRpc(target = Mirage.Client.Connection)]
-        public void ClientConnRpcTest(INetworkConnection conn, int arg1, string arg2)
+        public void ClientConnRpcTest(INetworkPlayer conn, int arg1, string arg2)
         {
             targetRpcConn = conn;
             targetRpcArg1 = arg1;

--- a/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
@@ -12,8 +12,8 @@ namespace Mirage.Tests
         #region test components
         class RebuildEmptyObserversNetworkBehaviour : NetworkVisibility
         {
-            public override bool OnCheckObserver(INetworkConnection conn) { return true; }
-            public override void OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize) { }
+            public override bool OnCheckObserver(INetworkPlayer conn) { return true; }
+            public override void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize) { }
             public override void OnSetHostVisibility(bool visible)
             {
             }
@@ -63,8 +63,8 @@ namespace Mirage.Tests
         [Test]
         public void AddAllReadyServerConnectionsToObservers()
         {
-            var connection1 = new NetworkConnection(tconn42) { IsReady = true };
-            var connection2 = new NetworkConnection(tconn43) { IsReady = false };
+            var connection1 = new NetworkPlayer(tconn42) { IsReady = true };
+            var connection2 = new NetworkPlayer(tconn43) { IsReady = false };
             // add some server connections
             server.connections.Add(connection1);
             server.connections.Add(connection2);
@@ -96,7 +96,7 @@ namespace Mirage.Tests
             gameObject.AddComponent<RebuildEmptyObserversNetworkBehaviour>();
 
             // add own player connection
-            (_, NetworkConnection connection) = PipedConnections();
+            (_, NetworkPlayer connection) = PipedConnections();
             connection.IsReady = true;
             identity.ConnectionToClient = connection;
 

--- a/Assets/Tests/Runtime/NetworkMatchCheckerTest.cs
+++ b/Assets/Tests/Runtime/NetworkMatchCheckerTest.cs
@@ -17,9 +17,9 @@ namespace Mirage.Tests
         private GameObject player3;
         private NetworkMatchChecker player1MatchChecker;
         private NetworkMatchChecker player2MatchChecker;
-        private NetworkConnection player1Connection;
-        private NetworkConnection player2Connection;
-        private NetworkConnection player3Connection;
+        private NetworkPlayer player1Connection;
+        private NetworkPlayer player2Connection;
+        private NetworkPlayer player3Connection;
         private Dictionary<Guid, HashSet<NetworkIdentity>> matchPlayers;
 
         [SetUp]
@@ -61,11 +61,11 @@ namespace Mirage.Tests
             return (Dictionary<Guid, HashSet<NetworkIdentity>>)fieldInfo.GetValue(null);
         }
 
-        static NetworkConnection CreateNetworkConnection(GameObject player)
+        static NetworkPlayer CreateNetworkConnection(GameObject player)
         {
             (IConnection conn1, IConnection _) = PipeConnection.CreatePipe();
 
-            var connection = new NetworkConnection(conn1)
+            var connection = new NetworkPlayer(conn1)
             {
                 Identity = player.GetComponent<NetworkIdentity>()
             };

--- a/Assets/Tests/Runtime/Serializers/NetworkConnectionTest.cs
+++ b/Assets/Tests/Runtime/Serializers/NetworkConnectionTest.cs
@@ -7,7 +7,7 @@ namespace Mirage.Tests
 {
     public class NetworkConnectionTest
     {
-        private NetworkConnection connection;
+        private NetworkPlayer connection;
         private byte[] serializedMessage;
         private IConnection mockTransportConnection;
 
@@ -15,9 +15,9 @@ namespace Mirage.Tests
 
         private NotifyPacket lastSent;
 
-        private Action<INetworkConnection, object> delivered;
+        private Action<INetworkPlayer, object> delivered;
 
-        private Action<INetworkConnection, object> lost;
+        private Action<INetworkPlayer, object> lost;
 
         private byte[] lastSerializedPacket;
 
@@ -41,13 +41,13 @@ namespace Mirage.Tests
             mockTransportConnection.Send(
                 Arg.Do<ArraySegment<byte>>(ParsePacket), Channel.Unreliable);
 
-            connection = new NetworkConnection(mockTransportConnection);
+            connection = new NetworkPlayer(mockTransportConnection);
 
             serializedMessage = MessagePacker.Pack(new ReadyMessage());
             connection.RegisterHandler<ReadyMessage>(message => { });
 
-            delivered = Substitute.For<Action<INetworkConnection, object>>();
-            lost = Substitute.For<Action<INetworkConnection, object>>();
+            delivered = Substitute.For<Action<INetworkPlayer, object>>();
+            lost = Substitute.For<Action<INetworkPlayer, object>>();
 
             connection.NotifyDelivered += delivered;
             connection.NotifyLost += lost;
@@ -255,7 +255,7 @@ namespace Mirage.Tests
 
             connection.ReceiveNotify(reply, new NetworkReader(serializedMessage), Channel.Unreliable);
 
-            delivered.DidNotReceive().Invoke(Arg.Any<INetworkConnection>(), 5);
+            delivered.DidNotReceive().Invoke(Arg.Any<INetworkPlayer>(), 5);
 
             reply = new NotifyPacket
             {

--- a/Assets/Tests/Weaver/NetworkBehaviourTests.cs
+++ b/Assets/Tests/Weaver/NetworkBehaviourTests.cs
@@ -136,7 +136,7 @@ namespace Mirage.Weaver
         [Test]
         public void NetworkBehaviourClientRpcParamNetworkConnectionNotFirst()
         {
-            HasError("ClientRpcCantHaveParamOptional has invalid parameter monkeyCon, Cannot pass NetworkConnections", "System.Void NetworkBehaviourTests.NetworkBehaviourClientRpcParamNetworkConnectionNotFirst.NetworkBehaviourClientRpcParamNetworkConnectionNotFirst::ClientRpcCantHaveParamOptional(System.Int32,Mirage.INetworkConnection)");
+            HasError("ClientRpcCantHaveParamOptional has invalid parameter monkeyCon, Cannot pass NetworkConnections", "System.Void NetworkBehaviourTests.NetworkBehaviourClientRpcParamNetworkConnectionNotFirst.NetworkBehaviourClientRpcParamNetworkConnectionNotFirst::ClientRpcCantHaveParamOptional(System.Int32,Mirage.INetworkPlayer)");
         }
 
         [Test]

--- a/Assets/Tests/Weaver/NetworkBehaviourTests~/NetworkBehaviourClientRpcParamNetworkConnection.cs
+++ b/Assets/Tests/Weaver/NetworkBehaviourTests~/NetworkBehaviourClientRpcParamNetworkConnection.cs
@@ -5,6 +5,6 @@ namespace NetworkBehaviourTests.NetworkBehaviourClientRpcParamNetworkConnection
     class NetworkBehaviourClientRpcParamNetworkConnection : NetworkBehaviour
     {
         [ClientRpc(target = Mirage.Client.Connection)]
-        public void RpcCantHaveParamOptional(INetworkConnection monkeyCon) { }
+        public void RpcCantHaveParamOptional(INetworkPlayer monkeyCon) { }
     }
 }

--- a/Assets/Tests/Weaver/NetworkBehaviourTests~/NetworkBehaviourClientRpcParamNetworkConnectionNotFirst.cs
+++ b/Assets/Tests/Weaver/NetworkBehaviourTests~/NetworkBehaviourClientRpcParamNetworkConnectionNotFirst.cs
@@ -5,6 +5,6 @@ namespace NetworkBehaviourTests.NetworkBehaviourClientRpcParamNetworkConnectionN
     class NetworkBehaviourClientRpcParamNetworkConnectionNotFirst : NetworkBehaviour
     {
         [ClientRpc(target = Mirage.Client.Connection)]
-        public void ClientRpcCantHaveParamOptional(int abc, INetworkConnection monkeyCon) { }
+        public void ClientRpcCantHaveParamOptional(int abc, INetworkPlayer monkeyCon) { }
     }
 }

--- a/Assets/Tests/Weaver/ServerRpcTests~/ServerRpcThatIgnoresAuthorityWithSenderConnection.cs
+++ b/Assets/Tests/Weaver/ServerRpcTests~/ServerRpcThatIgnoresAuthorityWithSenderConnection.cs
@@ -5,7 +5,7 @@ namespace ServerRpcTests.ServerRpcThatIgnoresAuthorityWithSenderConnection
     class ServerRpcThatIgnoresAuthorityWithSenderConnection : NetworkBehaviour
     {
         [ServerRpc(requireAuthority = false)]
-        void CmdFunction(INetworkConnection connection = null)
+        void CmdFunction(INetworkPlayer connection = null)
         {
             // do something
         }

--- a/Assets/Tests/Weaver/ServerRpcTests~/ServerRpcWithSenderConnectionAndOtherArgs.cs
+++ b/Assets/Tests/Weaver/ServerRpcTests~/ServerRpcWithSenderConnectionAndOtherArgs.cs
@@ -5,7 +5,7 @@ namespace ServerRpcTests.ServerRpcWithSenderConnectionAndOtherArgs
     class ServerRpcWithSenderConnectionAndOtherArgs : NetworkBehaviour
     {
         [ServerRpc(requireAuthority = false)]
-        void CmdFunction(int someNumber, NetworkIdentity someTarget, INetworkConnection connection = null)
+        void CmdFunction(int someNumber, NetworkIdentity someTarget, INetworkPlayer connection = null)
         {
             // do something
         }

--- a/doc/Articles/General/index.md
+++ b/doc/Articles/General/index.md
@@ -28,7 +28,7 @@ You will also need to create a class that represents a connection by implementin
 
 The message layer is concerned about sending and receiving [messages](../Guides/Communications/NetworkMessages.md)
 
-If you wish to use this funtionality, you will need to have a <xref:Mirage.NetworkClient> in the client and a <xref:Mirage.NetworkServer> for the server. These classes provide events you can subscribe to for the life cycle of connections.  A connection is an implementation of <xref:Mirage.INetworkConnection>, and can send and receive messages. 
+If you wish to use this funtionality, you will need to have a <xref:Mirage.NetworkClient> in the client and a <xref:Mirage.NetworkServer> for the server. These classes provide events you can subscribe to for the life cycle of connections.  A connection is an implementation of <xref:Mirage.INetworkPlayer>, and can send and receive messages. 
 
 ## Object Layer
 

--- a/doc/Articles/Guides/MirrorMigration.md
+++ b/doc/Articles/Guides/MirrorMigration.md
@@ -96,7 +96,7 @@ class MyNetworkManager : NetworkManager {
         // Server started
     }
 
-    void OnServerConnect(INetworkConnection conn) {
+    void OnServerConnect(INetworkPlayer conn) {
         // Client connected (and authenticated) on server
     }
 
@@ -104,7 +104,7 @@ class MyNetworkManager : NetworkManager {
         // Server stopped
     }
 
-    void OnClinetConnect(INetworkConnection conn) {
+    void OnClinetConnect(INetworkPlayer conn) {
         // Client connected
     }
 
@@ -182,7 +182,7 @@ These fields/properties have been renamed:
 | Mirror                                | Mirage                                                                                 |
 |:-------------------------------------:|:--------------------------------------------------------------------------------------:|
 | `ClientScene.localPlayer`             | [ClientObjectManager.LocalPlayer](xref:Mirage.ClientObjectManager.LocalPlayer)         |
-| `ClientScene.ready`                   | [NetworkClient.Connection.IsReady](xref:Mirage.NetworkConnection.IsReady)              |
+| `ClientScene.ready`                   | [NetworkClient.Connection.IsReady](xref:Mirage.NetworkPlayer.IsReady)              |
 | `NetworkIdentity.assetId`             | [NetworkIdentity.AssetId](xref:Mirage.NetworkIdentity.AssetId)                         |
 | `NetworkIdentity.netId`               | [NetworkIdentity.NetId](xref:Mirage.NetworkIdentity.NetId)                             |
 | `NetworkIdentity.connectionToClient`  | [NetworkIdentity.ConnectionToClient](xref:Mirage.NetworkIdentity.ConnectionToClient)   |
@@ -194,8 +194,8 @@ These fields/properties have been renamed:
 | `NetworkBehaviour.netId`              | [NetworkBehaviour.NetId](xref:Mirage.NetworkBehaviour.NetId)                           |
 | `NetworkBehaviour.isClientOnly`       | [NetworkBehaviour.IsClientOnly](xref:Mirage.NetworkBehaviour.IsClientOnly)             |
 | `NetworkBehaviour.islocalPlayer`      | [NetworkBehaviour.IsLocalPlayer](xref:Mirage.NetworkBehaviour.IsLocalPlayer)           |
-| `NetworkConnection.isReady`           | [NetworkConnection.IsReady](xref:Mirage.NetworkConnection.IsReady)                     |
-| `NetworkConnection.identity`          | [NetworkConnection.Identity](xref:Mirage.NetworkConnection.Identity)                   |
+| `NetworkConnection.isReady`           | [NetworkPlayer.IsReady](xref:Mirage.NetworkPlayer.IsReady)                     |
+| `NetworkConnection.identity`          | [NetworkPlayer.Identity](xref:Mirage.NetworkPlayer.Identity)                   |
 | `NetworkServer.active`                | [NetworkServer.Active](xref:Mirage.NetworkServer.Active)                               |
 | `NetworkServer.localConnection`       | [NetworkServer.LocalConnection](xref:Mirage.NetworkServer.LocalConnection)             |
 | `NetworkClient.connection`            | [NetworkClient.Connection](xref:Mirage.NetworkClient.Connection)                       |


### PR DESCRIPTION
part of Transport rewrite https://github.com/MirageNet/Mirage/pull/679

BREAKING CHANGE: renaming NetworkConnection to NetworkPlayer