### PR TITLE
feat: simplifying some checks in ServerObjectManager

### DIFF
--- a/Assets/Mirage/Runtime/IServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/IServerObjectManager.cs
@@ -6,18 +6,18 @@ namespace Mirage
     public interface IServerObjectManager
     {
         void AddCharacter(INetworkPlayer player, GameObject character);
-
         void AddCharacter(INetworkPlayer player, GameObject character, Guid assetId);
+        void AddCharacter(INetworkPlayer player, NetworkIdentity identity);
 
         void ReplaceCharacter(INetworkPlayer player, GameObject character, bool keepAuthority = false);
-
         void ReplaceCharacter(INetworkPlayer player, GameObject character, Guid assetId, bool keepAuthority = false);
-
-        void Spawn(GameObject obj, GameObject owner);
+        void ReplaceCharacter(INetworkPlayer player, NetworkIdentity identity, bool keepAuthority = false);
 
         void Spawn(GameObject obj, INetworkPlayer owner = null);
-
+        void Spawn(GameObject obj, GameObject ownerObject);
         void Spawn(GameObject obj, Guid assetId, INetworkPlayer owner = null);
+        void Spawn(NetworkIdentity identity);
+        void Spawn(NetworkIdentity identity, INetworkPlayer owner);
 
         void Destroy(GameObject obj, bool destroyServerObject = true);
 


### PR DESCRIPTION
- using GetNetworkIdentity method instead of GetComponent+throw
- adding ReplaceCharacter that takes a NetworkIdentity
- adding Spawn that takes a NetworkIdentity
- removing internal SpawnObject (use public methods instead)