### PR TITLE
refactor: updating errors and function names

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -341,7 +341,7 @@ namespace Mirage
             {
                 using (PooledNetworkReader payloadReader = NetworkReaderPool.GetReader(msg.payload))
                 {
-                    identity.OnDeserializeAllSafely(payloadReader, true);
+                    identity.OnDeserializeAll(payloadReader, true);
                 }
             }
 

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -525,7 +525,7 @@ namespace Mirage
 
             // serialize all components with initialState = true
             // (can be null if has none)
-            identity.OnSerializeAllSafely(true, ownerWriter, observersWriter);
+            identity.OnSerializeAll(true, ownerWriter, observersWriter);
 
             // use owner segment if 'conn' owns this identity, otherwise
             // use observers segment

--- a/Assets/Mirage/Runtime/SyncVarReceiver.cs
+++ b/Assets/Mirage/Runtime/SyncVarReceiver.cs
@@ -46,7 +46,7 @@ namespace Mirage
             if (objectLocator.TryGetIdentity(msg.netId, out NetworkIdentity localObject))
             {
                 using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
-                    localObject.OnDeserializeAllSafely(networkReader, false);
+                    localObject.OnDeserializeAll(networkReader, false);
             }
             else
             {

--- a/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
@@ -508,7 +508,7 @@ namespace Mirage
             // serialize should propagate exceptions
             Assert.Throws<Exception>(() =>
             {
-                identity.OnSerializeAllSafely(true, ownerWriter, observersWriter);
+                identity.OnSerializeAll(true, ownerWriter, observersWriter);
             });
         }
 
@@ -549,7 +549,7 @@ namespace Mirage
             // serialize
             var ownerWriter = new NetworkWriter();
             var observersWriter = new NetworkWriter();
-            identity.OnSerializeAllSafely(true, ownerWriter, observersWriter);
+            identity.OnSerializeAll(true, ownerWriter, observersWriter);
 
             // reset component values
             comp1.value = 0;
@@ -559,7 +559,7 @@ namespace Mirage
             var reader = new NetworkReader(ownerWriter.ToArray());
             Assert.Throws<InvalidMessageException>(() =>
             {
-                identity.OnDeserializeAllSafely(reader, true);
+                identity.OnDeserializeAll(reader, true);
             });
         }
 

--- a/Assets/Tests/Runtime/SyncVarTest.cs
+++ b/Assets/Tests/Runtime/SyncVarTest.cs
@@ -125,7 +125,7 @@ namespace Mirage.Tests.Runtime.Serialization
             var ownerWriter = new NetworkWriter();
             // not really used in this Test
             var observersWriter = new NetworkWriter();
-            identity1.OnSerializeAllSafely(true, ownerWriter, observersWriter);
+            identity1.OnSerializeAll(true, ownerWriter, observersWriter);
 
             // set up a "client" object
             var gameObject2 = new GameObject();
@@ -134,7 +134,7 @@ namespace Mirage.Tests.Runtime.Serialization
 
             // apply all the data from the server object
             var reader = new NetworkReader(ownerWriter.ToArray());
-            identity2.OnDeserializeAllSafely(reader, true);
+            identity2.OnDeserializeAll(reader, true);
 
             // check that the syncvars got updated
             Assert.That(player2.guild.name, Is.EqualTo("Back street boys"), "Data should be synchronized");

--- a/Assets/Tests/Runtime/SyncVarVirtualTest.cs
+++ b/Assets/Tests/Runtime/SyncVarVirtualTest.cs
@@ -79,11 +79,11 @@ namespace Mirage.Tests.Runtime.Serialization
             // not really used in this Test
             var observersWriter = new NetworkWriter();
 
-            netIdServer.OnSerializeAllSafely(true, ownerWriter, observersWriter);
+            netIdServer.OnSerializeAll(true, ownerWriter, observersWriter);
 
             // apply all the data from the server object
             var reader = new NetworkReader(ownerWriter.ToArray());
-            netIdClient.OnDeserializeAllSafely(reader, true);
+            netIdClient.OnDeserializeAll(reader, true);
         }
 
         [TearDown]


### PR DESCRIPTION
- Safely was added to imply a try catch, that try catch no longer exists