### PR TITLE
refactor: remove internal method as replace is no longer virtual

### DIFF
--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -258,11 +258,11 @@ namespace Mirage.Tests.Runtime.ClientServer
         }
 
         [Test]
-        public void InternalReplacePlayerNoIdentityExceptionTest()
+        public void ReplacePlayerNoIdentityExceptionTest()
         {
             Assert.Throws<ArgumentException>(() =>
             {
-                serverObjectManager.InternalReplacePlayerForConnection(connectionToClient, new GameObject(), true);
+                serverObjectManager.ReplaceCharacter(connectionToClient, new GameObject(), true);
             });
         }
 


### PR DESCRIPTION
In the past ReplaceCharacter was virtual so it's functionality could be changed. That has not been the case for a while so the actual logic being in another internal call is not adding value.