### PR TITLE
perf: serverrpc bypasses network on host mode

### DIFF
--- a/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
@@ -376,12 +376,12 @@ namespace Mirage.Weaver
         }
 
 
-        public void IfLocalClient(ILProcessor worker, Action body)
+        public void IsServer(ILProcessor worker, Action body)
         {
             // if (IsLocalClient) {
             Instruction endif = worker.Create(OpCodes.Nop);
             worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsLocalClient));
+            worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsServer));
             worker.Append(worker.Create(OpCodes.Brfalse, endif));
 
             body();

--- a/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 using Cysharp.Threading.Tasks;
@@ -372,6 +373,31 @@ namespace Mirage.Weaver
                 calledMethod = null;
                 return false;
             }
+        }
+
+
+        public void IfLocalClient(ILProcessor worker, Action body)
+        {
+            // if (IsLocalClient) {
+            Instruction endif = worker.Create(OpCodes.Nop);
+            worker.Append(worker.Create(OpCodes.Ldarg_0));
+            worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsLocalClient));
+            worker.Append(worker.Create(OpCodes.Brfalse, endif));
+
+            body();
+
+            // }
+            worker.Append(endif);
+
+        }
+
+        protected void InvokeBody(ILProcessor worker, MethodDefinition rpc)
+        {
+            for (int i = 0; i < rpc.Parameters.Count; i++)
+            {
+                worker.Append(worker.Create(OpCodes.Ldarg, i));
+            }
+            worker.Append(worker.Create(OpCodes.Callvirt, rpc));
         }
 
     }

--- a/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/RpcProcessor.cs
@@ -375,29 +375,13 @@ namespace Mirage.Weaver
             }
         }
 
-
-        public void IsServer(ILProcessor worker, Action body)
-        {
-            // if (IsLocalClient) {
-            Instruction endif = worker.Create(OpCodes.Nop);
-            worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsServer));
-            worker.Append(worker.Create(OpCodes.Brfalse, endif));
-
-            body();
-
-            // }
-            worker.Append(endif);
-
-        }
-
         protected void InvokeBody(ILProcessor worker, MethodDefinition rpc)
         {
-            for (int i = 0; i < rpc.Parameters.Count; i++)
+            for (int i = 0; i <= rpc.Parameters.Count; i++)
             {
                 worker.Append(worker.Create(OpCodes.Ldarg, i));
             }
-            worker.Append(worker.Create(OpCodes.Callvirt, rpc));
+            worker.Append(worker.Create(OpCodes.Call, rpc));
         }
 
     }

--- a/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
@@ -62,7 +62,7 @@ namespace Mirage.Weaver
 
             ILProcessor worker = md.Body.GetILProcessor();
 
-            // if (IsLocalClient)
+            // if (IsServer)
             // {
             //    call the body
             //    return;
@@ -108,7 +108,7 @@ namespace Mirage.Weaver
 
         private void CallBody(ILProcessor worker, MethodDefinition rpc)
         {
-            IfLocalClient(worker, () =>
+            IsServer(worker, () =>
             {
                 InvokeBody(worker, rpc);
                 worker.Append(worker.Create(OpCodes.Ret));

--- a/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
@@ -106,6 +106,21 @@ namespace Mirage.Weaver
             return cmd;
         }
 
+        public void IsServer(ILProcessor worker, Action body)
+        {
+            // if (IsLocalClient) {
+            Instruction endif = worker.Create(OpCodes.Nop);
+            worker.Append(worker.Create(OpCodes.Ldarg_0));
+            worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsServer));
+            worker.Append(worker.Create(OpCodes.Brfalse, endif));
+
+            body();
+
+            // }
+            worker.Append(endif);
+
+        }
+
         private void CallBody(ILProcessor worker, MethodDefinition rpc)
         {
             IsServer(worker, () =>

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -11,26 +11,6 @@ namespace Mirage.Tests.Host
 {
     public class HostComponentTests : HostSetup<MockComponent>
     {
-        [Test]
-        public void ServerRpcWithoutAuthority()
-        {
-            var gameObject2 = new GameObject("rpcObject", typeof(NetworkIdentity), typeof(MockComponent));
-            MockComponent rpcComponent2 = gameObject2.GetComponent<MockComponent>();
-
-            // spawn it without client authority
-            serverObjectManager.Spawn(gameObject2);
-
-            // process spawn message from server
-            client.Update();
-
-            // only authorized clients can call ServerRpc
-            Assert.Throws<UnauthorizedAccessException>(() =>
-           {
-               rpcComponent2.Test(1, "hello");
-           });
-
-        }
-
         [UnityTest]
         public IEnumerator ServerRpc() => UniTask.ToCoroutine(async () =>
         {


### PR DESCRIPTION
When calling a server rpc on server mode (whether host or not),  there is no need to go through the network.  Simply invoke the user code.

This changes behaviour a little.  When you call a ServerRpc,  it now executes immediately.  Before,  it executed on the next frame. 

This also allows the ServerRpc to be invoked from the server

BREAKING CHANGE: ServerRpc execute synchronous in host mode