### PR TITLE
feat: configurable wait time for tests

### DIFF
--- a/Assets/Tests/Common/AsyncUtil.cs
+++ b/Assets/Tests/Common/AsyncUtil.cs
@@ -11,7 +11,12 @@ namespace Mirage.Tests
 
         public static UniTask WaitUntilWithTimeout(Func<bool> predicate)
         {
-            return UniTask.WaitUntil(predicate).Timeout(TimeSpan.FromSeconds(2));
+            return WaitUntilWithTimeout(predicate, 2);
+        }
+
+        public static UniTask WaitUntilWithTimeout(Func<bool> predicate, double seconds)
+        {
+            return UniTask.WaitUntil(predicate).Timeout(TimeSpan.FromSeconds(seconds));
         }
 
         // Unity's nunit does not support async tests

--- a/Assets/Tests/Common/AsyncUtil.cs
+++ b/Assets/Tests/Common/AsyncUtil.cs
@@ -9,12 +9,7 @@ namespace Mirage.Tests
     public static class AsyncUtil
     {
 
-        public static UniTask WaitUntilWithTimeout(Func<bool> predicate)
-        {
-            return WaitUntilWithTimeout(predicate, 2);
-        }
-
-        public static UniTask WaitUntilWithTimeout(Func<bool> predicate, double seconds)
+        public static UniTask WaitUntilWithTimeout(Func<bool> predicate, double seconds = 2)
         {
             return UniTask.WaitUntil(predicate).Timeout(TimeSpan.FromSeconds(seconds));
         }


### PR DESCRIPTION
this came up when trying to write a test that depends on the client being disconnected after failing to connect. That process takes longer than the allowed 2 seconds.