### PR TITLE
refactor: creating network world that will have the list of spawned objects

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -13,7 +13,7 @@ namespace Mirage
 
     [AddComponentMenu("Network/ClientObjectManager")]
     [DisallowMultipleComponent]
-    public class ClientObjectManager : MonoBehaviour, IClientObjectManager, IObjectLocator
+    public class ClientObjectManager : MonoBehaviour, IClientObjectManager
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(ClientObjectManager));
 
@@ -25,21 +25,6 @@ namespace Mirage
         // spawn handlers. internal for testing purposes. do not use directly.
         internal readonly Dictionary<Guid, SpawnHandlerDelegate> spawnHandlers = new Dictionary<Guid, SpawnHandlerDelegate>();
         internal readonly Dictionary<Guid, UnSpawnDelegate> unspawnHandlers = new Dictionary<Guid, UnSpawnDelegate>();
-
-        [Header("Events")]
-        /// <summary>
-        /// Raised when the client spawns an object
-        /// </summary>
-        [FormerlySerializedAs("Spawned")]
-        [SerializeField] SpawnEvent _spawned = new SpawnEvent();
-        public SpawnEvent Spawned => _spawned;
-
-        /// <summary>
-        /// Raised when the client unspawns an object
-        /// </summary>
-        [FormerlySerializedAs("UnSpawned")]
-        [SerializeField] SpawnEvent _unSpawned = new SpawnEvent();
-        public SpawnEvent UnSpawned => _unSpawned;
 
         /// <summary>
         /// NetworkIdentity of the localPlayer
@@ -65,23 +50,6 @@ namespace Mirage
         /// </summary>
         public readonly Dictionary<ulong, NetworkIdentity> spawnableObjects = new Dictionary<ulong, NetworkIdentity>();
 
-        /// <summary>
-        /// List of all objects spawned in this client
-        /// </summary>
-        public Dictionary<uint, NetworkIdentity> SpawnedObjects
-        {
-            get
-            {
-                // if we are in host mode,  the list of spawned object is the same as the server list
-                if (Client.IsLocalClient)
-                    return ServerObjectManager.SpawnedObjects;
-                else
-                    return spawnedObjects;
-            }
-        }
-
-        internal readonly Dictionary<uint, NetworkIdentity> spawnedObjects = new Dictionary<uint, NetworkIdentity>();
-
         internal ServerObjectManager ServerObjectManager;
 
         SyncVarReceiver syncVarReceiver;
@@ -100,7 +68,7 @@ namespace Mirage
 
         void OnClientConnected(INetworkPlayer player)
         {
-            syncVarReceiver = new SyncVarReceiver(Client, this);
+            syncVarReceiver = new SyncVarReceiver(Client, Client.World);
             RegisterSpawnPrefabs();
 
             if (Client.IsLocalClient)
@@ -317,8 +285,6 @@ namespace Mirage
 
         void UnSpawn(NetworkIdentity identity)
         {
-            UnSpawned.Invoke(identity);
-
             Guid assetId = identity.AssetId;
 
             identity.StopClient();
@@ -336,6 +302,8 @@ namespace Mirage
                 identity.gameObject.SetActive(false);
                 spawnableObjects[identity.sceneId] = identity;
             }
+
+            Client.World.RemoveIdentity(identity);
         }
 
         /// <summary>
@@ -344,14 +312,14 @@ namespace Mirage
         /// </summary>
         public void DestroyAllClientObjects()
         {
-            foreach (NetworkIdentity identity in SpawnedObjects.Values)
+            foreach (NetworkIdentity identity in Client.World.SpawnedIdentities)
             {
                 if (identity != null && identity.gameObject != null)
                 {
                     UnSpawn(identity);
                 }
             }
-            SpawnedObjects.Clear();
+            Client.World.ClearSpawnedObjects();
         }
 
         void ApplySpawnPayload(NetworkIdentity identity, SpawnMessage msg)
@@ -386,7 +354,7 @@ namespace Mirage
                 }
             }
 
-            SpawnedObjects[msg.netId] = identity;
+            Client.World.AddIdentity(msg.netId, identity);
 
             // objects spawned as part of initial state are started on a second pass
             identity.NotifyAuthority();
@@ -402,16 +370,15 @@ namespace Mirage
             }
             if (logger.LogEnabled()) logger.Log($"Client spawn handler instantiating netId={msg.netId} assetID={msg.assetId} sceneId={msg.sceneId} pos={msg.position}");
 
-            bool spawned = false;
-
             // was the object already spawned?
-            NetworkIdentity identity = GetExistingObject(msg.netId);
+            bool existing = Client.World.TryGetIdentity(msg.netId, out NetworkIdentity identity);
 
-            if (identity == null)
+            if (!existing)
             {
                 //is the object on the prefab or scene object lists?
-                identity = msg.sceneId == 0 ? SpawnPrefab(msg) : SpawnSceneObject(msg);
-                spawned = true;
+                identity = msg.sceneId == 0
+                    ? SpawnPrefab(msg)
+                    : SpawnSceneObject(msg);
             }
 
             if (identity == null)
@@ -421,15 +388,6 @@ namespace Mirage
             }
 
             ApplySpawnPayload(identity, msg);
-
-            if (spawned)
-                Spawned.Invoke(identity);
-        }
-
-        NetworkIdentity GetExistingObject(uint netid)
-        {
-            SpawnedObjects.TryGetValue(netid, out NetworkIdentity localObject);
-            return localObject;
         }
 
         NetworkIdentity SpawnPrefab(SpawnMessage msg)
@@ -503,10 +461,9 @@ namespace Mirage
         {
             if (logger.LogEnabled()) logger.Log("ClientScene.OnObjDestroy netId:" + netId);
 
-            if (SpawnedObjects.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
+            if (Client.World.TryGetIdentity(netId, out NetworkIdentity localObject) && localObject != null)
             {
                 UnSpawn(localObject);
-                SpawnedObjects.Remove(netId);
             }
             else
             {
@@ -516,7 +473,7 @@ namespace Mirage
 
         internal void OnHostClientSpawn(SpawnMessage msg)
         {
-            if (SpawnedObjects.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
+            if (Client.World.TryGetIdentity(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 if (msg.isLocalPlayer)
                     InternalAddPlayer(localObject);
@@ -540,11 +497,11 @@ namespace Mirage
             {
                 throw new MethodInvocationException($"Invalid RPC call with id {msg.functionHash}");
             }
-            if (SpawnedObjects.TryGetValue(msg.netId, out NetworkIdentity identity) && identity != null)
+            if (Client.World.TryGetIdentity(msg.netId, out NetworkIdentity identity) && identity != null)
             {
                 using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
                 {
-                    networkReader.ObjectLocator = this;
+                    networkReader.ObjectLocator = Client.World;
                     identity.HandleRemoteCall(skeleton, msg.componentIndex, networkReader);
                 }
             }
@@ -580,11 +537,6 @@ namespace Mirage
 
         private readonly Dictionary<int, Action<NetworkReader>> callbacks = new Dictionary<int, Action<NetworkReader>>();
         private int replyId;
-
-        public bool TryGetIdentity(uint netId, out NetworkIdentity identity)
-        {
-            return SpawnedObjects.TryGetValue(netId, out identity) && identity != null;
-        }
 
         /// <summary>
         /// Creates a task that waits for a reply from the server

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -312,7 +312,10 @@ namespace Mirage
         /// </summary>
         public void DestroyAllClientObjects()
         {
-            foreach (NetworkIdentity identity in Client.World.SpawnedIdentities)
+            // create copy so they can be removed inside loop
+            // todo remove allocation? might not be a problem as this is clean up
+            NetworkIdentity[] all = Client.World.SpawnedIdentities.ToArray();
+            foreach (NetworkIdentity identity in all)
             {
                 if (identity != null && identity.gameObject != null)
                 {
@@ -354,8 +357,6 @@ namespace Mirage
                 }
             }
 
-            Client.World.AddIdentity(msg.netId, identity);
-
             // objects spawned as part of initial state are started on a second pass
             identity.NotifyAuthority();
             identity.StartClient();
@@ -388,6 +389,10 @@ namespace Mirage
             }
 
             ApplySpawnPayload(identity, msg);
+
+            // add after applying payload, but only if it is new object
+            if (!existing)
+                Client.World.AddIdentity(msg.netId, identity);
         }
 
         NetworkIdentity SpawnPrefab(SpawnMessage msg)

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -313,7 +313,7 @@ namespace Mirage
         public void DestroyAllClientObjects()
         {
             // create copy so they can be removed inside loop
-            // todo remove allocation? might not be a problem as this is clean up
+            // allocation here are fine because is part of clean up
             NetworkIdentity[] all = Client.World.SpawnedIdentities.ToArray();
             foreach (NetworkIdentity identity in all)
             {

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -343,6 +343,7 @@ namespace Mirage
             identity.NetId = msg.netId;
             identity.Client = Client;
             identity.ClientObjectManager = this;
+            identity.World = Client.World;
 
             if (msg.isLocalPlayer)
                 InternalAddPlayer(identity);

--- a/Assets/Mirage/Runtime/IClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/IClientObjectManager.cs
@@ -14,16 +14,6 @@ namespace Mirage
     public interface IClientObjectManager
     {
         /// <summary>
-        /// Raised when the client spawns an object
-        /// </summary>
-        SpawnEvent Spawned { get; }
-
-        /// <summary>
-        /// Raised when the client unspawns an object
-        /// </summary>
-        SpawnEvent UnSpawned { get; }
-
-        /// <summary>
         /// NetworkIdentity of the localPlayer
         /// </summary>
         NetworkIdentity LocalPlayer { get; }

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -36,6 +36,8 @@ namespace Mirage
         /// </summary>
         bool IsLocalClient { get; }
 
+        NetworkWorld World { get; }
+
         NetworkTime Time { get; }
 
         void Disconnect();

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -59,6 +59,8 @@ namespace Mirage
         /// </summary>
         bool Active { get; }
 
+        NetworkTime Time { get; }
+
         NetworkWorld World { get; }
 
         IReadOnlyCollection<INetworkPlayer> Players { get; }

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -59,7 +59,7 @@ namespace Mirage
         /// </summary>
         bool Active { get; }
 
-        NetworkTime Time { get; }
+        NetworkWorld World { get; }
 
         IReadOnlyCollection<INetworkPlayer> Players { get; }
 

--- a/Assets/Mirage/Runtime/IServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/IServerObjectManager.cs
@@ -5,17 +5,6 @@ namespace Mirage
 {
     public interface IServerObjectManager
     {
-
-        /// <summary>
-        /// Raised when the client spawns an object
-        /// </summary>
-        SpawnEvent Spawned { get; }
-
-        /// <summary>
-        /// Raised when the client unspawns an object
-        /// </summary>
-        SpawnEvent UnSpawned { get; }
-
         bool AddCharacter(INetworkPlayer player, GameObject character);
 
         bool AddCharacter(INetworkPlayer player, GameObject character, Guid assetId);

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -114,10 +114,13 @@ namespace Mirage
         /// </summary>
         public INetworkPlayer ConnectionToClient => NetIdentity.ConnectionToClient;
 
+
+        public NetworkWorld NetworkWorld => NetIdentity.NetworkWorld;
+
         /// <summary>
         /// Returns the appropriate NetworkTime instance based on if this NetworkBehaviour is running as a Server or Client.
         /// </summary>
-        public NetworkTime NetworkTime => IsClient ? Client.Time : Server.Time;
+        public NetworkTime NetworkTime => NetworkWorld.Time;
 
         protected internal ulong SyncVarDirtyBits { get; private set; }
         ulong syncVarHookGuard;

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -115,12 +115,12 @@ namespace Mirage
         public INetworkPlayer ConnectionToClient => NetIdentity.ConnectionToClient;
 
 
-        public NetworkWorld NetworkWorld => NetIdentity.NetworkWorld;
+        public NetworkWorld World => NetIdentity.World;
 
         /// <summary>
         /// Returns the appropriate NetworkTime instance based on if this NetworkBehaviour is running as a Server or Client.
         /// </summary>
-        public NetworkTime NetworkTime => NetworkWorld.Time;
+        public NetworkTime NetworkTime => IsClient ? Client.Time : Server.Time;
 
         protected internal ulong SyncVarDirtyBits { get; private set; }
         ulong syncVarHookGuard;

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -145,7 +145,7 @@ namespace Mirage
             {
                 IConnection transportConnection = await Transport.ConnectAsync(uri);
 
-                World = new NetworkWorld(null, this);
+                World = new NetworkWorld();
                 InitializeAuthEvents();
 
                 // setup all the handlers
@@ -156,7 +156,7 @@ namespace Mirage
                 Time.UpdateClient(this);
                 OnConnected().Forget();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 connectState = ConnectState.Disconnected;
                 throw;

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -81,7 +81,7 @@ namespace Mirage
         /// <summary>
         /// Time kept in this client
         /// </summary>
-        public NetworkTime Time => World.Time;
+        public NetworkTime Time { get; } = new NetworkTime();
 
         public NetworkWorld World { get; private set; }
 
@@ -156,9 +156,10 @@ namespace Mirage
                 Time.UpdateClient(this);
                 OnConnected().Forget();
             }
-            finally
+            catch (Exception e)
             {
                 connectState = ConnectState.Disconnected;
+                throw;
             }
         }
 

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -78,14 +78,12 @@ namespace Mirage
         /// </summary>
         public bool IsConnected => connectState == ConnectState.Connected;
 
-        readonly NetworkTime _time = new NetworkTime();
         /// <summary>
         /// Time kept in this client
         /// </summary>
-        public NetworkTime Time
-        {
-            get { return _time; }
-        }
+        public NetworkTime Time => World.Time;
+
+        public NetworkWorld World { get; private set; }
 
         /// <summary>
         /// NetworkClient can connect to local server in host mode too
@@ -147,6 +145,7 @@ namespace Mirage
             {
                 IConnection transportConnection = await Transport.ConnectAsync(uri);
 
+                World = new NetworkWorld(null, this);
                 InitializeAuthEvents();
 
                 // setup all the handlers
@@ -157,10 +156,9 @@ namespace Mirage
                 Time.UpdateClient(this);
                 OnConnected().Forget();
             }
-            catch (Exception)
+            finally
             {
                 connectState = ConnectState.Disconnected;
-                throw;
             }
         }
 
@@ -169,6 +167,7 @@ namespace Mirage
             logger.Log("Client Connect Host to Server");
             connectState = ConnectState.Connected;
 
+            World = server.World;
             InitializeAuthEvents();
 
             // create local connection objects and connect them

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -315,6 +315,7 @@ namespace Mirage
         /// This is invoked for NetworkBehaviour objects when they become active on the server.
         /// <para>This could be triggered by NetworkServer.Listen() for objects in the scene, or by NetworkServer.Spawn() for objects that are dynamically created.</para>
         /// <para>This will be called for objects on a "host" as well as for object on a dedicated server.</para>
+        /// <para>OnStartServer is invoked before this object is added to collection of spawned objects</para>
         /// </summary>
         public UnityEvent OnStartServer = new UnityEvent();
 

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -168,6 +168,11 @@ namespace Mirage
         public INetworkServer Server { get; internal set; }
 
         /// <summary>
+        /// The world this object exists in
+        /// </summary>
+        public NetworkWorld NetworkWorld;
+
+        /// <summary>
         /// The ServerObjectManager is present only for server/host instances.
         /// </summary>
         public ServerObjectManager ServerObjectManager;
@@ -871,7 +876,7 @@ namespace Mirage
         internal void OnDeserializeAllSafely(NetworkReader reader, bool initialState)
         {
             // needed so that we can deserialize gameobjects and NI
-            reader.ObjectLocator = ClientObjectManager;
+            reader.ObjectLocator = Client != null ? Client.World : null;
             // deserialize all components that were received
             NetworkBehaviour[] components = NetworkBehaviours;
             while (reader.Position < reader.Length)

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -170,7 +170,7 @@ namespace Mirage
         /// <summary>
         /// The world this object exists in
         /// </summary>
-        public NetworkWorld NetworkWorld;
+        public NetworkWorld World { get; internal set; }
 
         /// <summary>
         /// The ServerObjectManager is present only for server/host instances.

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -161,7 +161,7 @@ namespace Mirage
                 return;
 
             initialized = true;
-            World = new NetworkWorld(this, LocalClient);
+            World = new NetworkWorld();
 
             Application.quitting += Disconnect;
             if (logger.LogEnabled()) logger.Log($"NetworkServer Created, Mirage version: {Version.Current}");
@@ -377,7 +377,7 @@ namespace Mirage
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + player);
 
             //Only allow host client to connect when not Listening for new connections
-            if(!Listening && player != LocalPlayer)
+            if (!Listening && player != LocalPlayer)
             {
                 return;
             }

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -128,7 +128,7 @@ namespace Mirage
         /// <summary>
         /// Time kept in this server
         /// </summary>
-        public NetworkTime Time => World.Time;
+        public NetworkTime Time { get; } = new NetworkTime();
 
         public NetworkWorld World { get; private set; }
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -125,14 +125,12 @@ namespace Mirage
         /// </summary>
         public bool Active { get; private set; }
 
-        readonly NetworkTime _time = new NetworkTime();
         /// <summary>
         /// Time kept in this server
         /// </summary>
-        public NetworkTime Time
-        {
-            get { return _time; }
-        }
+        public NetworkTime Time => World.Time;
+
+        public NetworkWorld World { get; private set; }
 
         /// <summary>
         /// This shuts down the server and disconnects all clients.
@@ -163,6 +161,7 @@ namespace Mirage
                 return;
 
             initialized = true;
+            World = new NetworkWorld(this, LocalClient);
 
             Application.quitting += Disconnect;
             if (logger.LogEnabled()) logger.Log($"NetworkServer Created, Mirage version: {Version.Current}");
@@ -238,6 +237,9 @@ namespace Mirage
         {
             if (!client)
                 throw new InvalidOperationException("NetworkClient not assigned. Unable to StartHost()");
+
+            // need to set local client before listen as that is when world is created
+            LocalClient = client;
 
             // start listening to network connections
             UniTask task = ListenAsync();

--- a/Assets/Mirage/Runtime/NetworkTime.cs
+++ b/Assets/Mirage/Runtime/NetworkTime.cs
@@ -61,7 +61,7 @@ namespace Mirage
                 {
                     clientTime = LocalTime()
                 };
-                client.Player.Send(pingMessage, Channel.Unreliable);
+                client.Send(pingMessage, Channel.Unreliable);
                 lastPingTime = UnityEngine.Time.time;
             }
         }

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -35,7 +35,7 @@ namespace Mirage
         internal void AddIdentity(uint netId, NetworkIdentity identity)
         {
             SpawnedObjects.Add(netId, identity);
-            onSpawn.Invoke(identity);
+            onSpawn?.Invoke(identity);
         }
         internal void RemoveIdentity(NetworkIdentity identity)
         {

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using Mirage.Logging;
+using UnityEngine;
+
+namespace Mirage
+{
+    public class NetworkWorld : IObjectLocator
+    {
+        static readonly ILogger logger = LogFactory.GetLogger<NetworkWorld>();
+
+        /// <summary>
+        /// Raised when the client spawns an object
+        /// </summary>
+        public event Action<NetworkIdentity> onSpawn;
+
+        /// <summary>
+        /// Raised when the client unspawns an object
+        /// </summary>
+        public event Action<NetworkIdentity> onUnspawn;
+
+        private readonly Dictionary<uint, NetworkIdentity> SpawnedObjects = new Dictionary<uint, NetworkIdentity>();
+
+        public IReadOnlyCollection<NetworkIdentity> SpawnedIdentities => SpawnedObjects.Values;
+
+        public bool TryGetIdentity(uint id, out NetworkIdentity identity)
+        {
+            return SpawnedObjects.TryGetValue(id, out identity) && identity != null;
+        }
+        /// <summary>
+        /// Adds Identity to world and invokes spawned event
+        /// </summary>
+        /// <param name="netId"></param>
+        /// <param name="identity"></param>
+        internal void AddIdentity(uint netId, NetworkIdentity identity)
+        {
+            SpawnedObjects.Add(netId, identity);
+            onSpawn.Invoke(identity);
+        }
+        internal void RemoveIdentity(NetworkIdentity identity)
+        {
+            uint netId = identity.NetId;
+            SpawnedObjects.Remove(netId);
+            onUnspawn?.Invoke(identity);
+        }
+        internal void RemoveIdentity(uint netId)
+        {
+            if (netId == 0) throw new ArgumentException("netid = 0 is invalid");
+
+            SpawnedObjects.TryGetValue(netId, out NetworkIdentity identity);
+            SpawnedObjects.Remove(netId);
+            onUnspawn?.Invoke(identity);
+        }
+
+
+        internal void ClearSpawnedObjects()
+        {
+            SpawnedObjects.Clear();
+        }
+
+        public NetworkPlayer LocalPlayer { get; private set; }
+        public NetworkTime Time { get; }
+
+        public INetworkServer Server { get; }
+        public INetworkClient Client { get; }
+
+        public NetworkWorld(INetworkServer server, INetworkClient client)
+        {
+            Time = new NetworkTime();
+            Server = server;
+            Client = client;
+        }
+    }
+}

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -50,7 +50,8 @@ namespace Mirage
         }
         internal void RemoveIdentity(uint netId)
         {
-            if (netId == 0) throw new ArgumentException("netid = 0 is invalid");
+            if (netId == 0) throw new ArgumentException("id can not be zero", nameof(netId));
+
 
             SpawnedObjects.TryGetValue(netId, out NetworkIdentity identity);
             SpawnedObjects.Remove(netId);

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -34,6 +34,11 @@ namespace Mirage
         /// <param name="identity"></param>
         internal void AddIdentity(uint netId, NetworkIdentity identity)
         {
+            if (netId == 0) throw new ArgumentException("id can not be zero", nameof(netId));
+            if (SpawnedObjects.ContainsKey(netId)) throw new ArgumentException("An item with same id already exists", nameof(netId));
+            if (identity == null) throw new ArgumentNullException(nameof(identity));
+            if (netId != identity.NetId) throw new ArgumentException("NetworkIdentity did not have matching netId", nameof(identity));
+
             SpawnedObjects.Add(netId, identity);
             onSpawn?.Invoke(identity);
         }

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -58,13 +58,9 @@ namespace Mirage
             SpawnedObjects.Clear();
         }
 
-        public INetworkServer Server { get; }
-        public INetworkClient Client { get; }
-
-        public NetworkWorld(INetworkServer server, INetworkClient client)
+        public NetworkWorld()
         {
-            Server = server;
-            Client = client;
+
         }
     }
 }

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -23,9 +23,9 @@ namespace Mirage
 
         public IReadOnlyCollection<NetworkIdentity> SpawnedIdentities => SpawnedObjects.Values;
 
-        public bool TryGetIdentity(uint id, out NetworkIdentity identity)
+        public bool TryGetIdentity(uint netId, out NetworkIdentity identity)
         {
-            return SpawnedObjects.TryGetValue(id, out identity) && identity != null;
+            return SpawnedObjects.TryGetValue(netId, out identity) && identity != null;
         }
         /// <summary>
         /// Adds Identity to world and invokes spawned event

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -58,8 +58,6 @@ namespace Mirage
             SpawnedObjects.Clear();
         }
 
-        public NetworkPlayer LocalPlayer { get; private set; }
-
         public INetworkServer Server { get; }
         public INetworkClient Client { get; }
 

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -59,14 +59,12 @@ namespace Mirage
         }
 
         public NetworkPlayer LocalPlayer { get; private set; }
-        public NetworkTime Time { get; }
 
         public INetworkServer Server { get; }
         public INetworkClient Client { get; }
 
         public NetworkWorld(INetworkServer server, INetworkClient client)
         {
-            Time = new NetworkTime();
             Server = server;
             Client = client;
         }

--- a/Assets/Mirage/Runtime/NetworkWorld.cs.meta
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c85810b173bce04893aaa56412b2220
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -430,6 +430,7 @@ namespace Mirage
             identity.ConnectionToClient = ownerPlayer;
             identity.Server = Server;
             identity.ServerObjectManager = this;
+            identity.World = Server.World;
             identity.Client = Server.LocalClient;
 
             // special case to make sure hasAuthority is set

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -442,9 +442,8 @@ namespace Mirage
             {
                 // the object has not been spawned yet
                 identity.NetId = GetNextNetworkId();
-                Server.World.AddIdentity(identity.NetId, identity);
-                // todo should this be called before Add?
                 identity.StartServer();
+                Server.World.AddIdentity(identity.NetId, identity);
             }
 
             if (logger.LogEnabled()) logger.Log("SpawnObject instance ID " + identity.NetId + " asset ID " + identity.AssetId);

--- a/Assets/Mirage/Samples~/Tanks/Scripts/TankGameManager.cs
+++ b/Assets/Mirage/Samples~/Tanks/Scripts/TankGameManager.cs
@@ -84,9 +84,9 @@ namespace Mirage.Examples.Tanks
 
         void CheckPlayersNotInList()
         {
-            foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkManager.ClientObjectManager.SpawnedObjects)
+            foreach (NetworkIdentity identity in NetworkManager.Client.World.SpawnedIdentities)
             {
-                Tank comp = kvp.Value.GetComponent<Tank>();
+                Tank comp = identity.GetComponent<Tank>();
                 if (comp != null && !players.Contains(comp))
                 {
                     //Add if new

--- a/Assets/Tests/Common/AsyncUtil.cs
+++ b/Assets/Tests/Common/AsyncUtil.cs
@@ -8,6 +8,13 @@ namespace Mirage.Tests
 {
     public static class AsyncUtil
     {
+        public static async UniTask<NetworkIdentity> WaitUntilSpawn(NetworkWorld world, uint netId)
+        {
+            NetworkIdentity identity = null;
+            await UniTask.WaitUntil(() => world.TryGetIdentity(netId, out identity));
+
+            return identity;
+        }
 
         public static UniTask WaitUntilWithTimeout(Func<bool> predicate, double seconds = 2)
         {

--- a/Assets/Tests/Editor/NetworkWorldTests.cs
+++ b/Assets/Tests/Editor/NetworkWorldTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using UnityEngine;
+
+namespace Mirage.Tests
+{
+    public class NetworkWorldTests
+    {
+        private NetworkWorld world;
+        HashSet<uint> existingIds;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = new NetworkWorld();
+            existingIds = new HashSet<uint>();
+        }
+
+
+        void addValidIdentity(out uint id, out NetworkIdentity identity)
+        {
+            do
+            {
+                id = (uint)Random.Range(1, 10000);
+            }
+            while (existingIds.Contains(id));
+
+            existingIds.Add(id);
+
+            identity = new GameObject("WorldTest").AddComponent<NetworkIdentity>();
+            identity.NetId = 10;
+            world.AddIdentity(id, identity);
+        }
+
+        [Test]
+        public void StartsEmpty()
+        {
+            Assert.That(world.SpawnedIdentities.Count, Is.Zero);
+        }
+
+        [Test]
+        public void TryGetReturnsFalseIfNotFound()
+        {
+            uint id = 10;
+            bool found = world.TryGetIdentity(id, out NetworkIdentity _);
+            Assert.That(found, Is.False);
+        }
+        [Test]
+        public void TryGetReturnsFalseIfNull()
+        {
+            addValidIdentity(out uint id, out NetworkIdentity identity);
+
+            Object.DestroyImmediate(identity);
+
+            bool found = world.TryGetIdentity(id, out NetworkIdentity _);
+            Assert.That(found, Is.False);
+        }
+        [Test]
+        public void TryGetReturnsTrueIfFound()
+        {
+            addValidIdentity(out uint id, out NetworkIdentity identity);
+
+            bool found = world.TryGetIdentity(id, out NetworkIdentity _);
+            Assert.That(found, Is.True);
+        }
+
+        [Test, Ignore("not implemneted")] public void AddToCollection() { }
+        [Test, Ignore("not implemneted")] public void CanAddManyObjects() { }
+        [Test, Ignore("not implemneted")] public void AddInvokesEvent() { }
+        [Test, Ignore("not implemneted")] public void AddThrowsIfIdentityIsNull() { }
+        [Test, Ignore("not implemneted")] public void AddThrowsIfIdAlreadyInCollection() { }
+        [Test, Ignore("not implemneted")] public void AddThrowsIfIdIs0() { }
+        [Test, Ignore("not implemneted")] public void AddAssertsIfIdentityDoesNotHaveMatchingId() { }
+
+        [Test, Ignore("not implemneted")] public void RemoveFromCollectionUsingIdentity() { }
+        [Test, Ignore("not implemneted")] public void RemoveFromCollectionUsingNetId() { }
+        [Test, Ignore("not implemneted")] public void RemoveInvokesEvent() { }
+        [Test, Ignore("not implemneted")] public void RemoveThrowsIfIdIs0() { }
+
+        [Test, Ignore("not implemneted")] public void ClearRemovesAllFromCollection() { }
+        [Test, Ignore("not implemneted")] public void ClearDoesNotInvokeEvent() { }
+    }
+}

--- a/Assets/Tests/Editor/NetworkWorldTests.cs
+++ b/Assets/Tests/Editor/NetworkWorldTests.cs
@@ -201,12 +201,103 @@ namespace Mirage.Tests
             spawnListener.DidNotReceiveWithAnyArgs().Invoke(default);
         }
 
-        [Test] public void RemoveFromCollectionUsingIdentity() { Assert.Ignore("NotImplemented"); }
-        [Test] public void RemoveFromCollectionUsingNetId() { Assert.Ignore("NotImplemented"); }
-        [Test] public void RemoveInvokesEvent() { Assert.Ignore("NotImplemented"); }
-        [Test] public void RemoveThrowsIfIdIs0() { Assert.Ignore("NotImplemented"); }
+        [Test]
+        public void RemoveFromCollectionUsingIdentity()
+        {
+            AddValidIdentity(out uint id, out NetworkIdentity identity);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(1));
 
-        [Test] public void ClearRemovesAllFromCollection() { Assert.Ignore("NotImplemented"); }
-        [Test] public void ClearDoesNotInvokeEvent() { Assert.Ignore("NotImplemented"); }
+            world.RemoveIdentity(identity);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(0));
+
+            Assert.That(world.TryGetIdentity(id, out NetworkIdentity identityOut), Is.False);
+            Assert.That(identityOut, Is.EqualTo(null));
+        }
+        [Test]
+        public void RemoveFromCollectionUsingNetId()
+        {
+            AddValidIdentity(out uint id, out NetworkIdentity identity);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(1));
+
+            world.RemoveIdentity(id);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(0));
+
+            Assert.That(world.TryGetIdentity(id, out NetworkIdentity identityOut), Is.False);
+            Assert.That(identityOut, Is.EqualTo(null));
+        }
+        [Test]
+        public void RemoveOnlyRemovesCorrectItem()
+        {
+            AddValidIdentity(out uint id1, out NetworkIdentity identity1);
+            AddValidIdentity(out uint id2, out NetworkIdentity identity2);
+            AddValidIdentity(out uint id3, out NetworkIdentity identity3);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(3));
+
+            world.RemoveIdentity(identity2);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(2));
+
+            Assert.That(world.TryGetIdentity(id1, out NetworkIdentity identityOut1), Is.True);
+            Assert.That(world.TryGetIdentity(id2, out NetworkIdentity identityOut2), Is.False);
+            Assert.That(world.TryGetIdentity(id3, out NetworkIdentity identityOut3), Is.True);
+            Assert.That(identityOut1, Is.EqualTo(identity1));
+            Assert.That(identityOut2, Is.EqualTo(null));
+            Assert.That(identityOut3, Is.EqualTo(identity3));
+        }
+        [Test]
+        public void RemoveInvokesEvent()
+        {
+            AddValidIdentity(out uint id1, out NetworkIdentity identity1);
+            AddValidIdentity(out uint id2, out NetworkIdentity identity2);
+            AddValidIdentity(out uint id3, out NetworkIdentity identity3);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(3));
+
+            world.RemoveIdentity(identity3);
+            unspawnListener.Received(1).Invoke(identity3);
+
+            world.RemoveIdentity(id1);
+            unspawnListener.Received(1).Invoke(identity1);
+
+            world.RemoveIdentity(id2);
+            unspawnListener.Received(1).Invoke(identity2);
+        }
+
+        [Test]
+        public void RemoveThrowsIfIdIs0()
+        {
+            uint id = 0;
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            {
+                world.RemoveIdentity(id);
+            });
+
+            var expected = new ArgumentException("id can not be zero", "netId");
+            Assert.That(exception, Has.Message.EqualTo(expected.Message));
+
+            unspawnListener.DidNotReceiveWithAnyArgs().Invoke(default);
+        }
+
+        [Test]
+        public void ClearRemovesAllFromCollection()
+        {
+            AddValidIdentity(out uint id1, out NetworkIdentity identity1);
+            AddValidIdentity(out uint id2, out NetworkIdentity identity2);
+            AddValidIdentity(out uint id3, out NetworkIdentity identity3);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(3));
+
+            world.ClearSpawnedObjects();
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(0));
+        }
+        [Test]
+        public void ClearDoesNotInvokeEvent()
+        {
+            AddValidIdentity(out uint id1, out NetworkIdentity identity1);
+            AddValidIdentity(out uint id2, out NetworkIdentity identity2);
+            AddValidIdentity(out uint id3, out NetworkIdentity identity3);
+            Assert.That(world.SpawnedIdentities.Count, Is.EqualTo(3));
+
+            world.ClearSpawnedObjects();
+            unspawnListener.DidNotReceiveWithAnyArgs().Invoke(default);
+        }
     }
 }

--- a/Assets/Tests/Editor/NetworkWorldTests.cs.meta
+++ b/Assets/Tests/Editor/NetworkWorldTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3cb3f87b7ef235c4a891d99e207184ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
@@ -92,6 +92,7 @@ namespace Mirage.Tests.Runtime.ClientServer
             var gameObject = new GameObject();
             NetworkIdentity identity = gameObject.AddComponent<NetworkIdentity>();
             identity.AssetId = guid;
+            identity.NetId = (uint)Random.Range(0, int.MaxValue);
 
             clientObjectManager.RegisterSpawnHandler(guid, SpawnDelegateTest, go => { });
             clientObjectManager.RegisterPrefab(identity, guid);
@@ -110,6 +111,7 @@ namespace Mirage.Tests.Runtime.ClientServer
             var gameObject = new GameObject();
             NetworkIdentity identity = gameObject.AddComponent<NetworkIdentity>();
             identity.AssetId = guid;
+            identity.NetId = (uint)Random.Range(0, int.MaxValue);
 
             UnSpawnDelegate unspawnDelegate = Substitute.For<UnSpawnDelegate>();
 

--- a/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
@@ -44,7 +44,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             var goSyncvar = new GameObjectSyncvar
             {
-                objectLocator = clientObjectManager,
+                objectLocator = client.World,
                 netId = serverIdentity.NetId,
                 gameObject = null,
             };
@@ -63,10 +63,10 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             // wait until the client spawns it
             uint newObjectId = newBehavior.NetId;
-            await UniTask.WaitUntil(() => clientObjectManager.SpawnedObjects.ContainsKey(newObjectId));
+
+            NetworkIdentity newClientObject = await AsyncUtil.WaitUntilSpawn(client.World, newObjectId);
 
             // check if the target was set correctly in the client
-            NetworkIdentity newClientObject = clientObjectManager.SpawnedObjects[newObjectId];
             SampleBehaviorWithGO newClientBehavior = newClientObject.GetComponent<SampleBehaviorWithGO>();
             Assert.That(newClientBehavior.target, Is.SameAs(clientPlayerGO));
 

--- a/Assets/Tests/Runtime/ClientServer/GenericNetworkBehaviorSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/GenericNetworkBehaviorSyncvarTest.cs
@@ -165,9 +165,10 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             // wait until the client spawns it
             uint newObjectId = newBehavior.NetId;
-            await UniTask.WaitUntil(() => clientObjectManager.SpawnedObjects.ContainsKey(newObjectId));
+
+            NetworkIdentity newClientObject = await AsyncUtil.WaitUntilSpawn(client.World, newObjectId);
             // check if the target was set correctly in the client
-            NetworkIdentity newClientObject = clientObjectManager.SpawnedObjects[newObjectId];
+
             GenericBehaviourWithSyncVarImplement newClientBehavior = newClientObject.GetComponent<GenericBehaviourWithSyncVarImplement>();
             Assert.AreEqual(newClientBehavior.baseValue, 2);
             Assert.AreEqual(newClientBehavior.childValue, 22);

--- a/Assets/Tests/Runtime/ClientServer/GenericNetworkBehaviourSyncvarDeeperTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/GenericNetworkBehaviourSyncvarDeeperTest.cs
@@ -238,10 +238,9 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             // wait until the client spawns it
             uint newObjectId = newBehavior.NetId;
-            await UniTask.WaitUntil(() => clientObjectManager.SpawnedObjects.ContainsKey(newObjectId));
+            NetworkIdentity newClientObject = await AsyncUtil.WaitUntilSpawn(client.World, newObjectId);
 
             // check if the target was set correctly in the client
-            NetworkIdentity newClientObject = clientObjectManager.SpawnedObjects[newObjectId];
             GenericBehaviourWithSyncVarDeeperImplement newClientBehavior = newClientObject.GetComponent<GenericBehaviourWithSyncVarDeeperImplement>();
             Assert.AreEqual(newClientBehavior.baseValue, 2);
             Assert.AreEqual(newClientBehavior.middleValue, 22);

--- a/Assets/Tests/Runtime/ClientServer/GenericNetworkBehaviourSyncvarNoMiddleTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/GenericNetworkBehaviourSyncvarNoMiddleTest.cs
@@ -172,10 +172,9 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             // wait until the client spawns it
             uint newObjectId = newBehavior.NetId;
-            await UniTask.WaitUntil(() => clientObjectManager.SpawnedObjects.ContainsKey(newObjectId));
+            NetworkIdentity newClientObject = await AsyncUtil.WaitUntilSpawn(client.World, newObjectId);
 
             // check if the target was set correctly in the client
-            NetworkIdentity newClientObject = clientObjectManager.SpawnedObjects[newObjectId];
             GenericBehaviourWithSyncVarNoMiddleImplement newClientBehavior = newClientObject.GetComponent<GenericBehaviourWithSyncVarNoMiddleImplement>();
             Assert.AreEqual(newClientBehavior.baseValue, 2);
             Assert.AreEqual(newClientBehavior.implementValue, 222);

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
@@ -43,7 +43,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             var goSyncvar = new NetworkBehaviorSyncvar
             {
-                objectLocator = clientObjectManager,
+                objectLocator = client.World,
                 netId = serverIdentity.NetId,
                 component = null,
             };
@@ -62,10 +62,9 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             // wait until the client spawns it
             uint newObjectId = newBehavior.NetId;
-            await UniTask.WaitUntil(() => clientObjectManager.SpawnedObjects.ContainsKey(newObjectId));
+            NetworkIdentity newClientObject = await AsyncUtil.WaitUntilSpawn(client.World, newObjectId);
 
             // check if the target was set correctly in the client
-            NetworkIdentity newClientObject = clientObjectManager.SpawnedObjects[newObjectId];
             SampleBehaviorWithNB newClientBehavior = newClientObject.GetComponent<SampleBehaviorWithNB>();
             Assert.That(newClientBehavior.target, Is.SameAs(clientComponent));
 

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
@@ -48,7 +48,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             var networkIdentitySyncvar = new NetworkIdentitySyncvar
             {
-                objectLocator = clientObjectManager,
+                objectLocator = client.World,
                 netId = serverIdentity.NetId,
                 identity = null,
             };
@@ -67,10 +67,9 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             // wait until the client spawns it
             uint newObjectId = newBehavior.NetId;
-            await UniTask.WaitUntil(() => clientObjectManager.SpawnedObjects.ContainsKey(newObjectId));
+            NetworkIdentity newClientObject = await AsyncUtil.WaitUntilSpawn(client.World, newObjectId);
 
             // check if the target was set correctly in the client
-            NetworkIdentity newClientObject = clientObjectManager.SpawnedObjects[newObjectId];
             SampleBehaviorWithNI newClientBehavior = newClientObject.GetComponent<SampleBehaviorWithNI>();
             Assert.That(newClientBehavior.target, Is.SameAs(clientIdentity));
 

--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -5,7 +5,6 @@ using Cysharp.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.TestTools;
 
 namespace Mirage.Tests.Runtime.ClientServer
@@ -104,8 +103,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         public void SpawnEvent()
         {
 
-            UnityAction<NetworkIdentity> mockHandler = Substitute.For<UnityAction<NetworkIdentity>>();
-            serverObjectManager.Spawned.AddListener(mockHandler);
+            Action<NetworkIdentity> mockHandler = Substitute.For<Action<NetworkIdentity>>();
+            server.World.onSpawn += mockHandler;
             var newObj = GameObject.Instantiate(playerPrefab);
             serverObjectManager.Spawn(newObj);
 
@@ -116,8 +115,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator ClientSpawnEvent() => UniTask.ToCoroutine(async () =>
         {
-            UnityAction<NetworkIdentity> mockHandler = Substitute.For<UnityAction<NetworkIdentity>>();
-            clientObjectManager.Spawned.AddListener(mockHandler);
+            Action<NetworkIdentity> mockHandler = Substitute.For<Action<NetworkIdentity>>();
+            client.World.onSpawn += mockHandler;
             var newObj = GameObject.Instantiate(playerPrefab);
             serverObjectManager.Spawn(newObj);
 
@@ -130,8 +129,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator ClientUnSpawnEvent() => UniTask.ToCoroutine(async () =>
         {
-            UnityAction<NetworkIdentity> mockHandler = Substitute.For<UnityAction<NetworkIdentity>>();
-            clientObjectManager.UnSpawned.AddListener(mockHandler);
+            Action<NetworkIdentity> mockHandler = Substitute.For<Action<NetworkIdentity>>();
+            client.World.onUnspawn += mockHandler;
             var newObj = GameObject.Instantiate(playerPrefab);
             serverObjectManager.Spawn(newObj);
             serverObjectManager.Destroy(newObj);
@@ -143,8 +142,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         [Test]
         public void UnSpawnEvent()
         {
-            UnityAction<NetworkIdentity> mockHandler = Substitute.For<UnityAction<NetworkIdentity>>();
-            serverObjectManager.UnSpawned.AddListener(mockHandler);
+            Action<NetworkIdentity> mockHandler = Substitute.For<Action<NetworkIdentity>>();
+            server.World.onUnspawn += mockHandler;
             var newObj = GameObject.Instantiate(playerPrefab);
             serverObjectManager.Spawn(newObj);
             serverObjectManager.Destroy(newObj);

--- a/Assets/Tests/Runtime/Host/ClientObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ClientObjectManagerTest.cs
@@ -206,17 +206,5 @@ namespace Mirage.Tests.Runtime.Host
 
             Object.Destroy(prefabObject);
         }
-
-        [Test]
-        public void SpawnedNotNullTest()
-        {
-            Assert.That(clientObjectManager.Spawned, Is.Not.Null);
-        }
-
-        [Test]
-        public void UnSpawnedNotNullTest()
-        {
-            Assert.That(clientObjectManager.UnSpawned, Is.Not.Null);
-        }
     }
 }

--- a/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
@@ -129,25 +129,13 @@ namespace Mirage.Tests.Runtime.Host
             serverObjectManager.Spawn(spawnTestObj);
 
             //1 is the player. should be 2 at this point
-            Assert.That(serverObjectManager.SpawnedObjects.Count, Is.GreaterThan(1));
+            Assert.That(server.World.SpawnedIdentities.Count, Is.GreaterThan(1));
 
             server.Disconnect();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);
 
-            Assert.That(serverObjectManager.SpawnedObjects.Count, Is.Zero);
+            Assert.That(server.World.SpawnedIdentities.Count, Is.Zero);
         });
-
-        [Test]
-        public void SpawnedNotNullTest()
-        {
-            Assert.That(serverObjectManager.Spawned, Is.Not.Null);
-        }
-
-        [Test]
-        public void UnSpawnedNotNullTest()
-        {
-            Assert.That(serverObjectManager.UnSpawned, Is.Not.Null);
-        }
     }
 }


### PR DESCRIPTION
Will be split into smaller PR before merging

resolves: https://github.com/MirageNet/Mirage/issues/713

requires:
- [x] #720
- [x] #721 
- [x] #722 
- [x] #723
- [x] #724 


BREAKING CHANGE: NetworkIdentity collection is now found in NetworkWorld