### PR TITLE
feat: 0 is not lossy when compressing quaternions

### DIFF
--- a/Assets/Mirage/Runtime/Compression.cs
+++ b/Assets/Mirage/Runtime/Compression.cs
@@ -17,7 +17,7 @@ namespace Mirage
     /// </summary>
     public static class Compression
     {
-        private const float Minimum = -1.0f / 1.414214f; // note: 1.0f / sqrt(2)
+        // note: 1.0f / sqrt(2)
         private const float Maximum = +1.0f / 1.414214f;
 
         private const int BitsPerAxis = 10;

--- a/Assets/Tests/Editor/Compression.cs
+++ b/Assets/Tests/Editor/Compression.cs
@@ -29,7 +29,9 @@ namespace Mirage
             Quaternion decompressed = Compression.Decompress(compressed);
 
             Vector3 euler = decompressed.eulerAngles;
+            Assert.That(euler.x, Is.Zero);
             Assert.That(euler.y, Is.EqualTo(90).Within(0.1));
+            Assert.That(euler.z, Is.Zero);
         }
 
         [Test]
@@ -49,5 +51,6 @@ namespace Mirage
             Assert.That(Mathf.Abs(Quaternion.Dot(expected, decompressed)), Is.EqualTo(1).Within(0.001));
 
         }
+
     }
 }


### PR DESCRIPTION
if you compress a quaternion with zeroes,  for example, Quaternion.Euler(0,90,0),  then zeros are decompressed as zero instead of an approximation