### PR TITLE
fix: netId are now ok to wrap

### DIFF
--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -47,7 +47,7 @@ namespace Mirage
         uint nextNetworkId = 1;
         uint GetNextNetworkId() 
         {
-            while (SpawnedObjects.HasKey(nextNetworkId))
+            while (SpawnedObjects.HasKey(nextNetworkId) || nextNetworkId == 0)
                 nextNetworkId++;
             return nextNetworkId++;
         }

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -47,7 +47,7 @@ namespace Mirage
         uint nextNetworkId = 1;
         uint GetNextNetworkId() 
         {
-            while (SpawnedObjects.HasKey(nextNetworkId) || nextNetworkId == 0)
+            while (SpawnedObjects.ContainsKey(nextNetworkId) || nextNetworkId == 0)
                 nextNetworkId++;
             return nextNetworkId++;
         }

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -45,7 +45,12 @@ namespace Mirage
         public SpawnEvent UnSpawned => _unSpawned;
 
         uint nextNetworkId = 1;
-        uint GetNextNetworkId() => nextNetworkId++;
+        uint GetNextNetworkId() 
+        {
+            while (SpawnedObjects.HasKey(nextNetworkId))
+                nextNetworkId++;
+            return nextNetworkId++;
+        }
 
         public readonly Dictionary<uint, NetworkIdentity> SpawnedObjects = new Dictionary<uint, NetworkIdentity>();
 


### PR DESCRIPTION
A long-running server may end up wrapping the net id.