### PR TITLE
refactor: changing indexer to try get

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -604,13 +604,9 @@ namespace Mirage
         private readonly Dictionary<int, Action<NetworkReader>> callbacks = new Dictionary<int, Action<NetworkReader>>();
         private int replyId;
 
-        public NetworkIdentity this[uint netId]
+        public bool TryGetIdentity(uint id, out NetworkIdentity identity)
         {
-            get
-            {
-                SpawnedObjects.TryGetValue(netId, out NetworkIdentity identity);
-                return identity;
-            }
+            return SpawnedObjects.TryGetValue(id, out identity) && identity != null;
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -604,9 +604,9 @@ namespace Mirage
         private readonly Dictionary<int, Action<NetworkReader>> callbacks = new Dictionary<int, Action<NetworkReader>>();
         private int replyId;
 
-        public bool TryGetIdentity(uint id, out NetworkIdentity identity)
+        public bool TryGetIdentity(uint netId, out NetworkIdentity identity)
         {
-            return SpawnedObjects.TryGetValue(id, out identity) && identity != null;
+            return SpawnedObjects.TryGetValue(netId, out identity) && identity != null;
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/GameObjectSyncvar.cs
+++ b/Assets/Mirage/Runtime/GameObjectSyncvar.cs
@@ -1,4 +1,4 @@
-﻿using Mirage.Serialization;
+using Mirage.Serialization;
 using UnityEngine;
 
 namespace Mirage
@@ -28,11 +28,9 @@ namespace Mirage
                 if (gameObject != null)
                     return gameObject;
 
-                if (objectLocator != null)
+                if (objectLocator != null && objectLocator.TryGetIdentity(NetId, out NetworkIdentity result))
                 {
-                    NetworkIdentity result = objectLocator[netId];
-                    if (result != null)
-                        return result.gameObject;
+                    return result.gameObject;
                 }
 
                 return null;
@@ -60,14 +58,13 @@ namespace Mirage
             uint netId = reader.ReadPackedUInt32();
 
             NetworkIdentity identity = null;
-            if (!(reader.ObjectLocator is null))
-                identity = reader.ObjectLocator[netId];
+            bool hasValue = reader.ObjectLocator?.TryGetIdentity(netId, out identity) ?? false;
 
             return new GameObjectSyncvar
             {
                 objectLocator = reader.ObjectLocator,
                 netId = netId,
-                gameObject = identity != null ? identity.gameObject : null
+                gameObject = hasValue ? identity.gameObject : null
             };
         }
     }

--- a/Assets/Mirage/Runtime/IObjectLocator.cs
+++ b/Assets/Mirage/Runtime/IObjectLocator.cs
@@ -10,7 +10,8 @@ namespace Mirage
         /// Finds a network identity by id
         /// </summary>
         /// <param name="netId">the id of the object to find</param>
-        /// <returns>The NetworkIdentity matching the netid or null if none is found</returns>
-        NetworkIdentity this[uint netId] { get; }
+        /// <param name="identity">The NetworkIdentity matching the netid or null if none is found</param>
+        /// <returns>true if identity is found and is not null</returns>
+        bool TryGetIdentity(uint netId, out NetworkIdentity identity);
     }
 }

--- a/Assets/Mirage/Runtime/NetworkBehaviorSyncvar.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviorSyncvar.cs
@@ -1,4 +1,4 @@
-﻿using Mirage.Serialization;
+using Mirage.Serialization;
 
 namespace Mirage
 {
@@ -29,12 +29,11 @@ namespace Mirage
                 if (component != null)
                     return component;
 
-                if (objectLocator != null)
+                if (objectLocator != null && objectLocator.TryGetIdentity(NetId, out NetworkIdentity result))
                 {
-                    NetworkIdentity identity = objectLocator[netId];
-                    if (identity != null)
-                        return identity.NetworkBehaviours[componentId];
+                    return result.NetworkBehaviours[componentId];
                 }
+
 
                 return null;
             }
@@ -66,15 +65,14 @@ namespace Mirage
             int componentId = reader.ReadPackedInt32();
 
             NetworkIdentity identity = null;
-            if (!(reader.ObjectLocator is null))
-                identity = reader.ObjectLocator[netId];
+            bool hasValue = reader.ObjectLocator?.TryGetIdentity(netId, out identity) ?? false;
 
             return new NetworkBehaviorSyncvar
             {
                 objectLocator = reader.ObjectLocator,
                 netId = netId,
                 componentId = componentId,
-                component = identity != null ? identity.NetworkBehaviours[componentId] : null
+                component = hasValue ? identity.NetworkBehaviours[componentId] : null
             };
         }
     }

--- a/Assets/Mirage/Runtime/NetworkIdentitySyncvar.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentitySyncvar.cs
@@ -1,4 +1,4 @@
-﻿using Mirage.Serialization;
+using Mirage.Serialization;
 
 namespace Mirage
 {
@@ -27,9 +27,9 @@ namespace Mirage
                 if (identity != null)
                     return identity;
 
-                if (objectLocator != null)
+                if (objectLocator != null && objectLocator.TryGetIdentity(NetId, out NetworkIdentity result))
                 {
-                    return objectLocator[netId];
+                    return result;
                 }
 
                 return null;
@@ -57,8 +57,7 @@ namespace Mirage
             uint netId = reader.ReadPackedUInt32();
 
             NetworkIdentity identity = null;
-            if (!(reader.ObjectLocator is null))
-                identity = reader.ObjectLocator[netId];
+            reader.ObjectLocator?.TryGetIdentity(netId, out identity);
 
             return new NetworkIdentitySyncvar
             {

--- a/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
@@ -391,7 +391,10 @@ namespace Mirage.Serialization
 
             if (reader.ObjectLocator != null)
             {
-                return reader.ObjectLocator[netId];
+                // if not found return c# null
+                return reader.ObjectLocator.TryGetIdentity(netId, out NetworkIdentity identity)
+                    ? identity
+                    : null;
             }
 
             if (logger.WarnEnabled()) logger.LogFormat(LogType.Warning, "ReadNetworkIdentity netId:{0} not found in spawned", netId);

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -69,13 +69,9 @@ namespace Mirage
         public readonly HashSet<NetworkIdentity> DirtyObjects = new HashSet<NetworkIdentity>();
         private readonly List<NetworkIdentity> DirtyObjectsTmp = new List<NetworkIdentity>();
 
-        public NetworkIdentity this[uint netId]
+        public bool TryGetIdentity(uint id, out NetworkIdentity identity)
         {
-            get
-            {
-                SpawnedObjects.TryGetValue(netId, out NetworkIdentity identity);
-                return identity;
-            }
+            return SpawnedObjects.TryGetValue(id, out identity) && identity != null;
         }
 
         public void Start()

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -69,9 +69,9 @@ namespace Mirage
         public readonly HashSet<NetworkIdentity> DirtyObjects = new HashSet<NetworkIdentity>();
         private readonly List<NetworkIdentity> DirtyObjectsTmp = new List<NetworkIdentity>();
 
-        public bool TryGetIdentity(uint id, out NetworkIdentity identity)
+        public bool TryGetIdentity(uint netId, out NetworkIdentity identity)
         {
-            return SpawnedObjects.TryGetValue(id, out identity) && identity != null;
+            return SpawnedObjects.TryGetValue(netId, out identity) && identity != null;
         }
 
         public void Start()


### PR DESCRIPTION
It would be better to return bool if not found to avoid doing null check

BREAKING CHANGE: ObjectLocator now has TryGet method instead of indexer that returns null