### PR TITLE
refactor: remove duplicated ref to player can be accessed from client

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -510,7 +510,7 @@ namespace Mirage
 
         void CheckForLocalPlayer(NetworkIdentity identity)
         {
-            if (identity && identity == Client.Player.Identity)
+            if (identity && identity == Client.Player?.Identity)
             {
                 // Set isLocalPlayer to true on this NetworkIdentity and trigger OnStartLocalPlayer in all scripts on the same GO
                 identity.StartLocalPlayer();

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -26,11 +26,6 @@ namespace Mirage
         internal readonly Dictionary<Guid, SpawnHandlerDelegate> spawnHandlers = new Dictionary<Guid, SpawnHandlerDelegate>();
         internal readonly Dictionary<Guid, UnSpawnDelegate> unspawnHandlers = new Dictionary<Guid, UnSpawnDelegate>();
 
-        /// <summary>
-        /// NetworkIdentity of the localPlayer
-        /// </summary>
-        public NetworkIdentity LocalPlayer => Client.Player?.Identity;
-
         [Header("Prefabs")]
         /// <summary>
         /// List of prefabs that will be registered with the spawning system.

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -510,7 +510,7 @@ namespace Mirage
 
         void CheckForLocalPlayer(NetworkIdentity identity)
         {
-            if (identity && identity == LocalPlayer)
+            if (identity && identity == Client.Player.Identity)
             {
                 // Set isLocalPlayer to true on this NetworkIdentity and trigger OnStartLocalPlayer in all scripts on the same GO
                 identity.StartLocalPlayer();

--- a/Assets/Mirage/Runtime/IClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/IClientObjectManager.cs
@@ -13,11 +13,6 @@ namespace Mirage
 
     public interface IClientObjectManager
     {
-        /// <summary>
-        /// NetworkIdentity of the localPlayer
-        /// </summary>
-        NetworkIdentity LocalPlayer { get; }
-
         NetworkIdentity GetPrefab(Guid assetId);
 
         void RegisterPrefab(NetworkIdentity identity);

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -134,7 +134,7 @@ namespace Mirage
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool IsLocalPlayer => ClientObjectManager != null && ClientObjectManager.LocalPlayer == this;
+        public bool IsLocalPlayer => Client != null && Client.Player.Identity == this;
 
         /// <summary>
         /// This returns true if this object is the authoritative player object on the client.

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -134,7 +134,7 @@ namespace Mirage
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool IsLocalPlayer => Client != null && Client.Player.Identity == this;
+        public bool IsLocalPlayer => Client != null && Client.Player?.Identity == this;
 
         /// <summary>
         /// This returns true if this object is the authoritative player object on the client.

--- a/Assets/Mirage/Samples~/Tanks/Scripts/TankGameManager.cs
+++ b/Assets/Mirage/Samples~/Tanks/Scripts/TankGameManager.cs
@@ -146,10 +146,10 @@ namespace Mirage.Examples.Tanks
         void FindLocalTank()
         {
             //Check to see if the player is loaded in yet
-            if (NetworkManager.ClientObjectManager.LocalPlayer == null)
+            if (NetworkManager.Client.Player == null)
                 return;
 
-            LocalPlayer = NetworkManager.ClientObjectManager.LocalPlayer.GetComponent<Tank>();
+            LocalPlayer = NetworkManager.Client.Player.Identity.GetComponent<Tank>();
         }
 
         void UpdateStats()

--- a/doc/Articles/Guides/MirrorMigration.md
+++ b/doc/Articles/Guides/MirrorMigration.md
@@ -181,7 +181,7 @@ These fields/properties have been renamed:
 
 | Mirror                                | Mirage                                                                                 |
 |:-------------------------------------:|:--------------------------------------------------------------------------------------:|
-| `ClientScene.localPlayer`             | [Client.Player.Identity](xref:Mirage.NetworkClient.Player.Identity)                    |
+| `ClientScene.localPlayer`             | [NetworkPlayer.Identity](xref:Mirage.NetworkPlayer.Identity)             |
 | `ClientScene.ready`                   | [NetworkClient.Connection.IsReady](xref:Mirage.NetworkPlayer.IsReady)                  |
 | `NetworkIdentity.assetId`             | [NetworkIdentity.AssetId](xref:Mirage.NetworkIdentity.AssetId)                         |
 | `NetworkIdentity.netId`               | [NetworkIdentity.NetId](xref:Mirage.NetworkIdentity.NetId)                             |

--- a/doc/Articles/Guides/MirrorMigration.md
+++ b/doc/Articles/Guides/MirrorMigration.md
@@ -181,7 +181,7 @@ These fields/properties have been renamed:
 
 | Mirror                                | Mirage                                                                                 |
 |:-------------------------------------:|:--------------------------------------------------------------------------------------:|
-| `ClientScene.localPlayer`             | [ClientObjectManager.LocalPlayer](xref:Mirage.ClientObjectManager.LocalPlayer)         |
+| `ClientScene.localPlayer`             | [Client.Player.Identity](xref:Mirage.NetworkClient.Player.Identity)                    |
 | `ClientScene.ready`                   | [NetworkClient.Connection.IsReady](xref:Mirage.NetworkPlayer.IsReady)                  |
 | `NetworkIdentity.assetId`             | [NetworkIdentity.AssetId](xref:Mirage.NetworkIdentity.AssetId)                         |
 | `NetworkIdentity.netId`               | [NetworkIdentity.NetId](xref:Mirage.NetworkIdentity.NetId)                             |


### PR DESCRIPTION
There was multiple ways of getting the same information and while that can be useful it can also be confusing to new users. It also provides opportunities that some values may not be set at all or in the correct order. Do you think the reduction in API redundancy and size is a good thing?

BREAKING

Old: ClientObjectManager.LocalPlayer
New: Client.Player.Identity    (note: this worked before the change too)