### PR TITLE
fix: character spawner not spawning player in some cases

### DIFF
--- a/Assets/Mirage/Runtime/CharacterSpawner.cs
+++ b/Assets/Mirage/Runtime/CharacterSpawner.cs
@@ -33,7 +33,7 @@ namespace Mirage
         public bool AutoSpawn = true;
 
         // Start is called before the first frame update
-        public virtual void Start()
+        public virtual void Awake()
         {
             if (PlayerPrefab == null)
             {

--- a/Assets/Tests/Editor/CharacterSpawnerTest.cs
+++ b/Assets/Tests/Editor/CharacterSpawnerTest.cs
@@ -68,7 +68,7 @@ namespace Mirage
             spawner.PlayerPrefab = null;
             Assert.Throws<InvalidOperationException>(() =>
             {
-                spawner.Start();
+                spawner.Awake();
             });
         }
 
@@ -78,28 +78,28 @@ namespace Mirage
             spawner.ServerObjectManager = null;
             Assert.Throws<InvalidOperationException>(() =>
             {
-                spawner.Start();
+                spawner.Awake();
             });
         }
 
         [Test]
         public void AutoConfigureClient()
         {
-            spawner.Start();
+            spawner.Awake();
             Assert.That(spawner.Client, Is.SameAs(client));
         }
 
         [Test]
         public void AutoConfigureServer()
         {
-            spawner.Start();
+            spawner.Awake();
             Assert.That(spawner.Server, Is.SameAs(server));
         }
 
         [Test]
         public void GetStartPositionRoundRobinTest()
         {
-            spawner.Start();
+            spawner.Awake();
 
             spawner.playerSpawnMethod = CharacterSpawner.PlayerSpawnMethod.RoundRobin;
             Assert.That(spawner.GetStartPosition(), Is.SameAs(pos1.transform));
@@ -111,7 +111,7 @@ namespace Mirage
         [Test]
         public void GetStartPositionRandomTest()
         {
-            spawner.Start();
+            spawner.Awake();
 
             spawner.playerSpawnMethod = CharacterSpawner.PlayerSpawnMethod.Random;
             Assert.That(spawner.GetStartPosition(), Is.SameAs(pos1.transform) | Is.SameAs(pos2.transform));
@@ -120,7 +120,7 @@ namespace Mirage
         [Test]
         public void GetStartPositionNullTest()
         {
-            spawner.Start();
+            spawner.Awake();
 
             spawner.startPositions.Clear();
             Assert.That(spawner.GetStartPosition(), Is.SameAs(null));
@@ -132,7 +132,7 @@ namespace Mirage
             spawner.ClientObjectManager = null;
             Assert.Throws<InvalidOperationException>(() =>
             {
-                spawner.Start();
+                spawner.Awake();
             });
         }
     }


### PR DESCRIPTION
This PR fixes an issue with the character spawner component not spawning the player if the network manager has been spawned in later by a bootstrapper of some kind. I'm not exactly sure why putting the register calls in Awake fixes it but it seems to work.