### PR TITLE
fix: using add late event for authority and combining start and stop events

### DIFF
--- a/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs
+++ b/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs
@@ -1,0 +1,11 @@
+using System;
+using UnityEngine.Events;
+
+namespace Mirage.Events
+{
+    [Serializable]
+    public class BoolUnityEvent : UnityEvent<bool> { }
+
+    [Serializable]
+    public class BoolAddLateEvent : AddLateEvent<bool, BoolUnityEvent> { }
+}

--- a/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs.meta
+++ b/Assets/Mirage/Runtime/Events/BoolAddLateEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 343495f6fb762024eb6f72bea967238d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/doc/Articles/Guides/GameObjects/Lifecycle.md
+++ b/doc/Articles/Guides/GameObjects/Lifecycle.md
@@ -72,7 +72,7 @@ Immediatelly after the object is instantiated, all the data is updated to match 
 
 # Client Start Authority
 
-If the object is owned by this client, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnStartAuthority>
+If the object is owned by this client, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnAuthorityChanged>
 Subscribe to this event either by using `AddListener`,  or adding your method to the event in the inspector.
 Note the Authority can be revoked, and granted again.  Every time the client gains authority, this event will be invoked again.
 
@@ -89,7 +89,7 @@ Subscribe to this event by using `AddListener` or adding your method in the even
 
 # Stop Authority
 
-If the object loses authority over the object, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnStopAuthority>
+If the object loses authority over the object, then NetworkIdentity will invoke the <xref:Mirage.NetworkIdentity.OnAuthorityChanged>
 Subscribe to this event either by using `AddListener`,  or adding your method to the event in the inspector.
 Note the Authority can be revoked, and granted again.  Every time the client loses authority, this event will be invoked again.
 

--- a/doc/Articles/Guides/MirrorMigration.md
+++ b/doc/Articles/Guides/MirrorMigration.md
@@ -124,8 +124,8 @@ Table below shows the Mirror's `NetworkBehaviour` override method names on the l
 | `OnStartClient`        | [NetIdentity.OnStartClient](xref:Mirage.NetworkIdentity.OnStartClient)            |
 | `OnStopClient`         | [NetIdentity.OnStopClient](xref:Mirage.NetworkIdentity.OnStopClient)              |
 | `OnStartLocalPlayer`   | [NetIdentity.OnStartLocalPlayer](xref:Mirage.NetworkIdentity.OnStartLocalPlayer)  |
-| `OnStartAuthority`     | [NetIdentity.OnStartAuthority](xref:Mirage.NetworkIdentity.OnStartAuthority)      |
-| `OnStopAuthority`      | [NetIdentity.OnStopAuthority](xref:Mirage.NetworkIdentity.OnStopAuthority)        |
+| `OnStartAuthority`     | [NetIdentity.OnAuthorityChanged](xref:Mirage.NetworkIdentity.OnAuthorityChanged)      |
+| `OnStopAuthority`      | [NetIdentity.OnAuthorityChanged](xref:Mirage.NetworkIdentity.OnAuthorityChanged)        |
 
 Let's take this `Player` class as an example. In Mirror, you would do:
 


### PR DESCRIPTION
requires: https://github.com/MirageNet/Mirage/pull/766

BREAKING CHANGE:
- Identity.OnStartAuthority and IdentityOnStopAuthority are now Identity.OnAuthorityChanged and are type of IAddLateEvent<bool>