### PR TITLE
refactor: mirage will no longer set scene objects to disabled

### DIFF
--- a/Assets/Mirage/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirage/Editor/NetworkScenePostProcess.cs
@@ -67,8 +67,6 @@ namespace Mirage
             // set scene hash
             identity.SetSceneIdSceneHashPartInternal();
 
-            identity.gameObject.SetActive(false);
-
             // safety check for prefabs with more than one NetworkIdentity
             GameObject prefabGO = PrefabUtility.GetCorrespondingObjectFromSource(identity.gameObject);
 

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -714,7 +714,6 @@ namespace Mirage
                 if (ValidateSceneObject(identity))
                 {
                     if (logger.LogEnabled()) logger.Log("SpawnObjects sceneId:" + identity.sceneId.ToString("X") + " name:" + identity.gameObject.name);
-                    identity.gameObject.SetActive(true);
 
                     Spawn(identity.gameObject);
                 }

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -694,8 +694,7 @@ namespace Mirage
         /// <summary>
         /// This causes NetworkIdentity objects in a scene to be spawned on a server.
         /// <para>
-        ///     NetworkIdentity objects in a scene are disabled by default.
-        ///     Calling SpawnObjects() causes these scene objects to be enabled and spawned.
+        ///     Calling SpawnObjects() causes all scene objects to be spawned.
         ///     It is like calling NetworkServer.Spawn() for each of them.
         /// </para>
         /// </summary>

--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -88,7 +88,7 @@ namespace Mirage.Tests.Runtime.ClientServer
             serverIdentity.sceneId = 42;
             serverIdentity.gameObject.SetActive(false);
             serverObjectManager.SpawnObjects();
-            Assert.That(serverIdentity.gameObject.activeSelf, Is.True);
+            Assert.That(serverIdentity.gameObject.activeSelf, Is.False);
         }
 
         [Test]


### PR DESCRIPTION
fixes: #609 

BREAKING: Mirage will no longer set Scene Objects to disabled as part of NetworkScenePostProcessing (this happens when you save in editor or change scene at runtime)

From comments:
I did a test solution comparing the current vs not doing the disable/enable with NetworkScenePostProcess and ServerObjectManager.

I used the ChangeScene example. In Room1 and Room2 I added 1000 SceneObjects. I ran the server in server only mode. I put a Stopwatch at the start and end of SpawnObjects().

Current: 24-26ms scene changes
Dont Disable: 17-19ms scene changes

roughly 30% faster