### PR TITLE
feat: reworking network authenticator

### DIFF
--- a/Assets/Mirage/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirage/Runtime/NetworkAuthenticator.cs
@@ -21,39 +21,56 @@ namespace Mirage
 
         #region server
 
-        // This will get more code in the near future
-        internal void OnServerAuthenticateInternal(INetworkPlayer player)
-        {
-            OnServerAuthenticate(player);
-        }
-
         /// <summary>
-        /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
+        /// Call this when player has been accepted on the server
         /// </summary>
-        /// <param name="player">Connection to client.</param>
-        public virtual void OnServerAuthenticate(INetworkPlayer player)
+        /// <param name="player"></param>
+        protected void ServerAccept(INetworkPlayer player)
         {
             OnServerAuthenticated?.Invoke(player);
         }
+        /// <summary>
+        /// Call this when player has been rejected on the server. This will disconnect the player.
+        /// </summary>
+        /// <param name="player"></param>
+        protected void ServerReject(INetworkPlayer player)
+        {
+            player.Disconnect();
+        }
+
+        /// <summary>
+        /// Authenticate the player on the Server.
+        /// <para>Called by the server when new client connects</para>
+        /// </summary>
+        /// <param name="player"></param>
+        public abstract void ServerAuthenticate(INetworkPlayer player);
 
         #endregion
 
         #region client
-
-        // This will get more code in the near future
-        internal void OnClientAuthenticateInternal(INetworkPlayer player)
-        {
-            OnClientAuthenticate(player);
-        }
-
         /// <summary>
-        /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
+        /// Call this when player has been accepted on the client.
         /// </summary>
-        /// <param name="player">Connection of the client.</param>
-        public virtual void OnClientAuthenticate(INetworkPlayer player)
+        /// <param name="player"></param>
+        protected void ClientAccept(INetworkPlayer player)
         {
             OnClientAuthenticated?.Invoke(player);
         }
+        /// <summary>
+        /// Call this when player has been rejected on the client. This will disconnect the player.
+        /// </summary>
+        /// <param name="player"></param>
+        protected void ClientReject(INetworkPlayer player)
+        {
+            player.Disconnect();
+        }
+
+        /// <summary>
+        /// Authenticate the player on the Client.
+        /// <para>Called by the client after connected to the server</para>
+        /// </summary>
+        /// <param name="player"></param>
+        public abstract void ClientAuthenticate(INetworkPlayer player);
 
         #endregion
 

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -205,7 +205,7 @@ namespace Mirage
             {
                 authenticator.OnClientAuthenticated += OnAuthenticated;
 
-                Connected.AddListener(authenticator.OnClientAuthenticateInternal);
+                Connected.AddListener(authenticator.ClientAuthenticate);
             }
             else
             {
@@ -288,7 +288,7 @@ namespace Mirage
             if (authenticator != null)
             {
                 authenticator.OnClientAuthenticated -= OnAuthenticated;
-                Connected.RemoveListener(authenticator.OnClientAuthenticateInternal);
+                Connected.RemoveListener(authenticator.ClientAuthenticate);
             }
             else
             {

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -189,7 +189,7 @@ namespace Mirage
             {
                 authenticator.OnServerAuthenticated += OnAuthenticated;
 
-                Connected.AddListener(authenticator.OnServerAuthenticateInternal);
+                Connected.AddListener(authenticator.ServerAuthenticate);
             }
             else
             {
@@ -277,7 +277,7 @@ namespace Mirage
             if (authenticator != null)
             {
                 authenticator.OnServerAuthenticated -= OnAuthenticated;
-                Connected.RemoveListener(authenticator.OnServerAuthenticateInternal);
+                Connected.RemoveListener(authenticator.ServerAuthenticate);
             }
             else
             {

--- a/Assets/Tests/Runtime/ClientServer/NetworkAuthenticatorTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkAuthenticatorTest.cs
@@ -14,8 +14,11 @@ namespace Mirage.Tests.Runtime.ClientServer
         Action<INetworkPlayer> clientMockMethod;
 
 
-        class NetworkAuthenticationImpl : NetworkAuthenticator { };
-
+        class NetworkAuthenticationImpl : NetworkAuthenticator
+        {
+            public override void ClientAuthenticate(INetworkPlayer player) => ClientAccept(player);
+            public override void ServerAuthenticate(INetworkPlayer player) => ServerAccept(player);
+        }
         public override void ExtraSetup()
         {
             serverAuthenticator = serverGo.AddComponent<NetworkAuthenticationImpl>();
@@ -33,15 +36,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         [Test]
         public void OnServerAuthenticateTest()
         {
-            serverAuthenticator.OnServerAuthenticate(Substitute.For<INetworkPlayer>());
-
-            serverMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
-        }
-
-        [Test]
-        public void OnServerAuthenticateInternalTest()
-        {
-            serverAuthenticator.OnServerAuthenticateInternal(Substitute.For<INetworkPlayer>());
+            serverAuthenticator.ServerAuthenticate(Substitute.For<INetworkPlayer>());
 
             serverMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }
@@ -49,15 +44,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         [Test]
         public void OnClientAuthenticateTest()
         {
-            clientAuthenticator.OnClientAuthenticate(Substitute.For<INetworkPlayer>());
-
-            clientMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
-        }
-
-        [Test]
-        public void OnClientAuthenticateInternalTest()
-        {
-            clientAuthenticator.OnClientAuthenticateInternal(Substitute.For<INetworkPlayer>());
+            clientAuthenticator.ClientAuthenticate(Substitute.For<INetworkPlayer>());
 
             clientMockMethod.Received().Invoke(Arg.Any<INetworkPlayer>());
         }


### PR DESCRIPTION
- adding Server/Client Accept/Reject method so it is no longer required to call `base.`
- fixed TimeoutAuthenticator calling wrong authenticate method
- removing internal methods, and just having virual methods instead
- adding more doc comments
- methods are now abstract in base class instead of virtual, they should always be overriden by implementaion, and there are now accept methods to call instead of `base.`

BREAKING CHANGE:
- BasicAuthenticator now uses single string field instead of 2
- Renaming methods from OnServerAuthenticate to ServerAuthenticate
- Renaming methods from OnClientAuthenticate to ClientAuthenticate