### PR TITLE
refactor: simplifying packet size in config

### DIFF
--- a/Assets/Mirage/Runtime/SocketLayer/AckSystem.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/AckSystem.cs
@@ -29,7 +29,7 @@ namespace Mirage.SocketLayer
 
         //todo implement this
         readonly int maxPacketsInSendBufferPerConnection;
-        readonly int MTU;
+        readonly int maxPacketSize;
         readonly float ackTimeout;
         /// <summary>how many empty acks to send</summary>
         readonly int emptyAckLimit;
@@ -69,7 +69,7 @@ namespace Mirage.SocketLayer
             ackTimeout = config.TimeBeforeEmptyAck;
             emptyAckLimit = config.EmptyAckLimit;
             receivesBeforeEmpty = config.ReceivesBeforeEmptyAck;
-            MTU = config.Mtu;
+            maxPacketSize = config.MaxPacketSize;
             maxPacketsInSendBufferPerConnection = config.MaxReliablePacketsInSendBufferPerConnection;
 
             int size = config.SequenceSize;
@@ -173,9 +173,9 @@ namespace Mirage.SocketLayer
         public INotifyToken SendNotify(byte[] inPacket, int inOffset, int inLength)
         {
             // todo batch Notify?
-            if (inLength + HEADER_SIZE_NOTIFY > MTU)
+            if (inLength + HEADER_SIZE_NOTIFY > maxPacketSize)
             {
-                throw new IndexOutOfRangeException($"Message is bigger than MTU, max Notify message size is {MTU - HEADER_SIZE_NOTIFY}");
+                throw new IndexOutOfRangeException($"Message is bigger than MTU, max Notify message size is {maxPacketSize - HEADER_SIZE_NOTIFY}");
             }
             if (sentAckablePackets.IsFull)
             {
@@ -208,9 +208,9 @@ namespace Mirage.SocketLayer
 
         public void SendReliable(byte[] message, int offset, int length)
         {
-            if (length + HEADER_SIZE_RELIABLE + 2 > MTU)
+            if (length + HEADER_SIZE_RELIABLE + 2 > maxPacketSize)
             {
-                throw new IndexOutOfRangeException($"Message is bigger than MTU, max Reliable message size is {MTU - HEADER_SIZE_RELIABLE - 2}");
+                throw new IndexOutOfRangeException($"Message is bigger than MTU, max Reliable message size is {maxPacketSize - HEADER_SIZE_RELIABLE - 2}");
             }
             if (sentAckablePackets.IsFull)
             {
@@ -225,7 +225,7 @@ namespace Mirage.SocketLayer
 
             int msgLength = length + 2;
             int batchLength = nextBatch.length;
-            if (batchLength + msgLength > MTU)
+            if (batchLength + msgLength > maxPacketSize)
             {
                 // if full, send and create new
                 SendReliablePacket(nextBatch);

--- a/Assets/Mirage/Runtime/SocketLayer/Config.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Config.cs
@@ -40,20 +40,23 @@ namespace Mirage.SocketLayer
         /// </summary>
         public float DisconnectDuration = 1;
 
-        // todo move these settings to socket
         /// <summary>
-        /// Max size of a packet (excluding peer header)
-        /// </summary>
-        public int Mtu => BufferSize - HEADER_SIZE;
-        /// <summary>
-        /// Peer+ udp socket size
+        /// IP + UDP Header
         /// </summary>
         const int HEADER_SIZE = 20 + 8;
+
         /// <summary>
-        /// Size of buffers, Should be Mtu + header size + header size for socket
-        /// <para>Udp Packet is 1280</para>
+        /// MTU is expected to be atleast this number
         /// </summary>
-        public int BufferSize = 1280;
+        const int MIN_MTU = 1280;
+
+        /// <summary>
+        /// Max size of array that will be sent to or can be received from <see cref="ISocket"/>
+        /// <para>This will also be the size of all buffers used by <see cref="Peer"/></para>
+        /// <para>This is not max message size because this size includes packets header added by <see cref="Peer"/></para>
+        /// </summary>
+        // todo move these settings to socket
+        public int MaxPacketSize = MIN_MTU - HEADER_SIZE;
 
         /// <summary>
         /// How many buffers to create at start

--- a/Assets/Mirage/Runtime/SocketLayer/Peer.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Peer.cs
@@ -72,7 +72,7 @@ namespace Mirage.SocketLayer
             time = new Time();
 
             connectKeyValidator = new ConnectKeyValidator();
-            bufferPool = new BufferPool(this.config.Mtu, this.config.BufferPoolStartSize, this.config.BufferPoolMaxSize, this.logger);
+            bufferPool = new BufferPool(this.config.MaxPacketSize, this.config.BufferPoolStartSize, this.config.BufferPoolMaxSize, this.logger);
 
             Application.quitting += Application_quitting;
         }
@@ -241,8 +241,8 @@ namespace Mirage.SocketLayer
                     int length = socket.Receive(buffer.array, out EndPoint receiveEndPoint);
 
                     // this should never happen. buffer size is only MTU, if socket returns higher length then it has a bug.
-                    if (length > config.Mtu)
-                        throw new IndexOutOfRangeException($"Socket returned length above MTU: MTU:{config.Mtu} length:{length}");
+                    if (length > config.MaxPacketSize)
+                        throw new IndexOutOfRangeException($"Socket returned length above MTU. MaxPacketSize:{config.MaxPacketSize} length:{length}");
 
                     var packet = new Packet(buffer, length);
 

--- a/Assets/Tests/SocketLayer/PeerTest.cs
+++ b/Assets/Tests/SocketLayer/PeerTest.cs
@@ -100,7 +100,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
                 peer.Update();
             });
 
-            Assert.That(exception, Has.Message.EqualTo($"Socket returned length above MTU: MTU:{config.Mtu} length:{aboveMTU}"));
+            Assert.That(exception, Has.Message.EqualTo($"Socket returned length above MTU. MaxPacketSize:{config.MaxPacketSize} length:{aboveMTU}"));
         }
 
         [Test]


### PR DESCRIPTION
MaxPacketSize now sets max message size including headers. and also determine size of SocketLayer buffers

BREAKING CHANGE: BufferSize and MTU replaced by MaxPacketSize