### PR TITLE
refactor: make mirage engine agnostic free

### DIFF
--- a/Assets/Mirage/Runtime/Entity.meta
+++ b/Assets/Mirage/Runtime/Entity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33c140cd1a248074ea21c82b8f087b9d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Entity/IComponentDesigner.cs
+++ b/Assets/Mirage/Runtime/Entity/IComponentDesigner.cs
@@ -1,0 +1,12 @@
+namespace Mirage.Components
+{
+    public interface IComponentDesigner<out T>
+    {
+        /// <summary>
+        ///     Create new instance of specific component to allow usage of
+        ///     base class files of mirage to be more generic and agnostic free.
+        /// </summary>
+        /// <returns></returns>
+        public T CreateComponentInstance();
+    }
+}

--- a/Assets/Mirage/Runtime/Entity/IComponentDesigner.cs.meta
+++ b/Assets/Mirage/Runtime/Entity/IComponentDesigner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25f91599474c0dc4f99392a95c5dd57c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Entity/INetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/Entity/INetworkBehaviour.cs
@@ -1,0 +1,6 @@
+namespace Mirage.Entity
+{
+    public interface INetworkBehaviour
+    {
+    }
+}

--- a/Assets/Mirage/Runtime/Entity/INetworkBehaviour.cs.meta
+++ b/Assets/Mirage/Runtime/Entity/INetworkBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6847e4251737278449ebe292316a2720
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Entity/INetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/Entity/INetworkIdentity.cs
@@ -1,0 +1,10 @@
+namespace Mirage.Entity
+{
+    public interface INetworkIdentity
+    {
+        /// <summary>
+        ///     Network identity id.
+        /// </summary>
+        public uint NetId { get; }
+    }
+}

--- a/Assets/Mirage/Runtime/Entity/INetworkIdentity.cs.meta
+++ b/Assets/Mirage/Runtime/Entity/INetworkIdentity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb31a759bef5d77498629bc2a8d33fa7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Entity/INetworkObject.cs
+++ b/Assets/Mirage/Runtime/Entity/INetworkObject.cs
@@ -1,0 +1,10 @@
+namespace Mirage.Entity
+{
+    public interface INetworkObject
+    {
+        /// <summary>
+        ///     Network object identifier.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/Assets/Mirage/Runtime/Entity/INetworkObject.cs.meta
+++ b/Assets/Mirage/Runtime/Entity/INetworkObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0097e339741f02e40bb95c57c0004227
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Entity/MirageBaseComponent.cs
+++ b/Assets/Mirage/Runtime/Entity/MirageBaseComponent.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace Mirage.Components
+{
+    public abstract class MirageBaseComponent<T> : MonoBehaviour, IComponentDesigner<T> where T : new()
+    {
+        /// <summary>
+        ///     Convenient access to the type of component this component references. 
+        /// </summary>
+        protected internal T ComponentType;
+
+        /// <summary>
+        ///     Make sure to call base to this awake otherwise you need to manually call
+        ///     see <see cref="IComponentDesigner{T}.CreateComponentInstance"/> to allow correct
+        ///     initialization of these components.
+        /// </summary>
+        protected virtual void Awake()
+        {
+            CreateComponentInstance();
+        }
+
+        #region Implementation of IComponentDesigner<out T>
+
+        public T CreateComponentInstance()
+        {
+            ComponentType = new T();
+
+            return ComponentType;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Mirage/Runtime/Entity/MirageBaseComponent.cs.meta
+++ b/Assets/Mirage/Runtime/Entity/MirageBaseComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fad1547b80a9f4e47b0f766338221383
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Entity/NetworkBehaviourComponent.cs
+++ b/Assets/Mirage/Runtime/Entity/NetworkBehaviourComponent.cs
@@ -1,0 +1,9 @@
+using Mirage;
+using Mirage.Components;
+
+namespace Assets.Mirage.Runtime.Entity
+{
+    public class NetworkBehaviourComponent : MirageBaseComponent<NetworkBehaviour>
+    {
+    }
+}

--- a/Assets/Mirage/Runtime/Entity/NetworkBehaviourComponent.cs.meta
+++ b/Assets/Mirage/Runtime/Entity/NetworkBehaviourComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f17a5845086d104da4c0bd99bdd9ae4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using Mirage.Collections;
+using Mirage.Entity;
 using Mirage.Logging;
 using Mirage.RemoteCalls;
 using Mirage.Serialization;
@@ -24,7 +25,7 @@ namespace Mirage
     /// </remarks>
     [AddComponentMenu("")]
     [HelpURL("https://miragenet.github.io/Mirage/Articles/Guides/GameObjects/NetworkBehaviour.html")]
-    public abstract class NetworkBehaviour : MonoBehaviour
+    public class NetworkBehaviour : INetworkBehaviour
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkBehaviour));
 


### PR DESCRIPTION
This will be draft pr to hopefully show off engine specific only code and to allow mirage to break free and create network code to be used in any other engine or even .net core hopefully.

Create / Design new Networkbehaviour component.
Create / Design new NetworkIdentity component.