### PR TITLE
refactor: moving syncvar sending to its own class

### DIFF
--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -217,7 +217,7 @@ namespace Mirage
         {
             if (IsServer)
             {
-                ServerObjectManager.DirtyObjects.Add(NetIdentity);
+                ServerObjectManager.SyncVarSender.AddDirtyObject(NetIdentity);
             }
         }
 
@@ -374,7 +374,7 @@ namespace Mirage
         {
             SyncVarDirtyBits |= dirtyBit;
             if (IsServer)
-                ServerObjectManager.DirtyObjects.Add(NetIdentity);
+                ServerObjectManager.SyncVarSender.AddDirtyObject(NetIdentity);
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -1162,7 +1162,7 @@ namespace Mirage
             ClearObservers();
         }
 
-        internal void ServerUpdate()
+        internal void UpdateVars()
         {
             if (observers.Count > 0)
             {

--- a/Assets/Mirage/Runtime/SyncVarSender.cs
+++ b/Assets/Mirage/Runtime/SyncVarSender.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Mirage
 {
@@ -24,7 +24,7 @@ namespace Mirage
             {
                 if (identity != null)
                 {
-                    identity.ServerUpdate();
+                    identity.UpdateVars();
 
                     if (identity.StillDirty())
                         DirtyObjectsTmp.Add(identity);

--- a/Assets/Mirage/Runtime/SyncVarSender.cs
+++ b/Assets/Mirage/Runtime/SyncVarSender.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+
+namespace Mirage
+{
+    /// <summary>
+    /// Class that Syncs syncvar and other <see cref="NetworkIdentity"/> State
+    /// </summary>
+    public class SyncVarSender
+    {
+        private readonly HashSet<NetworkIdentity> DirtyObjects = new HashSet<NetworkIdentity>();
+        private readonly List<NetworkIdentity> DirtyObjectsTmp = new List<NetworkIdentity>();
+
+        public void AddDirtyObject(NetworkIdentity dirty)
+        {
+            DirtyObjects.Add(dirty);
+        }
+
+
+        internal void Update()
+        {
+            DirtyObjectsTmp.Clear();
+
+            foreach (NetworkIdentity identity in DirtyObjects)
+            {
+                if (identity != null)
+                {
+                    identity.ServerUpdate();
+
+                    if (identity.StillDirty())
+                        DirtyObjectsTmp.Add(identity);
+                }
+            }
+
+            DirtyObjects.Clear();
+
+            foreach (NetworkIdentity obj in DirtyObjectsTmp)
+                DirtyObjects.Add(obj);
+        }
+    }
+}

--- a/Assets/Mirage/Runtime/SyncVarSender.cs.meta
+++ b/Assets/Mirage/Runtime/SyncVarSender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e31d7a89fffff6e49a464e7bdab70439
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
+++ b/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
@@ -51,6 +51,9 @@ namespace Mirage.Tests.Performance.Runtime
 
             var started = new UniTaskCompletionSource();
             Server.Started.AddListener(() => started.TrySetResult());
+
+            // wait 1 frame before Starting server to give time for Unity to call "Start"
+            await UniTask.Yield();
             Server.ListenAsync().Forget();
 
             await started.Task;

--- a/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformance.cs
+++ b/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformance.cs
@@ -55,7 +55,7 @@ namespace Mirage.Tests.Performance
             for (int j = 0; j < 1000; j++)
             {
                 health.SetDirtyBit(1UL);
-                identity.ServerUpdate();
+                identity.UpdateVars();
             }
         }
 
@@ -73,7 +73,7 @@ namespace Mirage.Tests.Performance
         {
             for (int j = 0; j < 1000; j++)
             {
-                identity.ServerUpdate();
+                identity.UpdateVars();
             }
         }
     }

--- a/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformanceWithMultipleBehaviour.cs
+++ b/Assets/Tests/Performance/Runtime/NetworkWriter/NetworkIdentityPerformanceWithMultipleBehaviour.cs
@@ -54,7 +54,7 @@ namespace Mirage.Tests.Performance
                 {
                     health[i].SetDirtyBit(1UL);
                 }
-                identity.ServerUpdate();
+                identity.UpdateVars();
             }
         }
 
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Performance
         {
             for (int j = 0; j < 1000; j++)
             {
-                identity.ServerUpdate();
+                identity.UpdateVars();
             }
         }
     }


### PR DESCRIPTION
BREAKING CHANGE: Dirty object collection is now inside SyncVarSender