### PR TITLE
fix: fixing race condition when using events

### DIFF
--- a/Assets/Mirage/Runtime/Events/AddLateEvent.cs
+++ b/Assets/Mirage/Runtime/Events/AddLateEvent.cs
@@ -84,6 +84,11 @@ namespace Mirage.Events
             _event.AddListener(handler);
         }
 
+        public void RemoveListener(UnityAction handler)
+        {
+            _event.RemoveListener(handler);
+        }
+
         public void Invoke()
         {
             MarkInvoked();
@@ -117,6 +122,11 @@ namespace Mirage.Events
 
             // add handler to inner event so that it can be invoked again
             _event.AddListener(handler);
+        }
+
+        public void RemoveListener(UnityAction<T0> handler)
+        {
+            _event.RemoveListener(handler);
         }
 
         public void Invoke(T0 arg0)
@@ -154,6 +164,11 @@ namespace Mirage.Events
 
             // add handler to inner event so that it can be invoked again
             _event.AddListener(handler);
+        }
+
+        public void RemoveListener(UnityAction<T0, T1> handler)
+        {
+            _event.RemoveListener(handler);
         }
 
         public void Invoke(T0 arg0, T1 arg1)

--- a/Assets/Mirage/Runtime/Events/AddLateEventBase.cs
+++ b/Assets/Mirage/Runtime/Events/AddLateEventBase.cs
@@ -13,11 +13,19 @@ namespace Mirage.Events
         }
 
         /// <summary>
-        /// Resets event, removing all listens and allowing it to be invoked again
+        /// Resets invoked flag, meaning new handles wont be invoked untill invoke is called again
+        /// <para>Reset does not remove listeners</para>
         /// </summary>
         public void Reset()
         {
             hasInvoked = false;
+        }
+
+        /// <summary>
+        /// Remove all non-persisent (ie created from script) listeners from the event.
+        /// </summary>
+        public void RemoveAllListeners()
+        {
             baseEvent.RemoveAllListeners();
         }
     }

--- a/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs
+++ b/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs
@@ -1,0 +1,11 @@
+using System;
+using UnityEngine.Events;
+
+namespace Mirage.Events
+{
+    [Serializable]
+    public class BoolUnityEvent : UnityEvent<bool> { }
+
+    [Serializable]
+    public class BoolAddLateEvent : AddLateEvent<bool, BoolUnityEvent> { }
+}

--- a/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs.meta
+++ b/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 343495f6fb762024eb6f72bea967238d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Events/IAddLateEvent.cs
+++ b/Assets/Mirage/Runtime/Events/IAddLateEvent.cs
@@ -11,6 +11,7 @@ namespace Mirage.Events
     public interface IAddLateEvent
     {
         void AddListener(UnityAction handler);
+        void RemoveListener(UnityAction handler);
     }
 
 
@@ -20,6 +21,7 @@ namespace Mirage.Events
     public interface IAddLateEvent<T0>
     {
         void AddListener(UnityAction<T0> handler);
+        void RemoveListener(UnityAction<T0> handler);
     }
 
 
@@ -29,5 +31,6 @@ namespace Mirage.Events
     public interface IAddLateEvent<T0, T1>
     {
         void AddListener(UnityAction<T0, T1> handler);
+        void RemoveListener(UnityAction<T0, T1> handler);
     }
 }

--- a/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs
+++ b/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine.Events;
+
+namespace Mirage.Events
+{
+    /// <summary>
+    /// Event fires from a <see cref="NetworkClient">NetworkClient</see> or <see cref="NetworkServer">NetworkServer</see> during a new connection, a new authentication, or a disconnection.
+    /// <para>INetworkConnection - connection creating the event</para>
+    /// </summary>
+    [Serializable] public class NetworkPlayerEvent : UnityEvent<INetworkPlayer> { }
+
+    [Serializable]
+    public class NetworkPlayerAddLateEvent : AddLateEvent<INetworkPlayer, NetworkPlayerEvent> { }
+}

--- a/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs.meta
+++ b/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db78f722745e5d04aaac46f8aabd0450
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -1,4 +1,4 @@
-using UnityEngine.Events;
+using Mirage.Events;
 
 namespace Mirage
 {
@@ -8,17 +8,17 @@ namespace Mirage
         /// <summary>
         /// Event fires once the Client has connected its Server.
         /// </summary>
-        NetworkConnectionEvent Connected { get; }
+        IAddLateEvent<INetworkPlayer> Connected { get; }
 
         /// <summary>
         /// Event fires after the Client connection has sucessfully been authenticated with its Server.
         /// </summary>
-        NetworkConnectionEvent Authenticated { get; }
+        IAddLateEvent<INetworkPlayer> Authenticated { get; }
 
         /// <summary>
         /// Event fires after the Client has disconnected from its Server and Cleanup has been called.
         /// </summary>
-        UnityEvent Disconnected { get; }
+        IAddLateEvent Disconnected { get; }
 
         /// <summary>
         /// The NetworkConnection object this client is using.

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using UnityEngine.Events;
+using Mirage.Events;
 
 namespace Mirage
 {
@@ -8,7 +8,7 @@ namespace Mirage
         /// <summary>
         /// This is invoked when a server is started - including when a host is started.
         /// </summary>
-        UnityEvent Started { get; }
+        IAddLateEvent Started { get; }
 
         /// <summary>
         /// Event fires once a new Client has connect to the Server.
@@ -25,18 +25,18 @@ namespace Mirage
         /// </summary>
         NetworkConnectionEvent Disconnected { get; }
 
-        UnityEvent Stopped { get; }
+        IAddLateEvent Stopped { get; }
 
         /// <summary>
         /// This is invoked when a host is started.
         /// <para>StartHost has multiple signatures, but they all cause this hook to be called.</para>
         /// </summary>
-        UnityEvent OnStartHost { get; }
+        IAddLateEvent OnStartHost { get; }
 
         /// <summary>
         /// This is called when a host is stopped.
         /// </summary>
-        UnityEvent OnStopHost { get; }
+        IAddLateEvent OnStopHost { get; }
 
         /// <summary>
         /// The connection to the host mode client (if any).

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -13,17 +13,17 @@ namespace Mirage
         /// <summary>
         /// Event fires once a new Client has connect to the Server.
         /// </summary>
-        NetworkConnectionEvent Connected { get; }
+        NetworkPlayerEvent Connected { get; }
 
         /// <summary>
         /// Event fires once a new Client has passed Authentication to the Server.
         /// </summary>
-        NetworkConnectionEvent Authenticated { get; }
+        NetworkPlayerEvent Authenticated { get; }
 
         /// <summary>
         /// Event fires once a Client has Disconnected from the Server.
         /// </summary>
-        NetworkConnectionEvent Disconnected { get; }
+        NetworkPlayerEvent Disconnected { get; }
 
         IAddLateEvent Stopped { get; }
 

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Cysharp.Threading.Tasks;
+using Mirage.Events;
 using Mirage.Logging;
 using UnityEngine;
 using UnityEngine.Events;
@@ -39,26 +40,24 @@ namespace Mirage
         public NetworkAuthenticator authenticator;
 
         [Header("Events")]
+        [SerializeField] NetworkPlayerAddLateEvent _connected = new NetworkPlayerAddLateEvent();
+        [SerializeField] NetworkPlayerAddLateEvent _authenticated = new NetworkPlayerAddLateEvent();
+        [SerializeField] AddLateEvent _disconnected = new AddLateEvent();
+
         /// <summary>
         /// Event fires once the Client has connected its Server.
         /// </summary>
-        [FormerlySerializedAs("Connected")]
-        [SerializeField] NetworkConnectionEvent _connected = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Connected => _connected;
+        public IAddLateEvent<INetworkPlayer> Connected => _connected;
 
         /// <summary>
         /// Event fires after the Client connection has sucessfully been authenticated with its Server.
         /// </summary>
-        [FormerlySerializedAs("Authenticated")]
-        [SerializeField] NetworkConnectionEvent _authenticated = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Authenticated => _authenticated;
+        public IAddLateEvent<INetworkPlayer> Authenticated => _authenticated;
 
         /// <summary>
         /// Event fires after the Client has disconnected from its Server and Cleanup has been called.
         /// </summary>
-        [FormerlySerializedAs("Disconnected")]
-        [SerializeField] UnityEvent _disconnected = new UnityEvent();
-        public UnityEvent Disconnected => _disconnected;
+        public IAddLateEvent Disconnected => _disconnected;
 
         /// <summary>
         /// The NetworkConnection object this client is using.
@@ -212,7 +211,7 @@ namespace Mirage
             // the handler may want to send messages to the client
             // thus we should set the connected state before calling the handler
             connectState = ConnectState.Connected;
-            Connected?.Invoke(Player);
+            _connected.Invoke(Player);
 
             // start processing messages
             try
@@ -227,13 +226,13 @@ namespace Mirage
             {
                 Cleanup();
 
-                Disconnected?.Invoke();
+                _disconnected?.Invoke();
             }
         }
 
         internal void OnAuthenticated(INetworkPlayer player)
         {
-            Authenticated?.Invoke(player);
+            _authenticated.Invoke(player);
         }
 
         /// <summary>
@@ -300,14 +299,11 @@ namespace Mirage
             if (authenticator != null)
             {
                 authenticator.OnClientAuthenticated -= OnAuthenticated;
+            }
 
-                Connected.RemoveListener(authenticator.OnClientAuthenticateInternal);
-            }
-            else
-            {
-                // if no authenticator, consider connection as authenticated
-                Connected.RemoveListener(OnAuthenticated);
-            }
+            _connected.Reset();
+            _authenticated.Reset();
+            _disconnected.Reset();
         }
     }
 }

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -4,17 +4,10 @@ using Cysharp.Threading.Tasks;
 using Mirage.Events;
 using Mirage.Logging;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Mirage
 {
 
-    /// <summary>
-    /// Event fires from a <see cref="NetworkClient">NetworkClient</see> or <see cref="NetworkServer">NetworkServer</see> during a new connection, a new authentication, or a disconnection.
-    /// <para>INetworkConnection - connection creating the event</para>
-    /// </summary>
-    [Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkPlayer> { }
 
     public enum ConnectState
     {

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -55,22 +55,22 @@ namespace Mirage
         /// Event fires once a new Client has connect to the Server.
         /// </summary>
         [FormerlySerializedAs("Connected")]
-        [SerializeField] NetworkConnectionEvent _connected = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Connected => _connected;
+        [SerializeField] NetworkPlayerEvent _connected = new NetworkPlayerEvent();
+        public NetworkPlayerEvent Connected => _connected;
 
         /// <summary>
         /// Event fires once a new Client has passed Authentication to the Server.
         /// </summary>
         [FormerlySerializedAs("Authenticated")]
-        [SerializeField] NetworkConnectionEvent _authenticated = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Authenticated => _authenticated;
+        [SerializeField] NetworkPlayerEvent _authenticated = new NetworkPlayerEvent();
+        public NetworkPlayerEvent Authenticated => _authenticated;
 
         /// <summary>
         /// Event fires once a Client has Disconnected from the Server.
         /// </summary>
         [FormerlySerializedAs("Disconnected")]
-        [SerializeField] NetworkConnectionEvent _disconnected = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Disconnected => _disconnected;
+        [SerializeField] NetworkPlayerEvent _disconnected = new NetworkPlayerEvent();
+        public NetworkPlayerEvent Disconnected => _disconnected;
 
         [SerializeField] AddLateEvent _stopped = new AddLateEvent();
         public IAddLateEvent Stopped => _stopped;

--- a/Assets/Tests/Runtime/Host/HostSetup.cs
+++ b/Assets/Tests/Runtime/Host/HostSetup.cs
@@ -79,7 +79,6 @@ namespace Mirage.Tests.Runtime.Host
             manager.Server.StartHost(client).Forget();
 
             await completionSource.Task;
-            server.Started.RemoveListener(Started);
         }
 
         public virtual void ExtraTearDown() { }

--- a/doc/Articles/Guides/GameObjects/Lifecycle.md
+++ b/doc/Articles/Guides/GameObjects/Lifecycle.md
@@ -72,7 +72,7 @@ Immediatelly after the object is instantiated, all the data is updated to match 
 
 # Client Start Authority
 
-If the object is owned by this client, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnStartAuthority>
+If the object is owned by this client, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnAuthorityChanged>
 Subscribe to this event either by using `AddListener`,  or adding your method to the event in the inspector.
 Note the Authority can be revoked, and granted again.  Every time the client gains authority, this event will be invoked again.
 
@@ -89,7 +89,7 @@ Subscribe to this event by using `AddListener` or adding your method in the even
 
 # Stop Authority
 
-If the object loses authority over the object, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnStopAuthority>
+If the object loses authority over the object, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnAuthorityChanged>
 Subscribe to this event either by using `AddListener`,  or adding your method to the event in the inspector.
 Note the Authority can be revoked, and granted again.  Every time the client loses authority, this event will be invoked again.
 

--- a/doc/Articles/Guides/MirrorMigration.md
+++ b/doc/Articles/Guides/MirrorMigration.md
@@ -124,8 +124,8 @@ Table below shows the Mirror's `NetworkBehaviour` override method names on the l
 | `OnStartClient`        | [NetIdentity.OnStartClient](xref:Mirage.NetworkIdentity.OnStartClient)            |
 | `OnStopClient`         | [NetIdentity.OnStopClient](xref:Mirage.NetworkIdentity.OnStopClient)              |
 | `OnStartLocalPlayer`   | [NetIdentity.OnStartLocalPlayer](xref:Mirage.NetworkIdentity.OnStartLocalPlayer)  |
-| `OnStartAuthority`     | [NetIdentity.OnStartAuthority](xref:Mirage.NetworkIdentity.OnStartAuthority)      |
-| `OnStopAuthority`      | [NetIdentity.OnStopAuthority](xref:Mirage.NetworkIdentity.OnStopAuthority)        |
+| `OnStartAuthority`     | [NetIdentity.OnAuthorityChanged](xref:Mirage.NetworkIdentity.OnAuthorityChanged)      |
+| `OnStopAuthority`      | [NetIdentity.OnAuthorityChanged](xref:Mirage.NetworkIdentity.OnAuthorityChanged)        |
 
 Let's take this `Player` class as an example. In Mirror, you would do:
 


### PR DESCRIPTION
public event now uses IAddLateEvent, this should not effect how existing events are added via code.

BREAKING CHANGE:
- Server.Started event is now type of IAddLateEvent
- Server.Stoped event is now type of IAddLateEvent
- Server.OnStartHost event is now type of IAddLateEvent
- Server.OnStopHost event is now type of IAddLateEvent
- inspector values for changed events will need to be re-assigned
- Identity.OnStartServer event is now type of IAddLateEvent
- Identity.OnStopServer event is now type of IAddLateEvent
- Identity.OnStartClient event is now type of IAddLateEvent
- Identity.OnStopClient event is now type of IAddLateEvent
- Identity.OnStartLocalPlayer event is now type of IAddLateEvent
- Identity.OnStartAuthority and IdentityOnStopAuthority are now Identity.OnAuthorityChanged and are type of IAddLateEvent<bool>