### PR TITLE
feat: adding is authenticated bool to network player

### DIFF
--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -69,6 +69,15 @@ namespace Mirage
 
     public interface IAuthenticatedObject
     {
+        /// <summary>
+        /// Marks if this player has been accepted by a <see cref="NetworkAuthenticator"/>
+        /// </summary>
+        bool IsAuthenticated { get; set; }
+
+        /// <summary>
+        /// General purpose object to hold authentication data, character selection, tokens, etc.
+        /// associated with the connection for reference after Authentication completes.
+        /// </summary>
         object AuthenticationData { get; set; }
     }
 

--- a/Assets/Mirage/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirage/Runtime/NetworkAuthenticator.cs
@@ -27,6 +27,7 @@ namespace Mirage
         /// <param name="player"></param>
         protected void ServerAccept(INetworkPlayer player)
         {
+            player.IsAuthenticated = true;
             OnServerAuthenticated?.Invoke(player);
         }
         /// <summary>
@@ -54,6 +55,7 @@ namespace Mirage
         /// <param name="player"></param>
         protected void ClientAccept(INetworkPlayer player)
         {
+            player.IsAuthenticated = true;
             OnClientAuthenticated?.Invoke(player);
         }
         /// <summary>

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -49,6 +49,10 @@ namespace Mirage
         /// </summary>
         bool isDisconnected = false;
 
+        /// <summary>
+        /// Marks if this player has been accepted by a <see cref="NetworkAuthenticator"/>
+        /// </summary>
+        public bool IsAuthenticated { get; set; }
 
         /// <summary>
         /// General purpose object to hold authentication data, character selection, tokens, etc.


### PR DESCRIPTION
Adding an explicit way to check if a network authenticator has accepted a client. some Authenticators dont set `AuthenticationData` so without the bool it is impossible to check if a player is authenticated or not.