### PR TITLE
refactor: removing disconnect method from player

### DIFF
--- a/Assets/Mirage/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/BasicAuthenticator.cs
@@ -83,7 +83,7 @@ namespace Mirage.Authenticators
         public IEnumerator DelayedDisconnect(INetworkPlayer conn, float waitTime)
         {
             yield return new WaitForSeconds(waitTime);
-            conn.Disconnect();
+            conn.Connection?.Disconnect();
         }
 
         public void OnAuthResponseMessage(INetworkPlayer conn, AuthResponseMessage msg)
@@ -99,7 +99,7 @@ namespace Mirage.Authenticators
             {
                 logger.LogFormat(LogType.Error, "Authentication Response: {0}", msg.Message);
                 // disconnect the client
-                conn.Disconnect();
+                conn.Connection?.Disconnect();
             }
         }
     }

--- a/Assets/Mirage/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/TimeoutAuthenticator.cs
@@ -66,7 +66,7 @@ namespace Mirage.Authenticators
                 if (logger.LogEnabled()) logger.Log($"Authentication Timeout {conn}");
 
                 pendingAuthentication.Remove(conn);
-                conn.Disconnect();
+                conn.Connection?.Disconnect();
             }
         }
     }

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -104,8 +104,6 @@ namespace Mirage
         EndPoint Address { get; }
         object AuthenticationData { get; set; }
 
-        void Disconnect();
-
         IConnection Connection { get; }
     }
 }

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -241,7 +241,7 @@ namespace Mirage
         /// </summary>
         public void Disconnect()
         {
-            Connection?.Disconnect();
+            Connection?.Connection?.Disconnect();
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -95,13 +95,6 @@ namespace Mirage
             RegisterHandler<NotifyAck>(msg => { });
         }
 
-        /// <summary>
-        /// Disconnects this connection.
-        /// </summary>
-        public virtual void Disconnect()
-        {
-            connection.Disconnect();
-        }
 
         private static NetworkMessageDelegate MessageHandler<T>(Action<INetworkPlayer, T> handler)
         {

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -302,7 +302,7 @@ namespace Mirage
                 catch (Exception ex)
                 {
                     logger.LogError("Closed connection: " + this + ". Invalid message " + ex);
-                    Disconnect();
+                    Connection?.Disconnect();
                 }
             }
         }
@@ -425,7 +425,7 @@ namespace Mirage
             // sequence is so far out of bounds we can't save, just kick him (or her!)
             if (Math.Abs(sequenceDistance) > WINDOW_SIZE)
             {
-                Disconnect();
+                connection?.Disconnect();
                 return;
             }
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -148,7 +148,7 @@ namespace Mirage
             var connectionscopy = new HashSet<INetworkPlayer>(connections);
             foreach (INetworkPlayer conn in connectionscopy)
             {
-                conn.Disconnect();
+                conn.Connection?.Disconnect();
             }
             if (Transport != null)
                 Transport.Disconnect();
@@ -375,7 +375,7 @@ namespace Mirage
             //  Transport can't do that)
             if (connections.Count >= MaxConnections)
             {
-                conn.Disconnect();
+                conn.Connection?.Disconnect();
                 if (logger.WarnEnabled()) logger.LogWarning("Server full, kicked client:" + conn);
                 return;
             }


### PR DESCRIPTION
- disconnect just passthrough to connection.
- new concept: players can no longer be disconnected, but their connection can be

requires: 
- [x] https://github.com/MirageNet/Mirage/pull/687

BREAKING CHANGE: Disconnect replaced with Connection.Disconnect