### PR TITLE
feat: add optional imgui support to network manager hud

### DIFF
--- a/Assets/Mirage/Runtime/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Runtime/NetworkManagerGUI.cs
@@ -1,0 +1,183 @@
+using System.Collections;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace Mirage
+{
+    public class NetworkManagerGUI : MonoBehaviour
+    {
+        public NetworkManager NetworkManager;
+        public string NetworkAddress = "localhost";
+
+        [Range(0.01f, 10f)]
+        public float Scale = 1f;
+        public TextAnchor GUIAnchor = TextAnchor.UpperLeft;
+
+        private void OnGUI()
+        {
+            GUIUtility.ScaleAroundPivot(Vector2.one * Scale, GetPivotFromAnchor(GUIAnchor));
+
+            if (!NetworkManager.Server.Active && !NetworkManager.Client.Active)
+            {
+                StartButtons(GetRectFromAnchor(GUIAnchor, 71));
+            }
+            else
+            {
+                StatusLabels(GetRectFromAnchor(GUIAnchor, 100));
+            }
+        }
+
+        private void StartButtons(Rect position)
+        {
+            GUILayout.BeginArea(position);
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                GUILayout.Box("WebGL cannot host");
+            }
+            else
+            {
+                if (GUILayout.Button("Host (Server + Client)"))
+                {
+                    ClickHost();
+                }
+            }
+
+            GUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Client"))
+            {
+                ClickClient();
+            }
+            NetworkAddress = GUILayout.TextField(NetworkAddress);
+
+            GUILayout.EndHorizontal();
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                GUILayout.Box("WebGL cannot be a server");
+            }
+            else
+            {
+                if (GUILayout.Button("Server Only"))
+                {
+                    ClickServerOnly();
+                }
+            }
+
+            GUILayout.EndArea();
+        }
+
+        private void StatusLabels(Rect position)
+        {
+            GUILayout.BeginArea(position);
+
+            if (NetworkManager.Server.Active)
+            {
+                GUILayout.Label("Server: active");
+                GUILayout.Label($"Transport: {NetworkManager.Server.Transport.GetType().Name}");
+
+                if (NetworkManager.Client.IsConnected)
+                {
+                    if (GUILayout.Button("Stop Host"))
+                    {
+                        NetworkManager.Server.StopHost();
+                    }
+                }
+                else
+                {
+                    if (GUILayout.Button("Stop Server"))
+                    {
+                        NetworkManager.Server.Disconnect();
+                    }
+                }
+            }
+            if (NetworkManager.Client.IsConnected)
+            {
+                GUILayout.Label($"Client: address={NetworkAddress}");
+
+                if (GUILayout.Button("Stop Client"))
+                {
+                    NetworkManager.Client.Disconnect();
+                }
+            }
+            else if(NetworkManager.Client.Active)
+            {
+                GUILayout.Label($"Connecting to {NetworkAddress}...");
+                //TODO: Implement cancel button when it's possible.
+            }
+
+            GUILayout.EndArea();
+        }
+
+        private const int WIDTH = 200;
+        private const int PADDING_X = 10;
+        private const int PADDING_Y = 10;
+
+        private static Rect GetRectFromAnchor(TextAnchor anchor, int height)
+        {
+            switch (anchor)
+            {
+                case TextAnchor.UpperLeft:
+                    return new Rect(PADDING_X, PADDING_Y, WIDTH, height);
+                case TextAnchor.UpperCenter:
+                    return new Rect(Screen.width / 2 - (WIDTH / 2), PADDING_Y, WIDTH, height);
+                case TextAnchor.UpperRight:
+                    return new Rect(Screen.width - (WIDTH + PADDING_X), PADDING_Y, WIDTH, height);
+                case TextAnchor.MiddleLeft:
+                    return new Rect(PADDING_X, Screen.height / 2 - (height / 2), WIDTH, height);
+                case TextAnchor.MiddleCenter:
+                    return new Rect(Screen.width / 2 - (WIDTH / 2), Screen.height / 2 - (height / 2), WIDTH, height);
+                case TextAnchor.MiddleRight:
+                    return new Rect(Screen.width - (WIDTH + PADDING_X), Screen.height / 2 - (height / 2), WIDTH, height);
+                case TextAnchor.LowerLeft:
+                    return new Rect(PADDING_X, Screen.height - (height + PADDING_Y), WIDTH, height);
+                case TextAnchor.LowerCenter:
+                    return new Rect(Screen.width / 2 - (WIDTH / 2), Screen.height - (height + PADDING_Y), WIDTH, height);
+                default: // Lower right
+                    return new Rect(Screen.width - (WIDTH + PADDING_X), Screen.height - (height + PADDING_Y), WIDTH, height);
+            }
+        }
+
+        private static Vector2 GetPivotFromAnchor(TextAnchor anchor)
+        {
+            switch (anchor)
+            {
+                case TextAnchor.UpperLeft:
+                    return Vector2.zero;
+                case TextAnchor.UpperCenter:
+                    return new Vector2(Screen.width / 2f, 0f);
+                case TextAnchor.UpperRight:
+                    return new Vector2(Screen.width, 0f);
+                case TextAnchor.MiddleLeft:
+                    return new Vector2(0f, Screen.height / 2f);
+                case TextAnchor.MiddleCenter:
+                    return new Vector2(Screen.width / 2f, Screen.height / 2f);
+                case TextAnchor.MiddleRight:
+                    return new Vector2(Screen.width, Screen.height / 2f);
+                case TextAnchor.LowerLeft:
+                    return new Vector2(0f, Screen.height);
+                case TextAnchor.LowerCenter:
+                    return new Vector2(Screen.width / 2f, Screen.height);
+                default: // Lower right
+                    return new Vector2(Screen.width, Screen.height);
+            }
+        }
+
+        private void ClickHost()
+        {
+            NetworkManager.Server.StartHost(NetworkManager.Client).Forget();
+        }
+
+        private void ClickServerOnly()
+        {
+            NetworkManager.Server.ListenAsync().Forget();
+        }
+
+        private void ClickClient()
+        {
+            NetworkManager.Client.ConnectAsync(NetworkAddress);
+        }
+    }
+}

--- a/Assets/Mirage/Runtime/NetworkManagerGUI.cs.meta
+++ b/Assets/Mirage/Runtime/NetworkManagerGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81da5905cb362874ba7cbe36247debba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 7453abfe9e8b2c04a8a47eb536fe21eb, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/NetworkManagerHud.cs
+++ b/Assets/Mirage/Runtime/NetworkManagerHud.cs
@@ -247,7 +247,6 @@ namespace Mirage
 
         private void ClickClient()
         {
-            Debug.Log(NetworkAddress);
             NetworkManager.Client.ConnectAsync(NetworkAddress);
         }
     }

--- a/Assets/Mirage/Runtime/NetworkManagerHud.cs
+++ b/Assets/Mirage/Runtime/NetworkManagerHud.cs
@@ -5,9 +5,15 @@ using UnityEngine.UI;
 namespace Mirage
 {
     public class NetworkManagerHud : MonoBehaviour
-    {
+    { 
         public NetworkManager NetworkManager;
         public string NetworkAddress = "localhost";
+
+        [Header("IMGUI Settings")]
+        public bool UseIMGUI = false;
+        [Range(0.01f, 10f)]
+        public float Scale = 1f;
+        public TextAnchor GUIAnchor = TextAnchor.UpperLeft;
 
         [Header("Prefab Canvas Elements")]
         public InputField NetworkAddressInput;
@@ -17,7 +23,7 @@ namespace Mirage
         string labelText;
 
         private void Start()
-        {
+        { 
             DontDestroyOnLoad(transform.root.gameObject);
             Application.runInBackground = true;
         }
@@ -71,6 +77,178 @@ namespace Mirage
         public void OnNetworkAddressInputUpdate()
         {
             NetworkAddress = NetworkAddressInput.text;
+        }
+
+        private void OnGUI()
+        {
+            if (!UseIMGUI)
+            {
+                return;
+            }
+
+            GUIUtility.ScaleAroundPivot(Vector2.one * Scale, GetPivotFromAnchor(GUIAnchor));
+
+            if (!NetworkManager.Server.Active && !NetworkManager.Client.Active)
+            {
+                StartButtons(GetRectFromAnchor(GUIAnchor, 71));
+            }
+            else
+            {
+                StatusLabels(GetRectFromAnchor(GUIAnchor, 100));
+            }
+        }
+
+        private void StartButtons(Rect position)
+        {
+            GUILayout.BeginArea(position);
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                GUILayout.Box("WebGL cannot host");
+            }
+            else
+            {
+                if (GUILayout.Button("Host (Server + Client)"))
+                {
+                    ClickHost();
+                }
+            }
+
+            GUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Client"))
+            {
+                ClickClient();
+            }
+            NetworkAddress = GUILayout.TextField(NetworkAddress);
+
+            GUILayout.EndHorizontal();
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                GUILayout.Box("WebGL cannot be a server");
+            }
+            else
+            {
+                if (GUILayout.Button("Server Only"))
+                {
+                    ClickServerOnly();
+                }
+            }
+
+            GUILayout.EndArea();
+        }
+
+        private void StatusLabels(Rect position)
+        {
+            GUILayout.BeginArea(position);
+
+            if (NetworkManager.Server.Active)
+            {
+                GUILayout.Label("Server: active");
+                GUILayout.Label($"Transport: {NetworkManager.Server.Transport.GetType().Name}");
+
+                if (NetworkManager.Client.IsConnected)
+                {
+                    if (GUILayout.Button("Stop Host"))
+                    {
+                        NetworkManager.Server.StopHost();
+                    }
+                }
+                else
+                {
+                    if (GUILayout.Button("Stop Server"))
+                    {
+                        NetworkManager.Server.Disconnect();
+                    }
+                }
+            }
+            if (NetworkManager.Client.IsConnected)
+            {
+                GUILayout.Label($"Client: address={NetworkAddress}");
+
+                if (GUILayout.Button("Stop Client"))
+                {
+                    NetworkManager.Client.Disconnect();
+                }
+            }
+            else if(NetworkManager.Client.Active)
+            {
+                GUILayout.Label($"Connecting to {NetworkAddress}...");
+                //TODO: Implement cancel button when it's possible.
+            }
+           
+            GUILayout.EndArea();
+        }
+
+        private const int WIDTH = 200;
+        private const int PADDING_X = 10;
+        private const int PADDING_Y = 10;
+
+        private Rect GetRectFromAnchor(TextAnchor anchor, int height)
+        {
+            switch (anchor)
+            {
+                case TextAnchor.UpperLeft:
+                    return new Rect(PADDING_X, PADDING_Y, WIDTH, height);
+                case TextAnchor.UpperCenter:
+                    return new Rect(Screen.width / 2 - (WIDTH / 2), PADDING_Y, WIDTH, height);
+                case TextAnchor.UpperRight:
+                    return new Rect(Screen.width - (WIDTH + PADDING_X), PADDING_Y, WIDTH, height);
+                case TextAnchor.MiddleLeft:
+                    return new Rect(PADDING_X, Screen.height / 2 - (height / 2), WIDTH, height);
+                case TextAnchor.MiddleCenter:
+                    return new Rect(Screen.width / 2 - (WIDTH / 2), Screen.height / 2 - (height / 2), WIDTH, height);
+                case TextAnchor.MiddleRight:
+                    return new Rect(Screen.width - (WIDTH + PADDING_X), Screen.height / 2 - (height / 2), WIDTH, height);
+                case TextAnchor.LowerLeft:
+                    return new Rect(PADDING_X, Screen.height - (height + PADDING_Y), WIDTH, height);
+                case TextAnchor.LowerCenter:
+                    return new Rect(Screen.width / 2 - (WIDTH / 2), Screen.height - (height + PADDING_Y), WIDTH, height);
+                default: // Lower right
+                    return new Rect(Screen.width - (WIDTH + PADDING_X), Screen.height - (height + PADDING_Y), WIDTH, height);
+            }
+        }
+
+        private Vector2 GetPivotFromAnchor(TextAnchor anchor)
+        {
+            switch (anchor)
+            {
+                case TextAnchor.UpperLeft:
+                    return Vector2.zero;
+                case TextAnchor.UpperCenter:
+                    return new Vector2(Screen.width / 2, 0f);
+                case TextAnchor.UpperRight:
+                    return new Vector2(Screen.width, 0f);
+                case TextAnchor.MiddleLeft:
+                    return new Vector2(0f, Screen.height / 2);
+                case TextAnchor.MiddleCenter:
+                    return new Vector2(Screen.width / 2, Screen.height / 2);
+                case TextAnchor.MiddleRight:
+                    return new Vector2(Screen.width, Screen.height / 2);
+                case TextAnchor.LowerLeft:
+                    return new Vector2(0f, Screen.height);
+                case TextAnchor.LowerCenter:
+                    return new Vector2(Screen.width / 2, Screen.height);
+                default: // Lower right
+                    return new Vector2(Screen.width, Screen.height);
+            }
+        }
+
+        private void ClickHost()
+        {
+            NetworkManager.Server.StartHost(NetworkManager.Client).Forget();
+        }
+
+        private void ClickServerOnly()
+        {
+            NetworkManager.Server.ListenAsync().Forget();
+        }
+
+        private void ClickClient()
+        {
+            Debug.Log(NetworkAddress);
+            NetworkManager.Client.ConnectAsync(NetworkAddress);
         }
     }
 }

--- a/Assets/Mirage/Runtime/NetworkManagerHud.cs
+++ b/Assets/Mirage/Runtime/NetworkManagerHud.cs
@@ -5,15 +5,9 @@ using UnityEngine.UI;
 namespace Mirage
 {
     public class NetworkManagerHud : MonoBehaviour
-    { 
+    {
         public NetworkManager NetworkManager;
         public string NetworkAddress = "localhost";
-
-        [Header("IMGUI Settings")]
-        public bool UseIMGUI = false;
-        [Range(0.01f, 10f)]
-        public float Scale = 1f;
-        public TextAnchor GUIAnchor = TextAnchor.UpperLeft;
 
         [Header("Prefab Canvas Elements")]
         public InputField NetworkAddressInput;
@@ -23,7 +17,7 @@ namespace Mirage
         string labelText;
 
         private void Start()
-        { 
+        {
             DontDestroyOnLoad(transform.root.gameObject);
             Application.runInBackground = true;
         }
@@ -77,177 +71,6 @@ namespace Mirage
         public void OnNetworkAddressInputUpdate()
         {
             NetworkAddress = NetworkAddressInput.text;
-        }
-
-        private void OnGUI()
-        {
-            if (!UseIMGUI)
-            {
-                return;
-            }
-
-            GUIUtility.ScaleAroundPivot(Vector2.one * Scale, GetPivotFromAnchor(GUIAnchor));
-
-            if (!NetworkManager.Server.Active && !NetworkManager.Client.Active)
-            {
-                StartButtons(GetRectFromAnchor(GUIAnchor, 71));
-            }
-            else
-            {
-                StatusLabels(GetRectFromAnchor(GUIAnchor, 100));
-            }
-        }
-
-        private void StartButtons(Rect position)
-        {
-            GUILayout.BeginArea(position);
-
-            if (Application.platform == RuntimePlatform.WebGLPlayer)
-            {
-                GUILayout.Box("WebGL cannot host");
-            }
-            else
-            {
-                if (GUILayout.Button("Host (Server + Client)"))
-                {
-                    ClickHost();
-                }
-            }
-
-            GUILayout.BeginHorizontal();
-
-            if (GUILayout.Button("Client"))
-            {
-                ClickClient();
-            }
-            NetworkAddress = GUILayout.TextField(NetworkAddress);
-
-            GUILayout.EndHorizontal();
-
-            if (Application.platform == RuntimePlatform.WebGLPlayer)
-            {
-                GUILayout.Box("WebGL cannot be a server");
-            }
-            else
-            {
-                if (GUILayout.Button("Server Only"))
-                {
-                    ClickServerOnly();
-                }
-            }
-
-            GUILayout.EndArea();
-        }
-
-        private void StatusLabels(Rect position)
-        {
-            GUILayout.BeginArea(position);
-
-            if (NetworkManager.Server.Active)
-            {
-                GUILayout.Label("Server: active");
-                GUILayout.Label($"Transport: {NetworkManager.Server.Transport.GetType().Name}");
-
-                if (NetworkManager.Client.IsConnected)
-                {
-                    if (GUILayout.Button("Stop Host"))
-                    {
-                        NetworkManager.Server.StopHost();
-                    }
-                }
-                else
-                {
-                    if (GUILayout.Button("Stop Server"))
-                    {
-                        NetworkManager.Server.Disconnect();
-                    }
-                }
-            }
-            if (NetworkManager.Client.IsConnected)
-            {
-                GUILayout.Label($"Client: address={NetworkAddress}");
-
-                if (GUILayout.Button("Stop Client"))
-                {
-                    NetworkManager.Client.Disconnect();
-                }
-            }
-            else if(NetworkManager.Client.Active)
-            {
-                GUILayout.Label($"Connecting to {NetworkAddress}...");
-                //TODO: Implement cancel button when it's possible.
-            }
-           
-            GUILayout.EndArea();
-        }
-
-        private const int WIDTH = 200;
-        private const int PADDING_X = 10;
-        private const int PADDING_Y = 10;
-
-        private Rect GetRectFromAnchor(TextAnchor anchor, int height)
-        {
-            switch (anchor)
-            {
-                case TextAnchor.UpperLeft:
-                    return new Rect(PADDING_X, PADDING_Y, WIDTH, height);
-                case TextAnchor.UpperCenter:
-                    return new Rect(Screen.width / 2 - (WIDTH / 2), PADDING_Y, WIDTH, height);
-                case TextAnchor.UpperRight:
-                    return new Rect(Screen.width - (WIDTH + PADDING_X), PADDING_Y, WIDTH, height);
-                case TextAnchor.MiddleLeft:
-                    return new Rect(PADDING_X, Screen.height / 2 - (height / 2), WIDTH, height);
-                case TextAnchor.MiddleCenter:
-                    return new Rect(Screen.width / 2 - (WIDTH / 2), Screen.height / 2 - (height / 2), WIDTH, height);
-                case TextAnchor.MiddleRight:
-                    return new Rect(Screen.width - (WIDTH + PADDING_X), Screen.height / 2 - (height / 2), WIDTH, height);
-                case TextAnchor.LowerLeft:
-                    return new Rect(PADDING_X, Screen.height - (height + PADDING_Y), WIDTH, height);
-                case TextAnchor.LowerCenter:
-                    return new Rect(Screen.width / 2 - (WIDTH / 2), Screen.height - (height + PADDING_Y), WIDTH, height);
-                default: // Lower right
-                    return new Rect(Screen.width - (WIDTH + PADDING_X), Screen.height - (height + PADDING_Y), WIDTH, height);
-            }
-        }
-
-        private Vector2 GetPivotFromAnchor(TextAnchor anchor)
-        {
-            switch (anchor)
-            {
-                case TextAnchor.UpperLeft:
-                    return Vector2.zero;
-                case TextAnchor.UpperCenter:
-                    return new Vector2(Screen.width / 2, 0f);
-                case TextAnchor.UpperRight:
-                    return new Vector2(Screen.width, 0f);
-                case TextAnchor.MiddleLeft:
-                    return new Vector2(0f, Screen.height / 2);
-                case TextAnchor.MiddleCenter:
-                    return new Vector2(Screen.width / 2, Screen.height / 2);
-                case TextAnchor.MiddleRight:
-                    return new Vector2(Screen.width, Screen.height / 2);
-                case TextAnchor.LowerLeft:
-                    return new Vector2(0f, Screen.height);
-                case TextAnchor.LowerCenter:
-                    return new Vector2(Screen.width / 2, Screen.height);
-                default: // Lower right
-                    return new Vector2(Screen.width, Screen.height);
-            }
-        }
-
-        private void ClickHost()
-        {
-            NetworkManager.Server.StartHost(NetworkManager.Client).Forget();
-        }
-
-        private void ClickServerOnly()
-        {
-            NetworkManager.Server.ListenAsync().Forget();
-        }
-
-        private void ClickClient()
-        {
-            NetworkManager.Client.ConnectAsync(NetworkAddress);
         }
     }
 }


### PR DESCRIPTION
This PR adds an optional IMGUI menu for network manager hud, just like the one from before but with some added features. It now supports scaling and setting an anchor. 

Why? Because I can never bother with setting up a crappy UI with uGUI just to connect and I always end up making a script that auto connects for me, but it would obviously be handier to have more control. Also as someone who prototypes a lot and usually waits a really long time to make UI, this will make it so much easier to connect to servers.