### PR TITLE
refactor: renaming network server disconnect to stop

### DIFF
--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -65,7 +65,7 @@ namespace Mirage
 
         IReadOnlyCollection<INetworkPlayer> Players { get; }
 
-        void Disconnect();
+        void Stop();
 
         void AddConnection(INetworkPlayer player);
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -134,7 +134,7 @@ namespace Mirage
         /// <summary>
         /// This shuts down the server and disconnects all clients.
         /// </summary>
-        public void Disconnect()
+        public void Stop()
         {
             if (LocalClient != null)
             {
@@ -162,7 +162,7 @@ namespace Mirage
             initialized = true;
             World = new NetworkWorld();
 
-            Application.quitting += Disconnect;
+            Application.quitting += Stop;
             if (logger.LogEnabled()) logger.Log($"NetworkServer Created, Mirage version: {Version.Current}");
 
 
@@ -261,7 +261,7 @@ namespace Mirage
         /// </summary>
         public void StopHost()
         {
-            Disconnect();
+            Stop();
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Mirage
             _onStopHost.Reset();
             _stopped.Reset();
 
-            Application.quitting -= Disconnect;
+            Application.quitting -= Stop;
         }
 
         /// <summary>

--- a/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
+++ b/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
@@ -100,7 +100,7 @@ namespace Mirage.Tests.Performance.Runtime
         public IEnumerator TearDown()
         {
             // shutdown
-            Server.Disconnect();
+            Server.Stop();
             yield return null;
 
             // unload scene

--- a/Assets/Tests/Runtime/ClientServer/ClientServerSetup.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerSetup.cs
@@ -117,7 +117,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         public IEnumerator ShutdownHost() => UniTask.ToCoroutine(async () =>
         {
             client.Disconnect();
-            server.Disconnect();
+            server.Stop();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !client.Active);
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);

--- a/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
@@ -126,7 +126,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator DisconnectStateTest() => UniTask.ToCoroutine(async () =>
         {
-            server.Disconnect();
+            server.Stop();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);
         });
@@ -138,7 +138,7 @@ namespace Mirage.Tests.Runtime.ClientServer
             UnityAction func1 = Substitute.For<UnityAction>();
             server.Stopped.AddListener(func1);
 
-            server.Disconnect();
+            server.Stop();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);
 

--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -20,7 +20,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             var obj = new GameObject();
 
-            server.Disconnect();
+            server.Stop();
 
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
             {
@@ -268,7 +268,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator SpawnObjectsExceptionTest() => UniTask.ToCoroutine(async () =>
         {
-            server.Disconnect();
+            server.Stop();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);
 

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -71,7 +71,7 @@ namespace Mirage.Tests.Runtime.Host
             Assert.That(server.LocalClientActive, Is.True);
             Assert.That(server.Players, Has.Count.EqualTo(1));
 
-            server.Disconnect();
+            server.Stop();
 
             // wait for messages to get dispatched
             await AsyncUtil.WaitUntilWithTimeout(() => !server.LocalClientActive);
@@ -86,7 +86,7 @@ namespace Mirage.Tests.Runtime.Host
         [UnityTest]
         public IEnumerator ClientSceneChangedOnReconnect() => UniTask.ToCoroutine(async () =>
         {
-            server.Disconnect();
+            server.Stop();
 
             // wait for server to disconnect
             await UniTask.WaitUntil(() => !server.Active);

--- a/Assets/Tests/Runtime/Host/NetworkManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/NetworkManagerTest.cs
@@ -18,7 +18,7 @@ namespace Mirage.Tests.Runtime.Host
         [UnityTest]
         public IEnumerator IsNetworkActiveStopTest() => UniTask.ToCoroutine(async () =>
         {
-            manager.Server.Disconnect();
+            manager.Server.Stop();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !client.Active);
 

--- a/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
@@ -131,7 +131,7 @@ namespace Mirage.Tests.Runtime.Host
             //1 is the player. should be 2 at this point
             Assert.That(server.World.SpawnedIdentities.Count, Is.GreaterThan(1));
 
-            server.Disconnect();
+            server.Stop();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);
 

--- a/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
@@ -80,7 +80,7 @@ namespace Mirage.Tests.Runtime
             Assert.That(identity.observers, Is.EquivalentTo(new[] { connection1, server.LocalPlayer }));
 
             // clean up
-            server.Disconnect();
+            server.Stop();
         }
 
         // RebuildObservers should always add the own ready connection


### PR DESCRIPTION
Disconnect is not an intuitive name for a method that stops or closes the server.

BREAKING CHANGE: NetworkServer.Disconnect is now called Stop