### PR TITLE
refactor: removing address property from player

### DIFF
--- a/Assets/Mirage/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirage/Editor/NetworkInformationPreview.cs
@@ -184,7 +184,7 @@ namespace Mirage
                 foreach (INetworkPlayer conn in identity.observers)
                 {
 
-                    GUI.Label(observerRect, conn.Address + ":" + conn, styles.ComponentName);
+                    GUI.Label(observerRect, conn.Connection.GetEndPointAddress() + ":" + conn, styles.ComponentName);
                     observerRect.y += observerRect.height;
                     Y = observerRect.y;
                 }

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using Cysharp.Threading.Tasks;
 
 namespace Mirage
@@ -101,7 +100,6 @@ namespace Mirage
     public interface INetworkPlayer : IMessageHandler, IVisibilityTracker, IObjectOwner
     {
         bool IsReady { get; set; }
-        EndPoint Address { get; }
         object AuthenticationData { get; set; }
 
         IConnection Connection { get; }

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -941,7 +941,7 @@ namespace Mirage
                 return;
             }
 
-            if (logger.LogEnabled()) logger.Log("Added observer " + conn.Address + " added for " + gameObject);
+            if (logger.LogEnabled()) logger.Log("Added observer " + conn.Connection.GetEndPointAddress() + " added for " + gameObject);
             observers.Add(conn);
             conn.AddToVisList(this);
 


### PR DESCRIPTION
- address just passthrough to connection.
- new concept: players can no longer has an address, but their connection does

requires: 
- [x] https://github.com/MirageNet/Mirage/pull/687

BREAKING CHANGE: Address replaced with Connection.GetEndPointAddress