### PR TITLE
chore: fix ci to force sonar dependency version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
-          apt install -y default-jre
+          apt install -y openjdk-11-jre-headless
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
+          apt-cache policy openjdk-11-jre-headless
           apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2~18.04
 
       - name: Run editor Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
-          apt-get install -y default-jre
+          apt install -y default-jre
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
+          apt update
           apt install -y openjdk-11-jre-headless=11.0.10+9-0ubuntu1~18.04
 
       - name: Run editor Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
           apt update
           apt-cache policy openjdk-11-jre-headless
-          apt install -y openjdk-11-jre-headless=11.0.10+11-0ubuntu2~18.04
+          apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2~18.04
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
           apt update
-          apt-cache policy openjdk-11-jre-headless
           apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2~18.04
 
       - name: Run editor Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
-          apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2~18.04_amd64
+          apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2~18.04
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
-          apt install -y openjdk-11-jre-headless
+          apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
-          apt-cache policy openjdk-11-jre-headless
-          apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2~18.04
+          apt install -y openjdk-11-jre-headless=11.0.10+9-0ubuntu1~18.04
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,8 @@ jobs:
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
           apt update
-          apt install -y openjdk-11-jre-headless=11.0.10+9-0ubuntu1~18.04
+          apt-cache policy openjdk-11-jre-headless
+          apt install -y openjdk-11-jre-headless=11.0.10+11-0ubuntu2~18.04
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install sonar scanner
         run: |
           $DOTNET_ROOT/dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1
-          apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2
+          apt install -y openjdk-11-jre-headless=11.0.11+9-0ubuntu2~18.04_amd64
 
       - name: Run editor Tests
         run: unity-editor -nographics -logFile /dev/stdout -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests


### PR DESCRIPTION
For some reason, **apt install** isn't able to fetch the correct version, thus returning a 404 error and breaking the whole CI flow, so we force it now to make sure it is an available version