### PR TITLE
refactor: removing connection to server

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -577,7 +577,6 @@ namespace Mirage
             if (identity && identity == LocalPlayer)
             {
                 // Set isLocalPlayer to true on this NetworkIdentity and trigger OnStartLocalPlayer in all scripts on the same GO
-                identity.ConnectionToServer = Client.Player;
                 identity.StartLocalPlayer();
 
                 if (logger.LogEnabled()) logger.Log("ClientScene.OnOwnerMessage - player=" + identity.name);

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using Mirage.Collections;
-using Mirage.RemoteCalls;
-using UnityEngine;
 using Mirage.Logging;
+using Mirage.RemoteCalls;
 using Mirage.Serialization;
+using UnityEngine;
 
 namespace Mirage
 {
@@ -108,11 +108,6 @@ namespace Mirage
         /// Quick Reference to the NetworkIdentities ClientObjectManager. Present only for instances instances.
         /// </summary>
         public ClientObjectManager ClientObjectManager => NetIdentity.ClientObjectManager;
-
-        /// <summary>
-        /// The <see cref="NetworkPlayer">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the client.
-        /// </summary>
-        public INetworkPlayer ConnectionToServer => NetIdentity.ConnectionToServer;
 
         /// <summary>
         /// The <see cref="NetworkPlayer">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the server.
@@ -263,7 +258,7 @@ namespace Mirage
 
             if (Client.Player == null)
             {
-                throw new InvalidOperationException("Send ServerRpc attempted with no client running [client=" + ConnectionToServer + "].");
+                throw new InvalidOperationException("Send ServerRpc attempted with no client connection.");
             }
         }
 

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -173,11 +173,6 @@ namespace Mirage
         public ServerObjectManager ServerObjectManager;
 
         /// <summary>
-        /// The NetworkConnection associated with this NetworkIdentity. This is only valid for player objects on a local client.
-        /// </summary>
-        public INetworkPlayer ConnectionToServer { get; internal set; }
-
-        /// <summary>
         /// The NetworkClient associated with this NetworkIdentity.
         /// </summary>
         public NetworkClient Client { get; internal set; }

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -1156,7 +1156,6 @@ namespace Mirage
             Client = null;
             ServerObjectManager = null;
             ClientObjectManager = null;
-            ConnectionToServer = null;
             ConnectionToClient = null;
             networkBehavioursCache = null;
 

--- a/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
@@ -68,8 +68,11 @@ namespace Mirage.Weaver
 
             if (hasNetworkConnection)
             {
-                // todo re-add connection/player argument for RPC with targets (currently is just null)
-                worker.Append(worker.Create(OpCodes.Ldnull));
+               // this is called in the skeleton (the client)
+               // the client should just get the connection to the server and pass that in
+                worker.Append(worker.Create(OpCodes.Ldarg_0));
+                worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.Client));
+                worker.Append(worker.Create(OpCodes.Call, (NetworkClient nb) => nb.Player));
             }
 
             if (!ReadArguments(md, worker, hasNetworkConnection))

--- a/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
@@ -66,13 +66,11 @@ namespace Mirage.Weaver
             Client target = clientRpcAttr.GetField("target", Client.Observers);
             bool hasNetworkConnection = target == Client.Connection && HasNetworkConnectionParameter(md);
 
-            // todo re-add connection/player argument for RPC with targets
-            //if (hasNetworkConnection)
-            //{
-            //    //client.connection
-            //    worker.Append(worker.Create(OpCodes.Ldarg_0));
-            //    worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.ConnectionToServer));
-            //}
+            if (hasNetworkConnection)
+            {
+                // todo re-add connection/player argument for RPC with targets (currently is just null)
+                worker.Append(worker.Create(OpCodes.Ldnull));
+            }
 
             if (!ReadArguments(md, worker, hasNetworkConnection))
                 return rpc;

--- a/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
@@ -66,12 +66,13 @@ namespace Mirage.Weaver
             Client target = clientRpcAttr.GetField("target", Client.Observers);
             bool hasNetworkConnection = target == Client.Connection && HasNetworkConnectionParameter(md);
 
-            if (hasNetworkConnection)
-            {
-                //client.connection
-                worker.Append(worker.Create(OpCodes.Ldarg_0));
-                worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.ConnectionToServer));
-            }
+            // todo re-add connection/player argument for RPC with targets
+            //if (hasNetworkConnection)
+            //{
+            //    //client.connection
+            //    worker.Append(worker.Create(OpCodes.Ldarg_0));
+            //    worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.ConnectionToServer));
+            //}
 
             if (!ReadArguments(md, worker, hasNetworkConnection))
                 return rpc;

--- a/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
@@ -704,14 +704,12 @@ namespace Mirage
             // creates .observers and generates a netId
             identity.StartServer();
             identity.ConnectionToClient = new NetworkPlayer(tconn42);
-            identity.ConnectionToServer = new NetworkPlayer(tconn43);
             identity.observers.Add(new NetworkPlayer(tconn42));
 
             // mark for reset and reset
             identity.Reset();
             Assert.That(identity.NetId, Is.EqualTo(0));
             Assert.That(identity.ConnectionToClient, Is.Null);
-            Assert.That(identity.ConnectionToServer, Is.Null);
         }
 
         [Test]

--- a/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
@@ -70,7 +70,7 @@ namespace Mirage.Tests.ClientServer
             // process spawn message from server
             await AsyncUtil.WaitUntilWithTimeout(() => clientComponent.targetRpcArg1 != 0);
 
-            Assert.That(clientComponent.targetRpcPlayer, Is.Null, "target Rpc currently has null on client");
+            Assert.That(clientComponent.targetRpcPlayer, Is.EqualTo(connectionToServer));
             Assert.That(clientComponent.targetRpcArg1, Is.EqualTo(1));
             Assert.That(clientComponent.targetRpcArg2, Is.EqualTo("hello"));
         });

--- a/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
@@ -70,7 +70,7 @@ namespace Mirage.Tests.ClientServer
             // process spawn message from server
             await AsyncUtil.WaitUntilWithTimeout(() => clientComponent.targetRpcArg1 != 0);
 
-            Assert.That(clientComponent.targetRpcPlayer, Is.SameAs(connectionToServer));
+            Assert.That(clientComponent.targetRpcPlayer, Is.Null, "target Rpc currently has null on client");
             Assert.That(clientComponent.targetRpcArg1, Is.EqualTo(1));
             Assert.That(clientComponent.targetRpcArg2, Is.EqualTo("hello"));
         });

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -70,7 +70,7 @@ namespace Mirage.Tests.Host
             // process spawn message from server
             await AsyncUtil.WaitUntilWithTimeout(() => component.targetRpcArg1 != 0);
 
-            Assert.That(component.targetRpcPlayer, Is.Null, "target Rpc currently has null on client");
+            Assert.That(component.targetRpcPlayer, Is.EqualTo(manager.Client.Player));
             Assert.That(component.targetRpcArg1, Is.EqualTo(1));
             Assert.That(component.targetRpcArg2, Is.EqualTo("hello"));
         });

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -70,7 +70,7 @@ namespace Mirage.Tests.Host
             // process spawn message from server
             await AsyncUtil.WaitUntilWithTimeout(() => component.targetRpcArg1 != 0);
 
-            Assert.That(component.targetRpcPlayer, Is.SameAs(manager.Client.Player));
+            Assert.That(component.targetRpcPlayer, Is.Null, "target Rpc currently has null on client");
             Assert.That(component.targetRpcArg1, Is.EqualTo(1));
             Assert.That(component.targetRpcArg2, Is.EqualTo("hello"));
         });

--- a/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
@@ -107,13 +107,6 @@ namespace Mirage.Tests.Host
         }
 
         [Test]
-        public void HasIdentitysConnectionToServer()
-        {
-            (identity.ConnectionToServer, _) = PipedConnections();
-            Assert.That(component.ConnectionToServer, Is.EqualTo(identity.ConnectionToServer));
-        }
-
-        [Test]
         public void HasIdentitysConnectionToClient()
         {
             (_, identity.ConnectionToClient) = PipedConnections();

--- a/doc/Articles/Guides/MirrorMigration.md
+++ b/doc/Articles/Guides/MirrorMigration.md
@@ -182,23 +182,23 @@ These fields/properties have been renamed:
 | Mirror                                | Mirage                                                                                 |
 |:-------------------------------------:|:--------------------------------------------------------------------------------------:|
 | `ClientScene.localPlayer`             | [ClientObjectManager.LocalPlayer](xref:Mirage.ClientObjectManager.LocalPlayer)         |
-| `ClientScene.ready`                   | [NetworkClient.Connection.IsReady](xref:Mirage.NetworkPlayer.IsReady)              |
+| `ClientScene.ready`                   | [NetworkClient.Connection.IsReady](xref:Mirage.NetworkPlayer.IsReady)                  |
 | `NetworkIdentity.assetId`             | [NetworkIdentity.AssetId](xref:Mirage.NetworkIdentity.AssetId)                         |
 | `NetworkIdentity.netId`               | [NetworkIdentity.NetId](xref:Mirage.NetworkIdentity.NetId)                             |
 | `NetworkIdentity.connectionToClient`  | [NetworkIdentity.ConnectionToClient](xref:Mirage.NetworkIdentity.ConnectionToClient)   |
 | `NetworkBehaviour.isServer`           | [NetworkBehaviour.IsServer](xref:Mirage.NetworkBehaviour.IsServer)                     |
 | `NetworkBehaviour.connectionToClient` | [NetworkBehaviour.ConnectionToClient](xref:Mirage.NetworkBehaviour.ConnectionToClient) |
-| `NetworkBehaviour.connectionToServer` | [NetworkBehaviour.ConnectionToServer](xref:Mirage.NetworkBehaviour.ConnectionToServer) |
+| `NetworkBehaviour.connectionToServer` | Removed, use [Client.Player](xref:Mirage.NetworkClient.Player) instead                 |
 | `NetworkBehaviour.hasAuthority`       | [NetworkBehaviour.HasAuthority](xref:Mirage.NetworkBehaviour.HasAuthority)             |
 | `NetworkBehaviour.netIdentity`        | [NetworkBehaviour.NetIdentity](xref:Mirage.NetworkBehaviour.NetIdentity)               |
 | `NetworkBehaviour.netId`              | [NetworkBehaviour.NetId](xref:Mirage.NetworkBehaviour.NetId)                           |
 | `NetworkBehaviour.isClientOnly`       | [NetworkBehaviour.IsClientOnly](xref:Mirage.NetworkBehaviour.IsClientOnly)             |
 | `NetworkBehaviour.islocalPlayer`      | [NetworkBehaviour.IsLocalPlayer](xref:Mirage.NetworkBehaviour.IsLocalPlayer)           |
-| `NetworkConnection.isReady`           | [NetworkPlayer.IsReady](xref:Mirage.NetworkPlayer.IsReady)                     |
-| `NetworkConnection.identity`          | [NetworkPlayer.Identity](xref:Mirage.NetworkPlayer.Identity)                   |
+| `NetworkConnection.isReady`           | [NetworkPlayer.IsReady](xref:Mirage.NetworkPlayer.IsReady)                             |
+| `NetworkConnection.identity`          | [NetworkPlayer.Identity](xref:Mirage.NetworkPlayer.Identity)                           |
 | `NetworkServer.active`                | [NetworkServer.Active](xref:Mirage.NetworkServer.Active)                               |
-| `NetworkServer.localConnection`       | [NetworkServer.LocalPlayer](xref:Mirage.NetworkServer.LocalPlayer)             |
-| `NetworkClient.connection`            | [NetworkClient.Player](xref:Mirage.NetworkClient.Player)                       |
+| `NetworkServer.localConnection`       | [NetworkServer.LocalPlayer](xref:Mirage.NetworkServer.LocalPlayer)                     |
+| `NetworkClient.connection`            | [NetworkClient.Player](xref:Mirage.NetworkClient.Player)                               |
 | `NetworkTime.time`                    | [NetworkTime.Time](xref:Mirage.NetworkTime.Time)                                       |
 
 ## Object Management


### PR DESCRIPTION
this property is only used to send message to the server, there are alternative ways to send message to the server

todo
- [x] replace uses (to fix compile errors)
- [x] fix test for value

BREAKING CHANGE: Removed ConnectionToServer property