### PR TITLE
refactor: moving message handling out of networkplayer

### DIFF
--- a/Assets/Mirage/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/BasicAuthenticator.cs
@@ -33,7 +33,7 @@ namespace Mirage.Authenticators
         /// </para>
         /// <para>
         ///     You might want to use an accessToken or passwords. Be aware that the normal connection
-        ///     in mirror is not encrypted so sending secure information directly is not adviced
+        ///     in Mirage is not encrypted so sending secure information directly is not adviced
         /// </para>
         /// </summary>
 

--- a/Assets/Mirage/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/BasicAuthenticator.cs
@@ -50,22 +50,16 @@ namespace Mirage.Authenticators
             public string message;
         }
 
-        private void Awake()
-        {
-            // register messsage for Auth when server or client starts
-            // this will ensure the handlers are ready when client connects (even in host mode)
-            Server.Started.AddListener(() =>
-            {
-                Server.MessageHandler.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage);
-            });
-
-            Client.Started.AddListener(() =>
-            {
-                Client.MessageHandler.RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage);
-            });
-        }
 
         #region Server Authenticate
+
+        public override void ServerSetup(NetworkServer server)
+        {
+            // register messsage for Auth when server starts
+            // this will ensure the handlers are ready when client connects (even in host mode)
+
+            server.MessageHandler.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage);
+        }
 
         public override void ServerAuthenticate(INetworkPlayer player)
         {
@@ -117,6 +111,14 @@ namespace Mirage.Authenticators
         #endregion
 
         #region Client Authenticate
+
+        public override void ClientSetup(NetworkClient client)
+        {
+            // register messsage for Auth when client starts
+            // this will ensure the handlers are ready when client connects (even in host mode)
+
+            client.MessageHandler.RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage);
+        }
 
         public override void ClientAuthenticate(INetworkPlayer player)
         {

--- a/Assets/Mirage/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/BasicAuthenticator.cs
@@ -97,7 +97,6 @@ namespace Mirage.Authenticators
                 player.Send(authResponseMessage);
 
                 // disconnect the client after 1 second so that response message gets delivered
-                // todo do we still need this delay? message should arrive in order
                 StartCoroutine(DelayedDisconnect(player, 1));
             }
         }

--- a/Assets/Mirage/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirage/Authenticators/TimeoutAuthenticator.cs
@@ -40,6 +40,14 @@ namespace Mirage.Authenticators
             ClientAccept(player);
         }
 
+        public override void ServerAuthenticate(INetworkPlayer player)
+        {
+            pendingAuthentication.Add(player);
+            Authenticator.ServerAuthenticate(player);
+            if (Timeout > 0)
+                StartCoroutine(BeginAuthentication(player, ServerReject));
+        }
+
         public override void ClientAuthenticate(INetworkPlayer player)
         {
             pendingAuthentication.Add(player);
@@ -49,12 +57,14 @@ namespace Mirage.Authenticators
                 StartCoroutine(BeginAuthentication(player, ClientReject));
         }
 
-        public override void ServerAuthenticate(INetworkPlayer player)
+        public override void ServerSetup(NetworkServer server)
         {
-            pendingAuthentication.Add(player);
-            Authenticator.ServerAuthenticate(player);
-            if (Timeout > 0)
-                StartCoroutine(BeginAuthentication(player, ServerReject));
+            Authenticator.ServerSetup(server);
+        }
+
+        public override void ClientSetup(NetworkClient client)
+        {
+            Authenticator.ClientSetup(client);
         }
 
         IEnumerator BeginAuthentication(INetworkPlayer player, Action<INetworkPlayer> reject)

--- a/Assets/Mirage/Runtime/CharacterSpawner.cs
+++ b/Assets/Mirage/Runtime/CharacterSpawner.cs
@@ -61,7 +61,7 @@ namespace Mirage
             }
             if (Server != null)
             {
-                Server.Authenticated.AddListener(OnServerAuthenticated);
+                Server.Started.AddListener(OnServerStarted);
                 if (ServerObjectManager == null)
                 {
                     throw new InvalidOperationException("Assign a ServerObjectManager");
@@ -78,14 +78,13 @@ namespace Mirage
             }
             if (Server != null)
             {
-                Server.Authenticated.RemoveListener(OnServerAuthenticated);
+                Server.Started.RemoveListener(OnServerStarted);
             }
         }
 
-        private void OnServerAuthenticated(INetworkPlayer player)
+        private void OnServerStarted()
         {
-            // wait for client to send us an AddPlayerMessage
-            player.RegisterHandler<AddCharacterMessage>(OnServerAddPlayerInternal);
+            Server.MessageHandler.RegisterHandler<AddCharacterMessage>(OnServerAddPlayerInternal);
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -90,20 +90,20 @@ namespace Mirage
 
         internal void RegisterHostHandlers()
         {
-            Client.Player.RegisterHandler<ObjectDestroyMessage>(msg => { });
-            Client.Player.RegisterHandler<ObjectHideMessage>(msg => { });
-            Client.Player.RegisterHandler<SpawnMessage>(OnHostClientSpawn);
-            Client.Player.RegisterHandler<ServerRpcReply>(msg => { });
-            Client.Player.RegisterHandler<RpcMessage>(msg => { });
+            Client.MessageHandler.RegisterHandler<ObjectDestroyMessage>(msg => { });
+            Client.MessageHandler.RegisterHandler<ObjectHideMessage>(msg => { });
+            Client.MessageHandler.RegisterHandler<SpawnMessage>(OnHostClientSpawn);
+            Client.MessageHandler.RegisterHandler<ServerRpcReply>(msg => { });
+            Client.MessageHandler.RegisterHandler<RpcMessage>(msg => { });
         }
 
         internal void RegisterMessageHandlers()
         {
-            Client.Player.RegisterHandler<ObjectDestroyMessage>(OnObjectDestroy);
-            Client.Player.RegisterHandler<ObjectHideMessage>(OnObjectHide);
-            Client.Player.RegisterHandler<SpawnMessage>(OnSpawn);
-            Client.Player.RegisterHandler<ServerRpcReply>(OnServerRpcReply);
-            Client.Player.RegisterHandler<RpcMessage>(OnRpcMessage);
+            Client.MessageHandler.RegisterHandler<ObjectDestroyMessage>(OnObjectDestroy);
+            Client.MessageHandler.RegisterHandler<ObjectHideMessage>(OnObjectHide);
+            Client.MessageHandler.RegisterHandler<SpawnMessage>(OnSpawn);
+            Client.MessageHandler.RegisterHandler<ServerRpcReply>(OnServerRpcReply);
+            Client.MessageHandler.RegisterHandler<RpcMessage>(OnRpcMessage);
         }
 
         bool ConsiderForSpawning(NetworkIdentity identity)

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -12,14 +12,18 @@ namespace Mirage
         void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable);
     }
 
+    // delegates to give names to variables in handles
+    public delegate void MessageDelegate<T>(T message);
+    public delegate void MessageDelegateWithPlayer<T>(INetworkPlayer player, T message);
+
     /// <summary>
     /// An object that can receive messages
     /// </summary>
     public interface IMessageReceiver
     {
-        void RegisterHandler<T>(Action<INetworkPlayer, T> handler);
+        void RegisterHandler<T>(MessageDelegateWithPlayer<T> handler);
 
-        void RegisterHandler<T>(Action<T> handler);
+        void RegisterHandler<T>(MessageDelegate<T> handler);
 
         void UnregisterHandler<T>();
 

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -13,8 +13,8 @@ namespace Mirage
     }
 
     // delegates to give names to variables in handles
-    public delegate void MessageDelegate<T>(T message);
-    public delegate void MessageDelegateWithPlayer<T>(INetworkPlayer player, T message);
+    public delegate void MessageDelegate<in T>(T message);
+    public delegate void MessageDelegateWithPlayer<in T>(INetworkPlayer player, T message);
 
     /// <summary>
     /// An object that can receive messages

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -24,14 +24,8 @@ namespace Mirage
         void UnregisterHandler<T>();
 
         void ClearHandlers();
-    }
 
-    /// <summary>
-    /// An object that can send and receive messages and notify messages
-    /// </summary>
-    public interface IMessageHandler : IMessageSender, IMessageReceiver
-    {
-        void HandleMessage(ArraySegment<byte> packet);
+        void HandleMessage(INetworkPlayer player, ArraySegment<byte> packet);
     }
 
     /// <summary>
@@ -60,7 +54,7 @@ namespace Mirage
     /// An object owned by a player that can: send/receive messages, have network visibility, be an object owner, authenticated permissions, and load scenes.
     /// May be from the server to client or from client to server
     /// </summary>
-    public interface INetworkPlayer : IMessageHandler, IVisibilityTracker, IObjectOwner, IAuthenticatedObject, ISceneLoader
+    public interface INetworkPlayer : IMessageSender, IVisibilityTracker, IObjectOwner, IAuthenticatedObject, ISceneLoader
     {
         SocketLayer.IConnection Connection { get; }
         void Disconnect();

--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -66,6 +66,7 @@ namespace Mirage
 
         /// <summary>
         /// Unregister a handler for a particular message type.
+        /// <para>Note: Messages dont need to be unregister when server or client stops as MessageHandler will be re-created next time server or client starts</para>
         /// </summary>
         /// <typeparam name="T">Message type</typeparam>
         public void UnregisterHandler<T>()

--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -11,14 +11,14 @@ namespace Mirage
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(MessageHandler));
 
-        readonly bool KickPlayerOnException;
+        readonly bool disconnectOnException;
 
         // message handlers for this connection
         internal readonly Dictionary<int, NetworkMessageDelegate> messageHandlers = new Dictionary<int, NetworkMessageDelegate>();
 
-        public MessageHandler(bool kickPlayerOnException)
+        public MessageHandler(bool disconnectOnException)
         {
-            KickPlayerOnException = kickPlayerOnException;
+            this.disconnectOnException = disconnectOnException;
         }
 
         // Handles network messages on client and server
@@ -129,8 +129,12 @@ namespace Mirage
                 }
                 catch (Exception e)
                 {
-                    logger.LogError($"{e.GetType()} in Message handler (see stack below), Closed connection: {this}\n{e}");
-                    Connection?.Disconnect();
+                    string disconnectMessage = disconnectOnException ? ", Closed connection: {this}" : "";
+                    logger.LogError($"{e.GetType()} in Message handler (see stack below){disconnectMessage}\n{e}");                    
+                    if (disconnectOnException)
+                    {
+                        player.Disconnect();
+                    }
                 }
             }
         }

--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mirage.Logging;
+using Mirage.Serialization;
+using UnityEngine;
+
+namespace Mirage
+{
+    public class MessageHandler : IMessageReceiver
+    {
+        static readonly ILogger logger = LogFactory.GetLogger(typeof(MessageHandler));
+
+        readonly bool KickPlayerOnException;
+
+        // message handlers for this connection
+        internal readonly Dictionary<int, NetworkMessageDelegate> messageHandlers = new Dictionary<int, NetworkMessageDelegate>();
+
+        public MessageHandler(bool kickPlayerOnException)
+        {
+            KickPlayerOnException = kickPlayerOnException;
+        }
+
+        // Handles network messages on client and server
+        internal delegate void NetworkMessageDelegate(INetworkPlayer player, NetworkReader reader);
+        
+        private static NetworkMessageDelegate MessageWrapper<T>(Action<INetworkPlayer, T> handler)
+        {
+            void AdapterFunction(INetworkPlayer player, NetworkReader reader)
+            {
+                T message = NetworkDiagnostics.ReadWithDiagnostics<T>(reader);
+
+                handler.Invoke(player, message);
+            }
+            return AdapterFunction;
+        }
+
+        /// <summary>
+        /// Register a handler for a particular message type.
+        /// <para>There are several system message types which you can add handlers for. You can also add your own message types.</para>
+        /// </summary>
+        /// <typeparam name="T">Message type</typeparam>
+        /// <param name="handler">Function handler which will be invoked for when this message type is received.</param>
+        /// <param name="requireAuthentication">True if the message requires an authenticated connection</param>
+        public void RegisterHandler<T>(Action<INetworkPlayer, T> handler)
+        {
+            int msgType = MessagePacker.GetId<T>();
+            if (logger.filterLogType == LogType.Log && messageHandlers.ContainsKey(msgType))
+            {
+                logger.Log("RegisterHandler replacing " + msgType);
+            }
+            messageHandlers[msgType] = MessageWrapper(handler);
+        }
+
+        /// <summary>
+        /// Register a handler for a particular message type.
+        /// <para>There are several system message types which you can add handlers for. You can also add your own message types.</para>
+        /// </summary>
+        /// <typeparam name="T">Message type</typeparam>
+        /// <param name="handler">Function handler which will be invoked for when this message type is received.</param>
+        /// <param name="requireAuthentication">True if the message requires an authenticated connection</param>
+        public void RegisterHandler<T>(Action<T> handler)
+        {
+            RegisterHandler<T>((_, value) => { handler(value); });
+        }
+
+        /// <summary>
+        /// Unregister a handler for a particular message type.
+        /// </summary>
+        /// <typeparam name="T">Message type</typeparam>
+        public void UnregisterHandler<T>()
+        {
+            int msgType = MessagePacker.GetId<T>();
+            messageHandlers.Remove(msgType);
+        }
+
+        /// <summary>
+        /// Clear all registered callback handlers.
+        /// </summary>
+        public void ClearHandlers()
+        {
+            messageHandlers.Clear();
+        }
+
+
+        internal void InvokeHandler(INetworkPlayer player, int msgType, NetworkReader reader)
+        {
+            if (messageHandlers.TryGetValue(msgType, out NetworkMessageDelegate msgDelegate))
+            {
+                msgDelegate.Invoke(player, reader);
+            }
+            else
+            {
+                try
+                {
+                    Type type = MessagePacker.GetMessageType(msgType);
+                    throw new InvalidDataException($"Unexpected message {type} received in {this}. Did you register a handler for it?");
+                }
+                catch (KeyNotFoundException)
+                {
+                    throw new InvalidDataException($"Unexpected message ID {msgType} received in {this}. May be due to no existing RegisterHandler for this message.");
+                }
+            }
+        }
+
+        public void HandleMessage(INetworkPlayer player, ArraySegment<byte> packet)
+        {
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(packet))
+            {
+                // protect against attackers trying to send invalid data packets
+                // exception could be throw if:
+                // - invalid headers
+                // - invalid message ids
+                // - invalid data causing exceptions
+                // - negative ReadBytesAndSize prefixes
+                // - invalid utf8 strings
+                // - etc.
+                //
+                // if exception is caught, disconnect the attacker to stop any further attacks
+
+                try
+                {
+                    int msgType = MessagePacker.UnpackId(networkReader);
+                    InvokeHandler(msgType, networkReader);
+                }
+                catch (InvalidDataException ex)
+                {
+                    logger.Log(ex.ToString());
+                }
+                catch (Exception e)
+                {
+                    logger.LogError($"{e.GetType()} in Message handler (see stack below), Closed connection: {this}\n{e}");
+                    Connection?.Disconnect();
+                }
+            }
+        }
+    }
+}

--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -7,8 +7,6 @@ using UnityEngine;
 
 namespace Mirage
 {
-
-
     public class MessageHandler : IMessageReceiver
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(MessageHandler));

--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -23,7 +23,7 @@ namespace Mirage
 
         // Handles network messages on client and server
         internal delegate void NetworkMessageDelegate(INetworkPlayer player, NetworkReader reader);
-        
+
         private static NetworkMessageDelegate MessageWrapper<T>(Action<INetworkPlayer, T> handler)
         {
             void AdapterFunction(INetworkPlayer player, NetworkReader reader)
@@ -121,7 +121,7 @@ namespace Mirage
                 try
                 {
                     int msgType = MessagePacker.UnpackId(networkReader);
-                    InvokeHandler(msgType, networkReader);
+                    InvokeHandler(player, msgType, networkReader);
                 }
                 catch (InvalidDataException ex)
                 {
@@ -130,7 +130,7 @@ namespace Mirage
                 catch (Exception e)
                 {
                     string disconnectMessage = disconnectOnException ? ", Closed connection: {this}" : "";
-                    logger.LogError($"{e.GetType()} in Message handler (see stack below){disconnectMessage}\n{e}");                    
+                    logger.LogError($"{e.GetType()} in Message handler (see stack below){disconnectMessage}\n{e}");
                     if (disconnectOnException)
                     {
                         player.Disconnect();

--- a/Assets/Mirage/Runtime/MessageHandler.cs.meta
+++ b/Assets/Mirage/Runtime/MessageHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9b600aef1886a64c82a2263b230f007
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirage/Runtime/NetworkAuthenticator.cs
@@ -9,9 +9,6 @@ namespace Mirage
     [HelpURL("https://miragenet.github.io/Mirage/Articles/Components/Authenticators/index.html")]
     public abstract class NetworkAuthenticator : MonoBehaviour
     {
-        public NetworkServer Server;
-        public NetworkClient Client;
-
         /// <summary>
         /// Notify subscribers on the server when a client is authenticated
         /// </summary>
@@ -43,6 +40,12 @@ namespace Mirage
         }
 
         /// <summary>
+        /// Used to set up authenticator on server
+        /// <para>Can be used to register message handlers before any players connect</para>
+        /// </summary>
+        public abstract void ServerSetup(NetworkServer server);
+
+        /// <summary>
         /// Authenticate the player on the Server.
         /// <para>Called by the server when new client connects</para>
         /// </summary>
@@ -69,6 +72,12 @@ namespace Mirage
         {
             player.Disconnect();
         }
+
+        /// <summary>
+        /// Used to set up authenticator on client
+        /// <para>Can be used to register message handlers before any player connects</para>
+        /// </summary>
+        public abstract void ClientSetup(NetworkClient client);
 
         /// <summary>
         /// Authenticate the player on the Client.

--- a/Assets/Mirage/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirage/Runtime/NetworkAuthenticator.cs
@@ -9,6 +9,9 @@ namespace Mirage
     [HelpURL("https://miragenet.github.io/Mirage/Articles/Components/Authenticators/index.html")]
     public abstract class NetworkAuthenticator : MonoBehaviour
     {
+        public NetworkServer Server;
+        public NetworkClient Client;
+
         /// <summary>
         /// Notify subscribers on the server when a client is authenticated
         /// </summary>

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -114,7 +114,6 @@ namespace Mirage
             connectState = ConnectState.Connecting;
 
             World = new NetworkWorld();
-            InitializeAuthEvents();
 
             IEndPoint endPoint = SocketFactory.GetConnectEndPoint(address, port);
             if (logger.LogEnabled()) logger.Log($"Client connecting to endpoint: {endPoint}");
@@ -141,6 +140,7 @@ namespace Mirage
             Time.Reset();
 
             RegisterMessageHandlers();
+            InitializeAuthEvents();
             // invoke started event after everything is set up, but before peer has connected
             _started.Invoke();
         }
@@ -194,7 +194,6 @@ namespace Mirage
             connectState = ConnectState.Connecting;
 
             World = server.World;
-            InitializeAuthEvents();
 
             // create local connection objects and connect them
             MessageHandler = new MessageHandler(DisconnectOnException);
@@ -206,6 +205,7 @@ namespace Mirage
             Player = new NetworkPlayer(clientConn);
             dataHandler.SetConnection(clientConn, Player);
             RegisterHostHandlers();
+            InitializeAuthEvents();
             // invoke started event after everything is set up, but before peer has connected
             _started.Invoke();
 
@@ -223,10 +223,8 @@ namespace Mirage
         {
             if (authenticator != null)
             {
-                Debug.Assert(authenticator.Client == null || authenticator.Client == this, "authenticator had a reference to a different client");
-                authenticator.Client = this;
-
                 authenticator.OnClientAuthenticated += OnAuthenticated;
+                authenticator.ClientSetup(this);
 
                 Connected.AddListener(authenticator.ClientAuthenticate);
             }

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using Mirage.Events;
 using Mirage.Logging;
 using Mirage.Serialization;
@@ -224,6 +223,9 @@ namespace Mirage
         {
             if (authenticator != null)
             {
+                Debug.Assert(authenticator.Client == null || authenticator.Client == this, "authenticator had a reference to a different client");
+                authenticator.Client = this;
+
                 authenticator.OnClientAuthenticated += OnAuthenticated;
 
                 Connected.AddListener(authenticator.ClientAuthenticate);

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -344,9 +344,9 @@ namespace Mirage
         {
             IConnection connection;
             INetworkPlayer player;
-            readonly MessageHandler messageHandler;
+            readonly IMessageReceiver messageHandler;
 
-            public DataHandler(MessageHandler messageHandler)
+            public DataHandler(IMessageReceiver messageHandler)
             {
                 this.messageHandler = messageHandler;
             }

--- a/Assets/Mirage/Runtime/NetworkDiagnostics.cs
+++ b/Assets/Mirage/Runtime/NetworkDiagnostics.cs
@@ -74,6 +74,12 @@ namespace Mirage
 
         #endregion
 
+        /// <summary>
+        /// Calls <see cref="Reader{T}.Read"/> and measures number of bytes read
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="reader"></param>
+        /// <returns></returns>
         internal static T ReadWithDiagnostics<T>(NetworkReader reader)
         {
             var message = default(T);
@@ -87,7 +93,7 @@ namespace Mirage
             finally
             {
                 int endPos = reader.BitPosition;
-                int byteLength = (endPos - startPos) >> 3;
+                int byteLength = (endPos - startPos) / 8;
                 NetworkDiagnostics.OnReceive(message, byteLength);
             }
 

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using Mirage.Logging;
 using Mirage.Serialization;
 using Mirage.SocketLayer;
@@ -34,7 +32,7 @@ namespace Mirage
         /// <para>Transport layers connections begin at one. So on a client with a single connection to a server, the connectionId of that connection will be one. In NetworkServer, the connectionId of the local connection is zero.</para>
         /// <para>Clients do not know their connectionId on the server, and do not know the connectionId of other clients on the server.</para>
         /// </remarks>
-        private readonly SocketLayer.IConnection connection;
+        private readonly IConnection connection;
 
         /// <summary>
         /// Has this player been marked as disconnected
@@ -66,7 +64,7 @@ namespace Mirage
         /// </summary>
         public IEndPoint Address => connection.EndPoint;
 
-        public SocketLayer.IConnection Connection => connection;
+        public IConnection Connection => connection;
 
         /// <summary>
         /// Disconnects the player.
@@ -108,7 +106,7 @@ namespace Mirage
         /// Creates a new NetworkConnection with the specified address and connectionId
         /// </summary>
         /// <param name="networkConnectionId"></param>
-        public NetworkPlayer(SocketLayer.IConnection connection)
+        public NetworkPlayer(IConnection connection)
         {
             Assert.IsNotNull(connection);
             this.connection = connection;

--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -95,7 +95,7 @@ namespace Mirage
 
             if (Client != null)
             {
-                Client.Authenticated.AddListener(OnClientAuthenticated);
+                Client.Connected.AddListener(OnClientConnected);
             }
             if (Server != null)
             {
@@ -105,26 +105,26 @@ namespace Mirage
 
         #region Client
 
-        void RegisterClientMessages(INetworkPlayer player)
+        void RegisterClientMessages()
         {
-            player.RegisterHandler<SceneMessage>(ClientSceneMessage);
+            Client.MessageHandler.RegisterHandler<SceneMessage>(ClientSceneMessage);
             if (!Client.IsLocalClient)
             {
-                player.RegisterHandler<SceneReadyMessage>(ClientSceneReadyMessage);
-                player.RegisterHandler<NotReadyMessage>(ClientNotReadyMessage);
+                Client.MessageHandler.RegisterHandler<SceneReadyMessage>(ClientSceneReadyMessage);
+                Client.MessageHandler.RegisterHandler<NotReadyMessage>(ClientNotReadyMessage);
             }
-        }
-
-        void OnClientAuthenticated(INetworkPlayer player)
-        {
-            logger.Log("NetworkSceneManager.OnClientAuthenticated");
-            RegisterClientMessages(player);
         }
 
         void OnDestroy()
         {
             if (Client != null)
-                Client.Authenticated?.RemoveListener(OnClientAuthenticated);
+                Client.Authenticated?.RemoveListener(OnClientConnected);
+        }
+
+        void OnClientConnected(INetworkPlayer _)
+        {
+            logger.Log("NetworkSceneManager.OnClientAuthenticated");
+            RegisterClientMessages();
         }
 
         internal void ClientSceneMessage(INetworkPlayer player, SceneMessage msg)

--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -95,12 +95,18 @@ namespace Mirage
 
             if (Client != null)
             {
-                Client.Connected.AddListener(OnClientConnected);
+                Client.Started.AddListener(RegisterClientMessages);
             }
             if (Server != null)
             {
                 Server.Authenticated.AddListener(OnServerAuthenticated);
             }
+        }
+
+        void OnDestroy()
+        {
+            if (Client != null)
+                Client.Started.RemoveListener(RegisterClientMessages);
         }
 
         #region Client
@@ -113,18 +119,6 @@ namespace Mirage
                 Client.MessageHandler.RegisterHandler<SceneReadyMessage>(ClientSceneReadyMessage);
                 Client.MessageHandler.RegisterHandler<NotReadyMessage>(ClientNotReadyMessage);
             }
-        }
-
-        void OnDestroy()
-        {
-            if (Client != null)
-                Client.Authenticated?.RemoveListener(OnClientConnected);
-        }
-
-        void OnClientConnected(INetworkPlayer _)
-        {
-            logger.Log("NetworkSceneManager.OnClientAuthenticated");
-            RegisterClientMessages();
         }
 
         internal void ClientSceneMessage(INetworkPlayer player, SceneMessage msg)

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -196,6 +196,8 @@ namespace Mirage
 
             if (authenticator != null)
             {
+                Debug.Assert(authenticator.Server == null || authenticator.Server == this, "authenticator had a reference to a different server");
+                authenticator.Server = this;
                 authenticator.OnServerAuthenticated += OnAuthenticated;
 
                 Connected.AddListener(authenticator.ServerAuthenticate);

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -477,10 +477,10 @@ namespace Mirage
         /// </summary>
         class DataHandler : IDataHandler
         {
-            readonly MessageHandler messageHandler;
+            readonly IMessageReceiver messageHandler;
             readonly Dictionary<IConnection, INetworkPlayer> players;
 
-            public DataHandler(MessageHandler messageHandler, Dictionary<IConnection, INetworkPlayer> connections)
+            public DataHandler(IMessageReceiver messageHandler, Dictionary<IConnection, INetworkPlayer> connections)
             {
                 this.messageHandler = messageHandler;
                 players = connections;

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -55,7 +55,6 @@ namespace Mirage
             {
                 Server.Started.AddListener(OnServerStarted);
                 Server.OnStartHost.AddListener(StartedHost);
-                Server.Authenticated.AddListener(OnAuthenticated);
                 Server.Stopped.AddListener(OnServerStopped);
 
                 if (NetworkSceneManager != null)
@@ -66,19 +65,15 @@ namespace Mirage
             }
         }
 
-        internal void RegisterMessageHandlers(INetworkPlayer player)
+        internal void RegisterMessageHandlers()
         {
-            player.RegisterHandler<ReadyMessage>(OnClientReadyMessage);
-            player.RegisterHandler<ServerRpcMessage>(OnServerRpcMessage);
-        }
-
-        void OnAuthenticated(INetworkPlayer player)
-        {
-            RegisterMessageHandlers(player);
+            Server.MessageHandler.RegisterHandler<ReadyMessage>(OnClientReadyMessage);
+            Server.MessageHandler.RegisterHandler<ServerRpcMessage>(OnServerRpcMessage);
         }
 
         void OnServerStarted()
         {
+            RegisterMessageHandlers();
             SpawnOrActivate();
         }
 

--- a/Assets/Mirage/Runtime/SyncVarReceiver.cs
+++ b/Assets/Mirage/Runtime/SyncVarReceiver.cs
@@ -18,24 +18,24 @@ namespace Mirage
             this.objectLocator = objectLocator;
             if (client.IsConnected)
             {
-                AddHandlers(client, client.Player);
+                AddHandlers(client);
             }
             else
             {
                 // todo replace this with RunOnceEvent
-                client.Connected.AddListener(player => AddHandlers(client, player));
+                client.Connected.AddListener(_ => AddHandlers(client));
             }
         }
 
-        private void AddHandlers(NetworkClient client, INetworkPlayer player)
+        private void AddHandlers(NetworkClient client)
         {
             if (client.IsLocalClient)
             {
-                player.RegisterHandler<UpdateVarsMessage>(_ => { });
+                client.MessageHandler.RegisterHandler<UpdateVarsMessage>(_ => { });
             }
             else
             {
-                player.RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
+                client.MessageHandler.RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
             }
         }
 

--- a/Assets/Mirage/Samples~/Chat/Scripts/ChatNetworkManager.cs
+++ b/Assets/Mirage/Samples~/Chat/Scripts/ChatNetworkManager.cs
@@ -13,8 +13,8 @@ namespace Mirage.Examples.Chat
 
         void Awake()
         {
-            Server.Authenticated.AddListener(OnServerAuthenticated);
-            Client.Authenticated.AddListener(OnClientAuthenticated);
+            Server.Started.AddListener(OnServerStarted);
+            Client.Connected.AddListener(OnClientAuthenticated);
         }
 
         public struct CreateCharacterMessage
@@ -22,9 +22,9 @@ namespace Mirage.Examples.Chat
             public string name;
         }
 
-        public void OnServerAuthenticated(INetworkPlayer player)
+        public void OnServerStarted()
         {
-            player.RegisterHandler<CreateCharacterMessage>(OnCreatePlayer);
+            Server.MessageHandler.RegisterHandler<CreateCharacterMessage>(OnCreatePlayer);
         }
 
         public void OnClientAuthenticated(INetworkPlayer player)

--- a/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ReaderWriterProcessor.cs
@@ -188,11 +188,11 @@ namespace Mirage.Weaver
                 method.Is(typeof(MessagePacker), nameof(MessagePacker.GetId)) ||
                 method.Is(typeof(MessagePacker), nameof(MessagePacker.Unpack)) ||
                 method.Is<IMessageSender>(nameof(IMessageSender.Send)) ||
-                method.Is<IMessageSender>(nameof(IMessageReceiver.RegisterHandler)) ||
-                method.Is<IMessageSender>(nameof(IMessageReceiver.UnregisterHandler)) ||
+                method.Is<IMessageReceiver>(nameof(IMessageReceiver.RegisterHandler)) ||
+                method.Is<IMessageReceiver>(nameof(IMessageReceiver.UnregisterHandler)) ||
                 method.Is<NetworkPlayer>(nameof(NetworkPlayer.Send)) ||
-                method.Is<NetworkPlayer>(nameof(NetworkPlayer.RegisterHandler)) ||
-                method.Is<NetworkPlayer>(nameof(NetworkPlayer.UnregisterHandler)) ||
+                method.Is<MessageHandler>(nameof(MessageHandler.RegisterHandler)) ||
+                method.Is<MessageHandler>(nameof(MessageHandler.UnregisterHandler)) ||
                 method.Is<NetworkClient>(nameof(NetworkClient.Send)) ||
                 method.Is<NetworkServer>(nameof(NetworkServer.SendToAll)) ||
                 method.Is<NetworkServer>(nameof(NetworkServer.SendToMany)) ||

--- a/Assets/Tests/Common/LocalConnections.cs
+++ b/Assets/Tests/Common/LocalConnections.cs
@@ -3,11 +3,11 @@ namespace Mirage.Tests
 
     public static class LocalConnections
     {
-        public static (NetworkPlayer serverPlayer, NetworkPlayer clientPlayer) PipedConnections()
+        public static (NetworkPlayer serverPlayer, NetworkPlayer clientPlayer) PipedConnections(MessageHandler clientMessages, MessageHandler serverMessages)
         {
             // we can re-use networkclient's handlers here as it just needs connection and player
-            var clientHandler = new NetworkClient.DataHandler();
-            var serverHandler = new NetworkClient.DataHandler();
+            var clientHandler = new NetworkClient.DataHandler(clientMessages);
+            var serverHandler = new NetworkClient.DataHandler(serverMessages);
 
             (SocketLayer.IConnection clientConn, SocketLayer.IConnection serverConn) = PipePeerConnection.Create(clientHandler, serverHandler, null, null);
 

--- a/Assets/Tests/Common/LocalConnections.cs
+++ b/Assets/Tests/Common/LocalConnections.cs
@@ -3,7 +3,7 @@ namespace Mirage.Tests
 
     public static class LocalConnections
     {
-        public static (NetworkPlayer serverPlayer, NetworkPlayer clientPlayer) PipedConnections(MessageHandler clientMessages, MessageHandler serverMessages)
+        public static (NetworkPlayer serverPlayer, NetworkPlayer clientPlayer) PipedConnections(IMessageReceiver clientMessages, IMessageReceiver serverMessages)
         {
             // we can re-use networkclient's handlers here as it just needs connection and player
             var clientHandler = new NetworkClient.DataHandler(clientMessages);

--- a/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
@@ -239,7 +239,7 @@ namespace Mirage
         public void SetClientOwner()
         {
             // SetClientOwner
-            (_, NetworkPlayer original) = PipedConnections();
+            (_, NetworkPlayer original) = PipedConnections(Substitute.For<IMessageReceiver>(), Substitute.For<IMessageReceiver>());
             identity.SetClientOwner(original);
             Assert.That(identity.ConnectionToClient, Is.EqualTo(original));
         }
@@ -248,11 +248,11 @@ namespace Mirage
         public void SetOverrideClientOwner()
         {
             // SetClientOwner
-            (_, NetworkPlayer original) = PipedConnections();
+            (_, NetworkPlayer original) = PipedConnections(Substitute.For<IMessageReceiver>(), Substitute.For<IMessageReceiver>());
             identity.SetClientOwner(original);
 
             // setting it when it's already set shouldn't overwrite the original
-            (_, NetworkPlayer overwrite) = PipedConnections();
+            (_, NetworkPlayer overwrite) = PipedConnections(Substitute.For<IMessageReceiver>(), Substitute.For<IMessageReceiver>());
             // will log a warning
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -736,7 +736,7 @@ namespace Mirage
             gameObject.AddComponent<RebuildEmptyObserversNetworkBehaviour>();
 
             // add own player connection that isn't ready
-            (_, NetworkPlayer connection) = PipedConnections();
+            (_, NetworkPlayer connection) = PipedConnections(Substitute.For<IMessageReceiver>(), Substitute.For<IMessageReceiver>());
             identity.ConnectionToClient = connection;
 
             // call OnStartServer so that observers dict is created

--- a/Assets/Tests/Runtime/ClientServer/BasicAuthenticatorTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/BasicAuthenticatorTest.cs
@@ -12,8 +12,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         public void CheckConnected()
         {
             // Should have connected
-            Assert.That(connectionToServer, Is.Not.Null);
-            Assert.That(connectionToClient, Is.Not.Null);
+            Assert.That(clientPlayer, Is.Not.Null);
+            Assert.That(serverPlayer, Is.Not.Null);
         }
 
         public override void ExtraSetup()

--- a/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
@@ -64,11 +64,11 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator ClientConnRpc() => UniTask.ToCoroutine(async () =>
         {
-            serverComponent.ClientConnRpcTest(connectionToClient, 1, "hello");
+            serverComponent.ClientConnRpcTest(serverPlayer, 1, "hello");
             // process spawn message from server
             await AsyncUtil.WaitUntilWithTimeout(() => clientComponent.targetRpcArg1 != 0);
 
-            Assert.That(clientComponent.targetRpcPlayer, Is.EqualTo(connectionToServer));
+            Assert.That(clientComponent.targetRpcPlayer, Is.EqualTo(clientPlayer));
             Assert.That(clientComponent.targetRpcArg1, Is.EqualTo(1));
             Assert.That(clientComponent.targetRpcArg2, Is.EqualTo("hello"));
         });
@@ -96,7 +96,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             clientObjectManager.RegisterSpawnHandler(guid, SpawnDelegateTest, go => { });
             clientObjectManager.RegisterPrefab(identity, guid);
-            serverObjectManager.SendSpawnMessage(identity, connectionToClient);
+            serverObjectManager.SendSpawnMessage(identity, serverPlayer);
 
             await AsyncUtil.WaitUntilWithTimeout(() => spawnDelegateTestCalled != 0);
 
@@ -117,7 +117,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             clientObjectManager.RegisterSpawnHandler(guid, SpawnDelegateTest, unspawnDelegate);
             clientObjectManager.RegisterPrefab(identity, guid);
-            serverObjectManager.SendSpawnMessage(identity, connectionToClient);
+            serverObjectManager.SendSpawnMessage(identity, serverPlayer);
 
             await AsyncUtil.WaitUntilWithTimeout(() => spawnDelegateTestCalled != 0);
 

--- a/Assets/Tests/Runtime/ClientServer/ClientServerSetup.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerSetup.cs
@@ -32,8 +32,10 @@ namespace Mirage.Tests.Runtime.ClientServer
         protected GameObject playerPrefab;
 
         protected TestSocketFactory socketFactory;
-        protected INetworkPlayer connectionToServer;
-        protected INetworkPlayer connectionToClient;
+        protected INetworkPlayer clientPlayer;
+        protected INetworkPlayer serverPlayer;
+        protected MessageHandler ClientMessageHandler => client.MessageHandler;
+        protected MessageHandler ServerMessageHandler => server.MessageHandler;
 
         public virtual void ExtraSetup() { }
 
@@ -102,19 +104,19 @@ namespace Mirage.Tests.Runtime.ClientServer
                 await AsyncUtil.WaitUntilWithTimeout(() => server.Players.Count > 0);
 
                 // get the connections so that we can spawn players
-                connectionToClient = server.Players.First();
-                connectionToServer = client.Player;
+                serverPlayer = server.Players.First();
+                clientPlayer = client.Player;
 
                 // create a player object in the server
                 serverPlayerGO = Object.Instantiate(playerPrefab);
                 serverIdentity = serverPlayerGO.GetComponent<NetworkIdentity>();
                 serverComponent = serverPlayerGO.GetComponent<T>();
-                serverObjectManager.AddCharacter(connectionToClient, serverPlayerGO);
+                serverObjectManager.AddCharacter(serverPlayer, serverPlayerGO);
 
                 // wait for client to spawn it
-                await AsyncUtil.WaitUntilWithTimeout(() => connectionToServer.Identity != null);
+                await AsyncUtil.WaitUntilWithTimeout(() => clientPlayer.Identity != null);
 
-                clientIdentity = connectionToServer.Identity;
+                clientIdentity = clientPlayer.Identity;
                 clientPlayerGO = clientIdentity.gameObject;
                 clientComponent = clientPlayerGO.GetComponent<T>();
             }

--- a/Assets/Tests/Runtime/ClientServer/NetworkAuthenticatorTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkAuthenticatorTest.cs
@@ -18,7 +18,10 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             public override void ClientAuthenticate(INetworkPlayer player) => ClientAccept(player);
             public override void ServerAuthenticate(INetworkPlayer player) => ServerAccept(player);
+            public override void ClientSetup(NetworkClient client) { }
+            public override void ServerSetup(NetworkServer server) { }
         }
+
         public override void ExtraSetup()
         {
             serverAuthenticator = serverGo.AddComponent<NetworkAuthenticationImpl>();

--- a/Assets/Tests/Runtime/ClientServer/NetworkClientDisconnectTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkClientDisconnectTest.cs
@@ -51,7 +51,7 @@ namespace Mirage.Tests.Runtime.ClientServer.DisconnectTests
             });
 
             // server's object
-            connectionToClient.Disconnect();
+            serverPlayer.Disconnect();
 
             // wait 2 frames so that messages can go from client->server->client
             yield return null;

--- a/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.ClientServer
             Assert.That(startInvoked == 1, "Start should only be called once");
             Assert.That(endInvoked == 0, "Should wait for ready before end is called");
 
-            clientSceneManager.ClientSceneReadyMessage(connectionToServer, new SceneReadyMessage());
+            clientSceneManager.ClientSceneReadyMessage(clientPlayer, new SceneReadyMessage());
 
             await AsyncUtil.WaitUntilWithTimeout(() => endInvoked == 1);
 

--- a/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
@@ -45,12 +45,12 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator ReadyMessageSetsClientReadyTest() => UniTask.ToCoroutine(async () =>
         {
-            connectionToServer.Send(new ReadyMessage());
+            clientPlayer.Send(new ReadyMessage());
 
-            await AsyncUtil.WaitUntilWithTimeout(() => connectionToClient.IsReady);
+            await AsyncUtil.WaitUntilWithTimeout(() => serverPlayer.IsReady);
 
             // ready?
-            Assert.That(connectionToClient.IsReady, Is.True);
+            Assert.That(serverPlayer.IsReady, Is.True);
         });
 
         [UnityTest]
@@ -58,7 +58,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             bool invoked = false;
 
-            connectionToServer.RegisterHandler<WovenTestMessage>(msg => invoked = true);
+            ClientMessageHandler.RegisterHandler<WovenTestMessage>(msg => invoked = true);
 
             server.SendToAll(message);
 
@@ -73,7 +73,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             bool invoked = false;
 
-            connectionToServer.RegisterHandler<WovenTestMessage>(msg => invoked = true);
+            ClientMessageHandler.RegisterHandler<WovenTestMessage>(msg => invoked = true);
 
             serverIdentity.ConnectionToClient.Send(message);
 
@@ -88,8 +88,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             bool invoked = false;
 
-            connectionToClient.RegisterHandler<WovenTestMessage>(msg => invoked = true);
-            connectionToServer.Send(message);
+            ServerMessageHandler.RegisterHandler<WovenTestMessage>(msg => invoked = true);
+            clientPlayer.Send(message);
 
             await AsyncUtil.WaitUntilWithTimeout(() => invoked);
 
@@ -100,9 +100,9 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             bool invoked = false;
 
-            connectionToClient.RegisterHandler<WovenTestMessage>((conn, msg) => invoked = true);
+            ServerMessageHandler.RegisterHandler<WovenTestMessage>((conn, msg) => invoked = true);
 
-            connectionToServer.Send(message);
+            clientPlayer.Send(message);
 
             await AsyncUtil.WaitUntilWithTimeout(() => invoked);
         });
@@ -110,12 +110,12 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator UnRegisterMessage1() => UniTask.ToCoroutine(async () =>
         {
-            Action<WovenTestMessage> func = Substitute.For<Action<WovenTestMessage>>();
+            MessageDelegate<WovenTestMessage> func = Substitute.For<MessageDelegate<WovenTestMessage>>();
 
-            connectionToClient.RegisterHandler(func);
-            connectionToClient.UnregisterHandler<WovenTestMessage>();
+            ServerMessageHandler.RegisterHandler(func);
+            ServerMessageHandler.UnregisterHandler<WovenTestMessage>();
 
-            connectionToServer.Send(message);
+            clientPlayer.Send(message);
 
             await UniTask.Delay(1);
 

--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -27,7 +27,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                serverObjectManager.Spawn(new GameObject().AddComponent<NetworkIdentity>(), connectionToClient);
+                serverObjectManager.Spawn(new GameObject().AddComponent<NetworkIdentity>(), serverPlayer);
             });
 
             Assert.That(ex.Message, Is.EqualTo("NetworkServer is not active. Cannot spawn objects without an active server."));
@@ -73,12 +73,12 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             bool invoked = false;
 
-            connectionToServer.RegisterHandler<SpawnMessage>(msg => invoked = true);
+            ClientMessageHandler.RegisterHandler<SpawnMessage>(msg => invoked = true);
 
-            connectionToClient.IsReady = true;
+            serverPlayer.IsReady = true;
 
             // call ShowForConnection
-            serverObjectManager.ShowForConnection(serverIdentity, connectionToClient);
+            serverObjectManager.ShowForConnection(serverIdentity, serverPlayer);
 
             // todo assert correct message was sent using Substitute for socket or player
 
@@ -163,9 +163,9 @@ namespace Mirage.Tests.Runtime.ClientServer
             replacementIdentity.AssetId = Guid.NewGuid();
             clientObjectManager.RegisterPrefab(replacementIdentity);
 
-            serverObjectManager.ReplaceCharacter(connectionToClient, playerReplacement);
+            serverObjectManager.ReplaceCharacter(serverPlayer, playerReplacement);
 
-            Assert.That(connectionToClient.Identity, Is.EqualTo(replacementIdentity));
+            Assert.That(serverPlayer.Identity, Is.EqualTo(replacementIdentity));
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace Mirage.Tests.Runtime.ClientServer
             replacementIdentity.AssetId = Guid.NewGuid();
             clientObjectManager.RegisterPrefab(replacementIdentity);
 
-            serverObjectManager.ReplaceCharacter(connectionToClient, playerReplacement, true);
+            serverObjectManager.ReplaceCharacter(serverPlayer, playerReplacement, true);
 
             Assert.That(clientIdentity.ConnectionToClient, Is.EqualTo(null));
         }
@@ -190,9 +190,9 @@ namespace Mirage.Tests.Runtime.ClientServer
             replacementIdentity.AssetId = replacementGuid;
             clientObjectManager.RegisterPrefab(replacementIdentity);
 
-            serverObjectManager.ReplaceCharacter(connectionToClient, playerReplacement, replacementGuid);
+            serverObjectManager.ReplaceCharacter(serverPlayer, playerReplacement, replacementGuid);
 
-            Assert.That(connectionToClient.Identity.AssetId, Is.EqualTo(replacementGuid));
+            Assert.That(serverPlayer.Identity.AssetId, Is.EqualTo(replacementGuid));
         }
 
         [Test]
@@ -204,17 +204,17 @@ namespace Mirage.Tests.Runtime.ClientServer
             replacementIdentity.AssetId = replacementGuid;
             clientObjectManager.RegisterPrefab(replacementIdentity);
 
-            connectionToClient.Identity = null;
+            serverPlayer.Identity = null;
 
-            serverObjectManager.AddCharacter(connectionToClient, playerReplacement, replacementGuid);
+            serverObjectManager.AddCharacter(serverPlayer, playerReplacement, replacementGuid);
 
-            Assert.That(replacementIdentity == connectionToClient.Identity);
+            Assert.That(replacementIdentity == serverPlayer.Identity);
         }
 
         [UnityTest]
         public IEnumerator RemovePlayerForConnectionTest() => UniTask.ToCoroutine(async () =>
         {
-            serverObjectManager.RemovePlayerForConnection(connectionToClient);
+            serverObjectManager.RemovePlayerForConnection(serverPlayer);
 
             await AsyncUtil.WaitUntilWithTimeout(() => !clientIdentity);
 
@@ -224,20 +224,20 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator RemovePlayerForConnectionExceptionTest() => UniTask.ToCoroutine(async () =>
         {
-            serverObjectManager.RemovePlayerForConnection(connectionToClient);
+            serverObjectManager.RemovePlayerForConnection(serverPlayer);
 
             await AsyncUtil.WaitUntilWithTimeout(() => !clientIdentity);
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                serverObjectManager.RemovePlayerForConnection(connectionToClient);
+                serverObjectManager.RemovePlayerForConnection(serverPlayer);
             });
         });
 
         [UnityTest]
         public IEnumerator RemovePlayerForConnectionDestroyTest() => UniTask.ToCoroutine(async () =>
         {
-            serverObjectManager.RemovePlayerForConnection(connectionToClient, true);
+            serverObjectManager.RemovePlayerForConnection(serverPlayer, true);
 
             await AsyncUtil.WaitUntilWithTimeout(() => !clientIdentity);
 
@@ -249,7 +249,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                serverObjectManager.Spawn(new GameObject(), connectionToServer);
+                serverObjectManager.Spawn(new GameObject(), clientPlayer);
             });
 
             AssertNoIdentityMessage(ex);
@@ -261,7 +261,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                serverObjectManager.AddCharacter(connectionToClient, new GameObject());
+                serverObjectManager.AddCharacter(serverPlayer, new GameObject());
             });
             AssertNoIdentityMessage(ex);
 
@@ -272,7 +272,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                serverObjectManager.ReplaceCharacter(connectionToClient, new GameObject(), true);
+                serverObjectManager.ReplaceCharacter(serverPlayer, new GameObject(), true);
             });
             AssertNoIdentityMessage(ex);
         }

--- a/Assets/Tests/Runtime/Host/Authenticators.meta
+++ b/Assets/Tests/Runtime/Host/Authenticators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20494b0e67c66c44197be2409ebd30be
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/Host/Authenticators/AuthenticatorHostModeBase.cs
+++ b/Assets/Tests/Runtime/Host/Authenticators/AuthenticatorHostModeBase.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+
+namespace Mirage.Tests.Runtime.Host.Authenticators
+{
+    public abstract class AuthenticatorHostModeBase : HostSetup<MockComponent>
+    {
+        protected abstract void AddAuthenticator();
+
+
+        int serverAuthCalled;
+        int clientAuthCalled;
+
+        public sealed override void ExtraSetup()
+        {
+            AddAuthenticator();
+
+            // reset fields
+            serverAuthCalled = 0;
+            clientAuthCalled = 0;
+
+            server.Authenticated.AddListener(_ => serverAuthCalled++);
+            client.Authenticated.AddListener(_ => clientAuthCalled++);
+        }
+
+        [Test]
+        public void AuthenticatedCalledOnceOnServer()
+        {
+            Assert.That(serverAuthCalled, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AuthenticatedCalledOnceOnClient()
+        {
+            Assert.That(clientAuthCalled, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Tests/Runtime/Host/Authenticators/AuthenticatorHostModeBase.cs.meta
+++ b/Assets/Tests/Runtime/Host/Authenticators/AuthenticatorHostModeBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5ac94b5943de4c4cbd220c71cfe0405
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/Host/Authenticators/BasicAuthenticatorHostMode.cs
+++ b/Assets/Tests/Runtime/Host/Authenticators/BasicAuthenticatorHostMode.cs
@@ -1,0 +1,15 @@
+using Mirage.Authenticators;
+
+namespace Mirage.Tests.Runtime.Host.Authenticators
+{
+    public class BasicAuthenticatorHostMode : AuthenticatorHostModeBase
+    {
+        protected override void AddAuthenticator()
+        {
+            BasicAuthenticator auth = networkManagerGo.AddComponent<BasicAuthenticator>();
+            server.authenticator = auth;
+            client.authenticator = auth;
+            auth.serverCode = "1234";
+        }
+    }
+}

--- a/Assets/Tests/Runtime/Host/Authenticators/BasicAuthenticatorHostMode.cs.meta
+++ b/Assets/Tests/Runtime/Host/Authenticators/BasicAuthenticatorHostMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd6f1d4112ff5af4abf5a665ec75c1b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/Host/Authenticators/NoAuthenticatorHostMode.cs
+++ b/Assets/Tests/Runtime/Host/Authenticators/NoAuthenticatorHostMode.cs
@@ -1,0 +1,12 @@
+namespace Mirage.Tests.Runtime.Host.Authenticators
+{
+    public class NoAuthenticatorHostMode : AuthenticatorHostModeBase
+    {
+        protected override void AddAuthenticator()
+        {
+            server.authenticator = null;
+            client.authenticator = null;
+
+        }
+    }
+}

--- a/Assets/Tests/Runtime/Host/Authenticators/NoAuthenticatorHostMode.cs.meta
+++ b/Assets/Tests/Runtime/Host/Authenticators/NoAuthenticatorHostMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86cb6f26f16a4844fa4086b040991691
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/Host/CharacterSpawnerTest.cs
+++ b/Assets/Tests/Runtime/Host/CharacterSpawnerTest.cs
@@ -41,7 +41,7 @@ namespace Mirage.Tests.Runtime.Host
         public IEnumerator DontAutoSpawnTest() => UniTask.ToCoroutine(async () =>
         {
             bool invokeAddPlayerMessage = false;
-            server.LocalPlayer.RegisterHandler<AddCharacterMessage>(msg => invokeAddPlayerMessage = true);
+            ServerMessageHandler.RegisterHandler<AddCharacterMessage>(msg => invokeAddPlayerMessage = true);
 
             sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity");
             // wait for messages to be processed
@@ -55,7 +55,7 @@ namespace Mirage.Tests.Runtime.Host
         public IEnumerator ManualSpawnTest() => UniTask.ToCoroutine(async () =>
         {
             bool invokeAddPlayerMessage = false;
-            server.LocalPlayer.RegisterHandler<AddCharacterMessage>(msg => invokeAddPlayerMessage = true);
+            ServerMessageHandler.RegisterHandler<AddCharacterMessage>(msg => invokeAddPlayerMessage = true);
 
             spawner.RequestServerSpawnPlayer();
 

--- a/Assets/Tests/Runtime/Host/HostSetup.cs
+++ b/Assets/Tests/Runtime/Host/HostSetup.cs
@@ -23,6 +23,9 @@ namespace Mirage.Tests.Runtime.Host
         protected NetworkIdentity identity;
         protected T component;
 
+        protected MessageHandler ClientMessageHandler => client.MessageHandler;
+        protected MessageHandler ServerMessageHandler => server.MessageHandler;
+
         protected virtual bool AutoStartServer => true;
         protected virtual Config ServerConfig => null;
         protected virtual Config ClientConfig => null;

--- a/Assets/Tests/Runtime/Host/LobbyReadyTest.cs
+++ b/Assets/Tests/Runtime/Host/LobbyReadyTest.cs
@@ -43,7 +43,7 @@ namespace Mirage.Tests.Runtime.Host
             readyComp.IsReady = true;
 
             bool invokeWovenTestMessage = false;
-            client.Player.RegisterHandler<SceneMessage>(msg => invokeWovenTestMessage = true);
+            ClientMessageHandler.RegisterHandler<SceneMessage>(msg => invokeWovenTestMessage = true);
             lobby.SendToReady(identity, new SceneMessage(), true, Channel.Reliable);
 
             await AsyncUtil.WaitUntilWithTimeout(() => invokeWovenTestMessage);

--- a/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
@@ -109,7 +109,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void HasIdentitysConnectionToClient()
         {
-            (_, identity.ConnectionToClient) = PipedConnections();
+            (_, identity.ConnectionToClient) = PipedConnections(ClientMessageHandler, ServerMessageHandler);
             Assert.That(component.ConnectionToClient, Is.EqualTo(identity.ConnectionToClient));
         }
 

--- a/Assets/Tests/Runtime/Host/NetworkClientTest.cs
+++ b/Assets/Tests/Runtime/Host/NetworkClientTest.cs
@@ -32,13 +32,11 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void ConnectionClearHandlersTest()
         {
-            var clientConn = client.Player as NetworkPlayer;
+            Assert.That(ClientMessageHandler.messageHandlers.Count > 0);
 
-            Assert.That(clientConn.messageHandlers.Count > 0);
+            ClientMessageHandler.ClearHandlers();
 
-            clientConn.ClearHandlers();
-
-            Assert.That(clientConn.messageHandlers.Count == 0);
+            Assert.That(ClientMessageHandler.messageHandlers.Count == 0);
         }
 
         [Test]

--- a/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
@@ -66,8 +66,8 @@ namespace Mirage.Tests.Runtime.Host
             bool invokeClientSceneMessage = false;
             bool invokeNotReadyMessage = false;
             UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
-            client.Player.RegisterHandler<SceneMessage>(msg => invokeClientSceneMessage = true);
-            client.Player.RegisterHandler<NotReadyMessage>(msg => invokeNotReadyMessage = true);
+            ClientMessageHandler.RegisterHandler<SceneMessage>(msg => invokeClientSceneMessage = true);
+            ClientMessageHandler.RegisterHandler<NotReadyMessage>(msg => invokeNotReadyMessage = true);
             sceneManager.ServerChangeScene.AddListener(func1);
 
             sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity");

--- a/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
@@ -16,7 +16,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void SetClientReadyAndNotReadyTest()
         {
-            (_, NetworkPlayer connection) = PipedConnections();
+            (_, NetworkPlayer connection) = PipedConnections(ClientMessageHandler, ServerMessageHandler);
             Assert.That(connection.IsReady, Is.False);
 
             serverObjectManager.SetClientReady(connection);
@@ -30,12 +30,12 @@ namespace Mirage.Tests.Runtime.Host
         public void SetAllClientsNotReadyTest()
         {
             // add first ready client
-            (_, NetworkPlayer first) = PipedConnections();
+            (_, NetworkPlayer first) = PipedConnections(ClientMessageHandler, ServerMessageHandler);
             first.IsReady = true;
             server.Players.Add(first);
 
             // add second ready client
-            (_, NetworkPlayer second) = PipedConnections();
+            (_, NetworkPlayer second) = PipedConnections(ClientMessageHandler, ServerMessageHandler);
             second.IsReady = true;
             server.Players.Add(second);
 

--- a/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
@@ -93,7 +93,7 @@ namespace Mirage.Tests.Runtime
             gameObject.AddComponent<RebuildEmptyObserversNetworkBehaviour>();
 
             // add own player connection
-            (NetworkPlayer serverPlayer, NetworkPlayer _) = PipedConnections();
+            (NetworkPlayer serverPlayer, NetworkPlayer _) = PipedConnections(Substitute.For<IMessageReceiver>(), Substitute.For<IMessageReceiver>());
             serverPlayer.IsReady = true;
             identity.ConnectionToClient = serverPlayer;
 

--- a/Assets/Tests/Runtime/Serialization/MessageHandlerTest.cs
+++ b/Assets/Tests/Runtime/Serialization/MessageHandlerTest.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.IO;
+using Mirage.Serialization;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace Mirage.Tests.Runtime
+{
+    public class MessageHandlerTest
+    {
+        private NetworkPlayer player;
+        private NetworkReader reader;
+        private SocketLayer.IConnection connection;
+        private MessageHandler messageHandler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            connection = Substitute.For<SocketLayer.IConnection>();
+            player = new NetworkPlayer(connection);
+            // reader with some random data
+            reader = new NetworkReader();
+            reader.Reset(new byte[] { 1, 2, 3, 4 });
+
+            messageHandler = new MessageHandler(true);
+        }
+
+
+        [Test]
+        public void InvokesMessageHandler()
+        {
+            int invoked = 0;
+            messageHandler.RegisterHandler<ReadyMessage>(_ => { invoked++; });
+
+            int messageId = MessagePacker.GetId<ReadyMessage>();
+            messageHandler.InvokeHandler(player, messageId, reader);
+
+            Assert.That(invoked, Is.EqualTo(1), "Should have been invoked");
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DisconnectsIfHandlerHasException(bool disconnectOnThrow)
+        {
+            messageHandler = new MessageHandler(disconnectOnThrow);
+
+            int invoked = 0;
+            messageHandler.RegisterHandler<ReadyMessage>(_ => { invoked++; throw new InvalidOperationException("Fun Exception"); });
+
+            var packet = new ArraySegment<byte>(MessagePacker.Pack(new ReadyMessage()));
+            LogAssert.ignoreFailingMessages = true;
+            Assert.DoesNotThrow(() =>
+            {
+                messageHandler.HandleMessage(player, packet);
+            });
+            LogAssert.ignoreFailingMessages = false;
+
+            Assert.That(invoked, Is.EqualTo(1), "Should have been invoked");
+
+            if (disconnectOnThrow)
+            {
+                connection.Received(1).Disconnect();
+            }
+            else
+            {
+                connection.DidNotReceive().Disconnect();
+            }
+        }
+
+        [Test]
+        public void ThrowsWhenNoHandlerIsFound()
+        {
+            int messageId = MessagePacker.GetId<SceneMessage>();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            {
+                messageHandler.InvokeHandler(player, messageId, reader);
+            });
+
+            Assert.That(exception.Message, Does.StartWith("Unexpected message Mirage.SceneMessage received"));
+        }
+
+        [Test]
+        public void ThrowsWhenUnknownMessage()
+        {
+            _ = MessagePacker.GetId<SceneMessage>();
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            {
+                // some random id with no message
+                messageHandler.InvokeHandler(player, 1234, reader);
+            });
+
+            Assert.That(exception.Message, Does.StartWith("Unexpected message ID 1234 received"));
+        }
+    }
+}

--- a/Assets/Tests/Runtime/Serialization/MessageHandlerTest.cs.meta
+++ b/Assets/Tests/Runtime/Serialization/MessageHandlerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12d20767883feb64ebfc388ed9dac57d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/Serialization/NetworkPlayerTest.cs
+++ b/Assets/Tests/Runtime/Serialization/NetworkPlayerTest.cs
@@ -1,10 +1,7 @@
 using System;
-using System.IO;
 using System.Linq;
-using Mirage.Serialization;
 using NSubstitute;
 using NUnit.Framework;
-using UnityEngine.TestTools;
 
 namespace Mirage.Tests.Runtime
 {
@@ -59,81 +56,6 @@ namespace Mirage.Tests.Runtime
             player.Send(new ArraySegment<byte>(new byte[] { 0, 1, 2 }));
             connection.DidNotReceive().SendReliable(Arg.Any<byte[]>());
             connection.DidNotReceive().SendUnreliable(Arg.Any<byte[]>());
-        }
-    }
-    public class NetworkPlayerMessageHandlingTest
-    {
-        private NetworkPlayer player;
-        private NetworkReader reader;
-        private SocketLayer.IConnection connection;
-
-        [SetUp]
-        public void SetUp()
-        {
-            connection = Substitute.For<SocketLayer.IConnection>();
-            player = new NetworkPlayer(connection);
-            // reader with some random data
-            reader = new NetworkReader();
-            reader.Reset(new byte[] { 1, 2, 3, 4 });
-        }
-
-
-        [Test]
-        public void InvokesMessageHandler()
-        {
-            int invoked = 0;
-            player.RegisterHandler<ReadyMessage>(_ => { invoked++; });
-
-            int messageId = MessagePacker.GetId<ReadyMessage>();
-            player.InvokeHandler(messageId, reader);
-
-            Assert.That(invoked, Is.EqualTo(1), "Should have been invoked");
-        }
-
-        [Test]
-        public void DisconnectsIfHandlerHasException()
-        {
-            int invoked = 0;
-            player.RegisterHandler<ReadyMessage>(_ => { invoked++; throw new InvalidOperationException("Fun Exception"); });
-
-            var packet = new ArraySegment<byte>(MessagePacker.Pack(new ReadyMessage()));
-            LogAssert.ignoreFailingMessages = true;
-            Assert.DoesNotThrow(() =>
-            {
-                ((IMessageHandler)player).HandleMessage(packet);
-            });
-            LogAssert.ignoreFailingMessages = false;
-
-            Assert.That(invoked, Is.EqualTo(1), "Should have been invoked");
-
-            // should disconnect after catching the execption
-            connection.Received(1).Disconnect();
-        }
-
-        [Test]
-        public void ThrowsWhenNoHandlerIsFound()
-        {
-            int messageId = MessagePacker.GetId<SceneMessage>();
-
-            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
-            {
-                player.InvokeHandler(messageId, reader);
-            });
-
-            Assert.That(exception.Message, Does.StartWith("Unexpected message Mirage.SceneMessage received"));
-        }
-
-        [Test]
-        public void ThrowsWhenUnknownMessage()
-        {
-            _ = MessagePacker.GetId<SceneMessage>();
-            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
-            {
-                // some random id with no message
-                player.InvokeHandler(1234, reader);
-            });
-
-            Assert.That(exception.Message, Does.StartWith("Unexpected message ID 1234 received"));
         }
     }
 }


### PR DESCRIPTION
resolves: https://github.com/MirageNet/Mirage/issues/831
resolves: https://github.com/MirageNet/Mirage/pull/830

Making NetworkPlayer do less things, Server or client should handle message instead of player. 

Makes registering message simpler, no need to wait for player to Connect to register message.

BREAKING CHANGE: RegisterHandler functions now exist on MessageHandler On Server and Client
BREAKING CHANGE: NetworkAuthenticator now use Setup methods that should be used to register messages