### PR TITLE
fix: using AddLateEvent to stop race condition for client events 

### DIFF
--- a/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs
+++ b/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine.Events;
+
+namespace Mirage.Events
+{
+    /// <summary>
+    /// Event fires from a <see cref="NetworkClient">NetworkClient</see> or <see cref="NetworkServer">NetworkServer</see> during a new connection, a new authentication, or a disconnection.
+    /// <para>INetworkConnection - connection creating the event</para>
+    /// </summary>
+    [Serializable] public class NetworkPlayerEvent : UnityEvent<INetworkPlayer> { }
+
+    [Serializable]
+    public class NetworkPlayerAddLateEvent : AddLateEvent<INetworkPlayer, NetworkPlayerEvent> { }
+}

--- a/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs.meta
+++ b/Assets/Mirage/Runtime/Events/NetworkPlayerAddLateEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db78f722745e5d04aaac46f8aabd0450
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -1,4 +1,4 @@
-using UnityEngine.Events;
+using Mirage.Events;
 
 namespace Mirage
 {
@@ -8,17 +8,17 @@ namespace Mirage
         /// <summary>
         /// Event fires once the Client has connected its Server.
         /// </summary>
-        NetworkConnectionEvent Connected { get; }
+        IAddLateEvent<INetworkPlayer> Connected { get; }
 
         /// <summary>
         /// Event fires after the Client connection has sucessfully been authenticated with its Server.
         /// </summary>
-        NetworkConnectionEvent Authenticated { get; }
+        IAddLateEvent<INetworkPlayer> Authenticated { get; }
 
         /// <summary>
         /// Event fires after the Client has disconnected from its Server and Cleanup has been called.
         /// </summary>
-        UnityEvent Disconnected { get; }
+        IAddLateEvent Disconnected { get; }
 
         /// <summary>
         /// The NetworkConnection object this client is using.

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -13,17 +13,17 @@ namespace Mirage
         /// <summary>
         /// Event fires once a new Client has connect to the Server.
         /// </summary>
-        NetworkConnectionEvent Connected { get; }
+        NetworkPlayerEvent Connected { get; }
 
         /// <summary>
         /// Event fires once a new Client has passed Authentication to the Server.
         /// </summary>
-        NetworkConnectionEvent Authenticated { get; }
+        NetworkPlayerEvent Authenticated { get; }
 
         /// <summary>
         /// Event fires once a Client has Disconnected from the Server.
         /// </summary>
-        NetworkConnectionEvent Disconnected { get; }
+        NetworkPlayerEvent Disconnected { get; }
 
         IAddLateEvent Stopped { get; }
 

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Cysharp.Threading.Tasks;
+using Mirage.Events;
 using Mirage.Logging;
 using UnityEngine;
 using UnityEngine.Events;
@@ -39,26 +40,24 @@ namespace Mirage
         public NetworkAuthenticator authenticator;
 
         [Header("Events")]
+        [SerializeField] NetworkPlayerAddLateEvent _connected = new NetworkPlayerAddLateEvent();
+        [SerializeField] NetworkPlayerAddLateEvent _authenticated = new NetworkPlayerAddLateEvent();
+        [SerializeField] AddLateEvent _disconnected = new AddLateEvent();
+
         /// <summary>
         /// Event fires once the Client has connected its Server.
         /// </summary>
-        [FormerlySerializedAs("Connected")]
-        [SerializeField] NetworkConnectionEvent _connected = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Connected => _connected;
+        public IAddLateEvent<INetworkPlayer> Connected => _connected;
 
         /// <summary>
         /// Event fires after the Client connection has sucessfully been authenticated with its Server.
         /// </summary>
-        [FormerlySerializedAs("Authenticated")]
-        [SerializeField] NetworkConnectionEvent _authenticated = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Authenticated => _authenticated;
+        public IAddLateEvent<INetworkPlayer> Authenticated => _authenticated;
 
         /// <summary>
         /// Event fires after the Client has disconnected from its Server and Cleanup has been called.
         /// </summary>
-        [FormerlySerializedAs("Disconnected")]
-        [SerializeField] UnityEvent _disconnected = new UnityEvent();
-        public UnityEvent Disconnected => _disconnected;
+        public IAddLateEvent Disconnected => _disconnected;
 
         /// <summary>
         /// The NetworkConnection object this client is using.
@@ -212,7 +211,7 @@ namespace Mirage
             // the handler may want to send messages to the client
             // thus we should set the connected state before calling the handler
             connectState = ConnectState.Connected;
-            Connected?.Invoke(Player);
+            _connected.Invoke(Player);
 
             // start processing messages
             try
@@ -227,13 +226,13 @@ namespace Mirage
             {
                 Cleanup();
 
-                Disconnected?.Invoke();
+                _disconnected?.Invoke();
             }
         }
 
         internal void OnAuthenticated(INetworkPlayer player)
         {
-            Authenticated?.Invoke(player);
+            _authenticated.Invoke(player);
         }
 
         /// <summary>
@@ -300,14 +299,11 @@ namespace Mirage
             if (authenticator != null)
             {
                 authenticator.OnClientAuthenticated -= OnAuthenticated;
+            }
 
-                Connected.RemoveListener(authenticator.OnClientAuthenticateInternal);
-            }
-            else
-            {
-                // if no authenticator, consider connection as authenticated
-                Connected.RemoveListener(OnAuthenticated);
-            }
+            _connected.Reset();
+            _authenticated.Reset();
+            _disconnected.Reset();
         }
     }
 }

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -4,17 +4,10 @@ using Cysharp.Threading.Tasks;
 using Mirage.Events;
 using Mirage.Logging;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Mirage
 {
 
-    /// <summary>
-    /// Event fires from a <see cref="NetworkClient">NetworkClient</see> or <see cref="NetworkServer">NetworkServer</see> during a new connection, a new authentication, or a disconnection.
-    /// <para>INetworkConnection - connection creating the event</para>
-    /// </summary>
-    [Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkPlayer> { }
 
     public enum ConnectState
     {

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -292,6 +292,12 @@ namespace Mirage
             if (authenticator != null)
             {
                 authenticator.OnClientAuthenticated -= OnAuthenticated;
+                Connected.RemoveListener(authenticator.OnClientAuthenticateInternal);
+            }
+            else
+            {
+                // if no authenticator, consider connection as authenticated
+                Connected.RemoveListener(OnAuthenticated);
             }
 
             _connected.Reset();

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -55,22 +55,22 @@ namespace Mirage
         /// Event fires once a new Client has connect to the Server.
         /// </summary>
         [FormerlySerializedAs("Connected")]
-        [SerializeField] NetworkConnectionEvent _connected = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Connected => _connected;
+        [SerializeField] NetworkPlayerEvent _connected = new NetworkPlayerEvent();
+        public NetworkPlayerEvent Connected => _connected;
 
         /// <summary>
         /// Event fires once a new Client has passed Authentication to the Server.
         /// </summary>
         [FormerlySerializedAs("Authenticated")]
-        [SerializeField] NetworkConnectionEvent _authenticated = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Authenticated => _authenticated;
+        [SerializeField] NetworkPlayerEvent _authenticated = new NetworkPlayerEvent();
+        public NetworkPlayerEvent Authenticated => _authenticated;
 
         /// <summary>
         /// Event fires once a Client has Disconnected from the Server.
         /// </summary>
         [FormerlySerializedAs("Disconnected")]
-        [SerializeField] NetworkConnectionEvent _disconnected = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Disconnected => _disconnected;
+        [SerializeField] NetworkPlayerEvent _disconnected = new NetworkPlayerEvent();
+        public NetworkPlayerEvent Disconnected => _disconnected;
 
         [SerializeField] AddLateEvent _stopped = new AddLateEvent();
         public IAddLateEvent Stopped => _stopped;


### PR DESCRIPTION
requires: https://github.com/MirageNet/Mirage/pull/764

public event now uses IAddLateEvent, this should not effect how existing events are added via code.

BREAKING CHANGE:
- NetworkClient.Connected event is now type of IAddLateEvent
- NetworkClient.Authenticated event is now type of IAddLateEvent
- NetworkClient.Disconnected event is now type of IAddLateEvent
- NetworkConnectionEvent renamed to NetworkPlayerEvent