### PR TITLE
perf: clientrpc in host mode bypasses network

### DIFF
--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -321,7 +321,7 @@ namespace Mirage
             // The public facing parameter is excludeOwner in [ClientRpc]
             // so we negate it here to logically align with SendToReady.
             bool includeOwner = !excludeOwner;
-            NetIdentity.SendToObservers(message, includeOwner, channelId);
+            NetIdentity.SendToRemoteObservers(message, includeOwner, channelId);
         }
 
         protected internal void SendTargetRpcInternal(INetworkPlayer player, Type invokeClass, string rpcName, NetworkWriter writer, int channelId)

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -631,7 +631,7 @@ namespace Mirage
             SpawnedObjects.Remove(identity.NetId);
             identity.ConnectionToClient?.RemoveOwnedObject(identity);
 
-            identity.SendToObservers(new ObjectDestroyMessage { netId = identity.NetId });
+            identity.SendToRemoteObservers(new ObjectDestroyMessage { netId = identity.NetId });
 
             identity.ClearObservers();
             if (Server.LocalClientActive)

--- a/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
@@ -108,7 +108,7 @@ namespace Mirage.Weaver
 
         public void IsServer(ILProcessor worker, Action body)
         {
-            // if (IsLocalClient) {
+            // if (IsServer) {
             Instruction endif = worker.Create(OpCodes.Nop);
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsServer));


### PR DESCRIPTION
client rpcs just bypass the network and get called immediately in host mode

this is the 10K example before in host mode:
<img width="883" alt="Screen Shot 2021-03-19 at 5 21 57 PM" src="https://user-images.githubusercontent.com/466007/111847839-b3c04300-88d7-11eb-8d6a-ff0773d09b06.png">

This is the 10K example after in host mode:
<img width="883" alt="Screen Shot 2021-03-19 at 5 19 40 PM" src="https://user-images.githubusercontent.com/466007/111847874-c9356d00-88d7-11eb-9b39-ab1d76947625.png">



BREAKING CHANGE: ClientRpc get called synchronously in host mode