### PR TITLE
fix: make sure resolved typedef isn't null

### DIFF
--- a/Assets/Mirage/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncObjectProcessor.cs
@@ -37,7 +37,7 @@ namespace Mirage.Weaver
                 }
 
                 TypeDefinition tf = fd.FieldType.Resolve();
-                if (fd.FieldType.Resolve() == null)
+                if (tf == null)
                 {
                     continue;
                 }

--- a/Assets/Mirage/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncObjectProcessor.cs
@@ -36,7 +36,13 @@ namespace Mirage.Weaver
                     continue;
                 }
 
-                if (fd.FieldType.Resolve().ImplementsInterface<ISyncObject>())
+                TypeDefinition tf = fd.FieldType.Resolve();
+                if (fd.FieldType.Resolve() == null)
+                {
+                    continue;
+                }
+
+                if (tf.ImplementsInterface<ISyncObject>())
                 {
                     if (fd.IsStatic)
                     {


### PR DESCRIPTION
fix support for Unity 2021.1