### PR TITLE
fix: compression of 90 degrees angle

### DIFF
--- a/Assets/Mirage/Runtime/Compression.cs
+++ b/Assets/Mirage/Runtime/Compression.cs
@@ -20,12 +20,19 @@ namespace Mirage
         private const float Minimum = -1.0f / 1.414214f; // note: 1.0f / sqrt(2)
         private const float Maximum = +1.0f / 1.414214f;
 
+        private const int BIT_PER_AXIS = 10;
+        private const int COMP_SHIFT = BIT_PER_AXIS * 3;
+        private const int A_SHIFT = BIT_PER_AXIS * 2;
+        private const int B_SHIFT = BIT_PER_AXIS * 1;
+        private const int MAX_NUMBER = (1 << BIT_PER_AXIS) - 1;
+        private const float MAX_NUMBER_INVERSE = 1f / MAX_NUMBER;
+
         internal static uint Compress(Quaternion quaternion)
         {
-            float absX = Mathf.Abs(quaternion.x),
-                      absY = Mathf.Abs(quaternion.y),
-                      absZ = Mathf.Abs(quaternion.z),
-                      absW = Mathf.Abs(quaternion.w);
+            float absX = Mathf.Abs(quaternion.x);
+            float absY = Mathf.Abs(quaternion.y);
+            float absZ = Mathf.Abs(quaternion.z);
+            float absW = Mathf.Abs(quaternion.w);
 
             ComponentType largestComponent = ComponentType.X;
             float largestAbs = absX;
@@ -87,23 +94,23 @@ namespace Mirage
                 normalizedB = (b - Minimum) / (Maximum - Minimum),
                 normalizedC = (c - Minimum) / (Maximum - Minimum);
 
-            uint integerA = (uint)Mathf.RoundToInt(normalizedA * 1024.0f),
-                integerB = (uint)Mathf.RoundToInt(normalizedB * 1024.0f),
-                integerC = (uint)Mathf.RoundToInt(normalizedC * 1024.0f);
+            uint integerA = (uint)Mathf.RoundToInt(normalizedA * MAX_NUMBER);
+            uint integerB = (uint)Mathf.RoundToInt(normalizedB * MAX_NUMBER);
+            uint integerC = (uint)Mathf.RoundToInt(normalizedC * MAX_NUMBER);
 
-            return (((uint)largestComponent) << 30) | (integerA << 20) | (integerB << 10) | integerC;
+            return (((uint)largestComponent) << COMP_SHIFT) | (integerA << A_SHIFT) | (integerB << B_SHIFT) | integerC;
         }
 
         internal static Quaternion Decompress(uint compressed)
         {
-            var largestComponentType = (ComponentType)(compressed >> 30);
-            uint integerA = (compressed >> 20) & ((1 << 10) - 1),
-                integerB = (compressed >> 10) & ((1 << 10) - 1),
-                integerC = compressed & ((1 << 10) - 1);
+            var largestComponentType = (ComponentType)(compressed >> COMP_SHIFT);
+            uint integerA = (compressed >> A_SHIFT) & MAX_NUMBER;
+            uint integerB = (compressed >> B_SHIFT) & MAX_NUMBER;
+            uint integerC = compressed & MAX_NUMBER;
 
-            float a = integerA / 1024.0f * (Maximum - Minimum) + Minimum,
-                b = integerB / 1024.0f * (Maximum - Minimum) + Minimum,
-                c = integerC / 1024.0f * (Maximum - Minimum) + Minimum;
+            float a = integerA * MAX_NUMBER_INVERSE * (Maximum - Minimum) + Minimum;
+            float b = integerB * MAX_NUMBER_INVERSE * (Maximum - Minimum) + Minimum;
+            float c = integerC * MAX_NUMBER_INVERSE * (Maximum - Minimum) + Minimum;
 
             Quaternion rotation;
             switch (largestComponentType)

--- a/Assets/Tests/Editor/Compression.cs
+++ b/Assets/Tests/Editor/Compression.cs
@@ -19,5 +19,16 @@ namespace Mirage
             // decompressed should be almost the same
             Assert.That(Mathf.Abs(Quaternion.Dot(expected, decompressed)), Is.GreaterThan(1 - 0.001));
         }
+
+        [Test]
+        public void Compress90Degrees()
+        {
+            uint compressed = Compression.Compress(Quaternion.Euler(0,90,0));
+
+            Quaternion decompressed = Compression.Decompress(compressed);
+
+            Vector3 euler = decompressed.eulerAngles;
+            Assert.That(euler.y, Is.EqualTo(90).Within(0.1));
+        }
     }
 }


### PR DESCRIPTION
compressing (0,90, 0) and decompressing it gave (0,-90,0) because the encoding overflowed that the 10 bit space.

Tx to Punfish who reported it.