### PR TITLE
refactor: move MirageInvokeType out of UNetwork

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -558,7 +558,7 @@ namespace Mirage
 
             Skeleton skeleton = RemoteCallHelper.GetSkeleton(msg.functionHash);
 
-            if (skeleton.invokeType != MirageInvokeType.ClientRpc)
+            if (skeleton.invokeType != RpcInvokeType.ClientRpc)
             {
                 throw new MethodInvocationException($"Invalid RPC call with id {msg.functionHash}");
             }

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -421,7 +421,7 @@ namespace Mirage
             }
             Skeleton skeleton = RemoteCallHelper.GetSkeleton(msg.functionHash);
 
-            if (skeleton.invokeType != MirageInvokeType.ServerRpc)
+            if (skeleton.invokeType != RpcInvokeType.ServerRpc)
             {
                 throw new MethodInvocationException($"Invalid ServerRpc for id {msg.functionHash}");
             }

--- a/Assets/Mirage/Runtime/UNetwork.cs
+++ b/Assets/Mirage/Runtime/UNetwork.cs
@@ -2,13 +2,6 @@ using System.Runtime.InteropServices;
 
 namespace Mirage
 {
-    // invoke type for Rpc
-    public enum MirageInvokeType
-    {
-        ServerRpc,
-        ClientRpc
-    }
-
     public static class Version
     {
         public static readonly string Current = typeof(NetworkIdentity).Assembly.GetName().Version.ToString();


### PR DESCRIPTION
Move this enum to RemoteCalls helper and renamed to RpcInvokeType