### PR TITLE
refactor: removing GetNewPlayer and sealing networkplayer

### DIFF
--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -141,7 +141,7 @@ namespace Mirage
                 InitializeAuthEvents();
 
                 // setup all the handlers
-                Player = GetNewPlayer(transportConnection);
+                Player = new NetworkPlayer(transportConnection);
                 Time.Reset();
 
                 RegisterMessageHandlers();
@@ -168,18 +168,10 @@ namespace Mirage
 
             server.SetLocalConnection(this, c2);
             IsLocalClient = true;
-            Player = GetNewPlayer(c1);
+            Player = new NetworkPlayer(c1);
             RegisterHostHandlers();
 
             OnConnected().Forget();
-        }
-
-        /// <summary>
-        /// Creates a new INetworkConnection based on the provided IConnection.
-        /// </summary>
-        public virtual INetworkPlayer GetNewPlayer(IConnection connection)
-        {
-            return new NetworkPlayer(connection);
         }
 
         void InitializeAuthEvents()

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -25,7 +25,7 @@ namespace Mirage
     /// <para>NetworkConnection objects also act as observers for networked objects. When a connection is an observer of a networked object with a NetworkIdentity, then the object will be visible to corresponding client for the connection, and incremental state changes will be sent to the client.</para>
     /// <para>There are many virtual functions on NetworkConnection that allow its behaviour to be customized. NetworkClient and NetworkServer can both be made to instantiate custom classes derived from NetworkConnection by setting their networkConnectionClass member variable.</para>
     /// </remarks>
-    public class NetworkPlayer : INetworkPlayer
+    public sealed class NetworkPlayer : INetworkPlayer
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkPlayer));
 
@@ -65,7 +65,7 @@ namespace Mirage
         /// The IP address / URL / FQDN associated with the connection.
         /// Can be useful for a game master to do IP Bans etc.
         /// </summary>
-        public virtual EndPoint Address => connection.GetEndPointAddress();
+        public EndPoint Address => connection.GetEndPointAddress();
 
         public IConnection Connection => connection;
 
@@ -183,7 +183,7 @@ namespace Mirage
         /// <param name="msg">The message to send.</param>
         /// <param name="channelId">The transport layer channel to send on.</param>
         /// <returns></returns>
-        public virtual void Send<T>(T message, int channelId = Channel.Reliable)
+        public void Send<T>(T message, int channelId = Channel.Reliable)
         {
             using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
             {

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -224,7 +224,7 @@ namespace Mirage
 
         private void TransportConnected(IConnection connection)
         {
-            INetworkPlayer networkConnectionToClient = GetNewPlayer(connection);
+            var networkConnectionToClient = new NetworkPlayer(connection);
             ConnectionAcceptedAsync(networkConnectionToClient).Forget();
         }
 
@@ -292,14 +292,6 @@ namespace Mirage
         }
 
         /// <summary>
-        /// Creates a new INetworkConnection based on the provided IConnection.
-        /// </summary>
-        public virtual INetworkPlayer GetNewPlayer(IConnection connection)
-        {
-            return new NetworkPlayer(connection);
-        }
-
-        /// <summary>
         /// <para>This accepts a network connection and adds it to the server.</para>
         /// <para>This connection will use the callbacks registered with the server.</para>
         /// </summary>
@@ -328,15 +320,15 @@ namespace Mirage
         /// called by LocalClient to add itself. dont call directly.
         /// </summary>
         /// <param name="client">The local client</param>
-        /// <param name="tconn">The connection to the client</param>
-        internal void SetLocalConnection(INetworkClient client, IConnection tconn)
+        /// <param name="connection">The connection to the client</param>
+        internal void SetLocalConnection(INetworkClient client, IConnection connection)
         {
             if (LocalPlayer != null)
             {
                 throw new InvalidOperationException("Local Connection already exists");
             }
 
-            INetworkPlayer player = GetNewPlayer(tconn);
+            var player = new NetworkPlayer(connection);
             LocalPlayer = player;
             LocalClient = client;
 

--- a/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
@@ -118,12 +118,6 @@ namespace Mirage.Tests.Runtime.ClientServer
         }
 
         [Test]
-        public void GetNewConnectionTest()
-        {
-            Assert.That(server.GetNewPlayer(Substitute.For<IConnection>()), Is.Not.Null);
-        }
-
-        [Test]
         public void VariableTest()
         {
             Assert.That(server.MaxConnections, Is.EqualTo(4));

--- a/Assets/Tests/Runtime/Host/NetworkClientTest.cs
+++ b/Assets/Tests/Runtime/Host/NetworkClientTest.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using Cysharp.Threading.Tasks;
-using NSubstitute;
 using NUnit.Framework;
 using UnityEngine.TestTools;
 
@@ -19,12 +18,6 @@ namespace Mirage.Tests.Runtime.Host
         public void ConnectionTest()
         {
             Assert.That(client.Player != null);
-        }
-
-        [Test]
-        public void GetNewConnectionTest()
-        {
-            Assert.That(client.GetNewPlayer(Substitute.For<IConnection>()), Is.Not.Null);
         }
 
         [UnityTest]

--- a/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
@@ -80,13 +80,13 @@ namespace Mirage.Tests.Runtime.Host
         {
             // add connection
 
-            NetworkPlayer connectionToClient = Substitute.For<NetworkPlayer>(Substitute.For<IConnection>());
+            INetworkPlayer player = Substitute.For<INetworkPlayer>();
 
             NetworkIdentity identity = new GameObject().AddComponent<NetworkIdentity>();
 
-            serverObjectManager.HideForConnection(identity, connectionToClient);
+            serverObjectManager.HideForConnection(identity, player);
 
-            connectionToClient.Received().Send(Arg.Is<ObjectHideMessage>(msg => msg.netId == identity.NetId));
+            player.Received().Send(Arg.Is<ObjectHideMessage>(msg => msg.netId == identity.NetId));
 
             // destroy GO after shutdown, otherwise isServer is true in OnDestroy and it tries to call
             // GameObject.Destroy (but we need DestroyImmediate in Editor)


### PR DESCRIPTION
mirage should have full control over networkplayer

BREAKING CHANGE: it is no longer possible to create custom INetworkPlayer to be used inside mirage