### PR TITLE
feat: adding weaver support for nullable types

### DIFF
--- a/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
@@ -460,5 +460,18 @@ namespace Mirage.Serialization
             }
             return identity.gameObject;
         }
+
+        public static T? ReadNullable<T>(this NetworkReader reader) where T : struct
+        {
+            bool hasValue = reader.ReadBoolean();
+            if (hasValue)
+            {
+                return reader.Read<T>();
+            }
+            else
+            {
+                return null;
+            }
+        }
     }
 }

--- a/Assets/Mirage/Runtime/Serialization/NetworkWriter.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkWriter.cs
@@ -540,5 +540,15 @@ namespace Mirage.Serialization
                 throw new InvalidOperationException($"Cannot send GameObject without a NetworkIdentity {value.name}");
             writer.WriteNetworkIdentity(identity);
         }
+
+        public static void WriteNullable<T>(this NetworkWriter writer, T? nullable) where T : struct
+        {
+            bool hasValue = nullable.HasValue;
+            writer.WriteBoolean(hasValue);
+            if (hasValue)
+            {
+                writer.Write(nullable.Value);
+            }
+        }
     }
 }

--- a/Assets/Mirage/Weaver/Readers.cs
+++ b/Assets/Mirage/Weaver/Readers.cs
@@ -58,6 +58,14 @@ namespace Mirage.Weaver
                 logger.Error($"{typeReference.Name} is not a supported type", typeReference, sequencePoint);
                 return null;
             }
+
+            if (typeReference.Is(typeof(Nullable<>)))
+            {
+                var genericInstance = (GenericInstanceType)typeReference;
+                TypeReference elementType = genericInstance.GenericArguments[0];
+
+                return GenerateReadCollection(typeReference, elementType, () => NetworkReaderExtensions.ReadNullable<byte>(default), sequencePoint);
+            }
             if (variableDefinition.Is(typeof(ArraySegment<>)))
             {
                 return GenerateArraySegmentReadFunc(typeReference, sequencePoint);

--- a/Assets/Mirage/Weaver/Writers.cs
+++ b/Assets/Mirage/Weaver/Writers.cs
@@ -81,6 +81,13 @@ namespace Mirage.Weaver
             }
 
             // check for collections
+            if (typeReference.Is(typeof(Nullable<>)))
+            {
+                var genericInstance = (GenericInstanceType)typeReference;
+                TypeReference elementType = genericInstance.GenericArguments[0];
+
+                return GenerateCollectionWriter(typeReference, elementType, () => NetworkWriterExtensions.WriteNullable<byte>(default, default), sequencePoint);
+            }
             if (typeReference.Is(typeof(ArraySegment<>)))
             {
                 var genericInstance = (GenericInstanceType)typeReference;

--- a/Assets/Tests/Runtime/Serializers/NetworkWriterTest.cs
+++ b/Assets/Tests/Runtime/Serializers/NetworkWriterTest.cs
@@ -1073,7 +1073,6 @@ namespace Mirage.Tests.Runtime
         [TestCase(1234)]
         public void NullableInt(int? value)
         {
-            var writer = new NetworkWriter();
             writer.Write<int?>(value);
             var reader = new NetworkReader(writer.ToArray());
             int? unpacked = reader.Read<int?>();
@@ -1087,7 +1086,6 @@ namespace Mirage.Tests.Runtime
         [TestCase(false)]
         public void NullableBool(bool? value)
         {
-            var writer = new NetworkWriter();
             writer.Write<bool?>(value);
             var reader = new NetworkReader(writer.ToArray());
             bool? unpacked = reader.Read<bool?>();
@@ -1101,7 +1099,6 @@ namespace Mirage.Tests.Runtime
         [TestCase(20202020ul)]
         public void NullableUlong(ulong? value)
         {
-            var writer = new NetworkWriter();
             writer.Write<ulong?>(value);
             var reader = new NetworkReader(writer.ToArray());
             ulong? unpacked = reader.Read<ulong?>();

--- a/Assets/Tests/Runtime/Serializers/NetworkWriterTest.cs
+++ b/Assets/Tests/Runtime/Serializers/NetworkWriterTest.cs
@@ -1056,5 +1056,57 @@ namespace Mirage.Tests.Runtime
 
             Assert.That(writer.Position, Is.EqualTo(reader.Position));
         }
+
+        // use networkmessage to make sure writer is generated
+        [NetworkMessage]
+        public struct NullableIntMessage
+        {
+            public int? value1;
+            public bool? value2;
+            public ulong? value3;
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(1234)]
+        public void NullableInt(int? value)
+        {
+            var writer = new NetworkWriter();
+            writer.Write<int?>(value);
+            var reader = new NetworkReader(writer.ToArray());
+            int? unpacked = reader.Read<int?>();
+
+            Assert.That(unpacked, Is.EqualTo(value));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void NullableBool(bool? value)
+        {
+            var writer = new NetworkWriter();
+            writer.Write<bool?>(value);
+            var reader = new NetworkReader(writer.ToArray());
+            bool? unpacked = reader.Read<bool?>();
+
+            Assert.That(unpacked, Is.EqualTo(value));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(0ul)]
+        [TestCase(20202020ul)]
+        public void NullableUlong(ulong? value)
+        {
+            var writer = new NetworkWriter();
+            writer.Write<ulong?>(value);
+            var reader = new NetworkReader(writer.ToArray());
+            ulong? unpacked = reader.Read<ulong?>();
+
+            Assert.That(unpacked, Is.EqualTo(value));
+        }
     }
 }

--- a/Assets/Tests/Weaver/GeneratedReaderWriterTests.cs
+++ b/Assets/Tests/Weaver/GeneratedReaderWriterTests.cs
@@ -229,5 +229,11 @@ namespace Mirage.Weaver
             HasError("Cannot generate writer for System.Collections.Generic.List`1<UnityEngine.MonoBehaviour>. Use a supported type or provide a custom writer", "System.Collections.Generic.List`1<UnityEngine.MonoBehaviour>");
             HasError("Cannot generate reader for component type MonoBehaviour. Use a supported type or provide a custom reader", "UnityEngine.MonoBehaviour");
         }
+
+        [Test]
+        public void CreatesForNullable()
+        {
+            IsSuccess();
+        }
     }
 }

--- a/Assets/Tests/Weaver/GeneratedReaderWriterTests~/CreatesForNullable.cs
+++ b/Assets/Tests/Weaver/GeneratedReaderWriterTests~/CreatesForNullable.cs
@@ -1,0 +1,11 @@
+using Mirage;
+using UnityEngine;
+
+namespace GeneratedReaderWriter.CreatesForNullable
+{
+    [NetworkMessage]public struct NullableIntMessage { public int? value; }
+    [NetworkMessage]public struct NullableBoolMessage { public bool? value; }
+    [NetworkMessage]public struct NullableUlongMessage { public ulong? value; }
+    [NetworkMessage]public struct NullableUshortMessage { public ushort? value; }
+    [NetworkMessage]public struct NullableVector3Message { public Vector3? value; }
+}


### PR DESCRIPTION
nullable types can now be used in rpc, synvars and messages. They are sent as a bool and the value