### PR TITLE
refactor: remove uri support from networkwriter

### DIFF
--- a/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
@@ -429,11 +429,6 @@ namespace Mirage.Serialization
             return result;
         }
 
-        public static Uri ReadUri(this NetworkReader reader)
-        {
-            return new Uri(reader.ReadString());
-        }
-
         public static NetworkBehaviour ReadNetworkBehaviour(this NetworkReader reader)
         {
             NetworkIdentity identity = reader.ReadNetworkIdentity();

--- a/Assets/Mirage/Runtime/Serialization/NetworkWriter.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkWriter.cs
@@ -478,11 +478,6 @@ namespace Mirage.Serialization
             writer.WritePackedUInt32(value.NetId);
         }
 
-        public static void WriteUri(this NetworkWriter writer, Uri uri)
-        {
-            writer.WriteString(uri.ToString());
-        }
-
         public static void WriteList<T>(this NetworkWriter writer, List<T> list)
         {
             if (list is null)

--- a/Assets/Tests/Runtime/Serializers/NetworkWriterTest.cs
+++ b/Assets/Tests/Runtime/Serializers/NetworkWriterTest.cs
@@ -999,18 +999,6 @@ namespace Mirage.Tests.Runtime
         }
 
         [Test]
-        public void TestWritingUri()
-        {
-
-            var testUri = new Uri("https://www.mirror-networking.com?somthing=other");
-
-            writer.WriteUri(testUri);
-
-            var reader = new NetworkReader(writer.ToArray());
-            Assert.That(reader.ReadUri(), Is.EqualTo(testUri));
-        }
-
-        [Test]
         public void TestList()
         {
             var original = new List<int> { 1, 2, 3, 4, 5 };


### PR DESCRIPTION
BREAKING: write uri as a string instead. (uri.ToString())