### PR TITLE
perf: improving how socketlayer handles endpoints

### DIFF
--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -112,7 +112,7 @@ namespace Mirage
             World = new NetworkWorld();
             InitializeAuthEvents();
 
-            EndPoint endPoint = SocketFactory.GetConnectEndPoint(address, port);
+            IEndPoint endPoint = SocketFactory.GetConnectEndPoint(address, port);
             if (logger.LogEnabled()) logger.Log($"Client connecting to endpoint: {endPoint}");
 
             ISocket socket = SocketFactory.CreateClientSocket();

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using Mirage.Logging;
 using Mirage.Serialization;
+using Mirage.SocketLayer;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -70,7 +70,7 @@ namespace Mirage
         /// The IP address / URL / FQDN associated with the connection.
         /// Can be useful for a game master to do IP Bans etc.
         /// </summary>
-        public EndPoint Address => connection.EndPoint;
+        public IEndPoint Address => connection.EndPoint;
 
         public SocketLayer.IConnection Connection => connection;
 

--- a/Assets/Mirage/Runtime/PipePeerConnection.cs
+++ b/Assets/Mirage/Runtime/PipePeerConnection.cs
@@ -118,6 +118,10 @@ namespace Mirage
 
         public class PipeEndPoint : IEndPoint
         {
+            IEndPoint IEndPoint.CreateCopy()
+            {
+                throw new NotImplementedException();
+            }
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/PipePeerConnection.cs
+++ b/Assets/Mirage/Runtime/PipePeerConnection.cs
@@ -120,7 +120,8 @@ namespace Mirage
         {
             IEndPoint IEndPoint.CreateCopy()
             {
-                throw new NotImplementedException();
+                // never need copy of pipeendpoint
+                throw new NotSupportedException();
             }
         }
 

--- a/Assets/Mirage/Runtime/PipePeerConnection.cs
+++ b/Assets/Mirage/Runtime/PipePeerConnection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using Mirage.Logging;
 using Mirage.SocketLayer;
 using UnityEngine;
@@ -58,7 +57,7 @@ namespace Mirage
             return name;
         }
 
-        EndPoint IConnection.EndPoint => new PipeEndPoint();
+        IEndPoint IConnection.EndPoint => new PipeEndPoint();
 
 
         public ConnectionState State { get; private set; } = ConnectionState.Connected;
@@ -117,7 +116,7 @@ namespace Mirage
             otherHandler.ReceiveMessage(otherConnection, new ArraySegment<byte>(packet, offset, length));
         }
 
-        public class PipeEndPoint : EndPoint
+        public class PipeEndPoint : IEndPoint
         {
         }
 

--- a/Assets/Mirage/Runtime/SocketLayer/Connection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection.cs
@@ -113,9 +113,9 @@ namespace Mirage.SocketLayer
             this.peer = peer;
             this.logger = logger ?? Debug.unityLogger;
 
-            // todo stop boxing of struct?
+            // create copy of endpoint for this connection
+            // this is so that we can re-use the endpoint (reduces alloc) for receive and not worry about changing internal data needed for each connection
             EndPoint = endPoint?.CreateCopy() ?? throw new ArgumentNullException(nameof(endPoint));
-
             this.dataHandler = dataHandler ?? throw new ArgumentNullException(nameof(dataHandler));
             State = ConnectionState.Created;
 

--- a/Assets/Mirage/Runtime/SocketLayer/Connection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using UnityEngine;
 
 namespace Mirage.SocketLayer
@@ -9,7 +8,7 @@ namespace Mirage.SocketLayer
     /// </summary>
     public interface IConnection
     {
-        EndPoint EndPoint { get; }
+        IEndPoint EndPoint { get; }
         ConnectionState State { get; }
 
         void Disconnect();
@@ -97,7 +96,7 @@ namespace Mirage.SocketLayer
         public bool Connected => State == ConnectionState.Connected;
 
         private readonly Peer peer;
-        public readonly EndPoint EndPoint;
+        public readonly IEndPoint EndPoint;
         private readonly IDataHandler dataHandler;
 
         private readonly ConnectingTracker connectingTracker;
@@ -107,12 +106,14 @@ namespace Mirage.SocketLayer
 
         private readonly AckSystem ackSystem;
 
-        EndPoint IConnection.EndPoint => EndPoint;
+        IEndPoint IConnection.EndPoint => EndPoint;
 
-        internal Connection(Peer peer, EndPoint endPoint, IDataHandler dataHandler, Config config, Time time, BufferPool bufferPool, ILogger logger, Metrics metrics)
+        internal Connection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, Time time, BufferPool bufferPool, ILogger logger, Metrics metrics)
         {
             this.peer = peer;
             this.logger = logger ?? Debug.unityLogger;
+
+            // todo stop boxing of struct?
             EndPoint = endPoint ?? throw new ArgumentNullException(nameof(endPoint));
             this.dataHandler = dataHandler ?? throw new ArgumentNullException(nameof(dataHandler));
             State = ConnectionState.Created;

--- a/Assets/Mirage/Runtime/SocketLayer/Connection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection.cs
@@ -114,7 +114,8 @@ namespace Mirage.SocketLayer
             this.logger = logger ?? Debug.unityLogger;
 
             // todo stop boxing of struct?
-            EndPoint = endPoint ?? throw new ArgumentNullException(nameof(endPoint));
+            EndPoint = endPoint?.CreateCopy() ?? throw new ArgumentNullException(nameof(endPoint));
+
             this.dataHandler = dataHandler ?? throw new ArgumentNullException(nameof(dataHandler));
             State = ConnectionState.Created;
 

--- a/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
@@ -55,12 +55,20 @@ namespace Mirage.SocketLayer
     /// <summary>
     /// Object that can be used as an endpoint for <see cref="Peer"/> and <see cref="ISocket"/>
     /// <para>
-    /// Should be a struct that overrides <see cref="object.GetHashCode"/> and <see cref="object.Equals(object)"/>
-    /// so instances returned from <see cref="ISocket.Receive(byte[], out IEndPoint)"/> will be unique and not change address of another <see cref="Connection"/>
+    /// Implementation of this should override <see cref="object.GetHashCode"/> and <see cref="object.Equals(object)"/> so that 2 instance wil be equal if they have the same address internally
+    /// </para>
+    /// <para>
+    /// When a new connection is received by Peer a copy of this endpoint will be created and given to that connection.
+    /// On future received the incoming endpoint will be compared to active connections inside a dictionary
     /// </para>
     /// </summary>
     public interface IEndPoint
     {
+        /// <summary>
+        /// Creates a new instance of <see cref="IEndPoint"/> with same connection data
+        /// <para>this is called when a new connection is created by <see cref="Peer"/></para>
+        /// </summary>
+        /// <returns></returns>
         IEndPoint CreateCopy();
     }
 }

--- a/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
@@ -1,5 +1,3 @@
-using System.Net;
-
 namespace Mirage.SocketLayer
 {
     /// <summary>
@@ -12,13 +10,13 @@ namespace Mirage.SocketLayer
         /// <para>Used by Server to allow clients to connect</para>
         /// </summary>
         /// <param name="endPoint">the endpoint to listen on</param>
-        void Bind(EndPoint endPoint);
+        void Bind(IEndPoint endPoint);
 
         /// <summary>
         /// Sets up Socket ready to send data to endpoint as a client
         /// </summary>
         /// <param name="endPoint"></param>
-        void Connect(EndPoint endPoint);
+        void Connect(IEndPoint endPoint);
 
         /// <summary>
         /// Closes the socket, stops receiving messages from other peers
@@ -42,7 +40,7 @@ namespace Mirage.SocketLayer
         /// <param name="buffer">buffer to write recevived packet into</param>
         /// <param name="endPoint">where packet came from</param>
         /// <returns>length of packet, should not be above <paramref name="buffer"/> length</returns>
-        int Receive(byte[] buffer, out EndPoint endPoint);
+        int Receive(byte[] buffer, out IEndPoint endPoint);
 
         /// <summary>
         /// Sends a packet to an endpoint
@@ -51,6 +49,18 @@ namespace Mirage.SocketLayer
         /// <param name="endPoint">where packet is being sent to</param>
         /// <param name="packet">buffer that contains the packet, starting at index 0</param>
         /// <param name="length">length of the packet</param>
-        void Send(EndPoint endPoint, byte[] packet, int length);
+        void Send(IEndPoint endPoint, byte[] packet, int length);
+    }
+
+    /// <summary>
+    /// Object that can be used as an endpoint for <see cref="Peer"/> and <see cref="ISocket"/>
+    /// <para>
+    /// Should be a struct that overrides <see cref="object.GetHashCode"/> and <see cref="object.Equals(object)"/>
+    /// so instances returned from <see cref="ISocket.Receive(byte[], out IEndPoint)"/> will be unique and not change address of another <see cref="Connection"/>
+    /// </para>
+    /// </summary>
+    public interface IEndPoint
+    {
+
     }
 }

--- a/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
@@ -61,6 +61,6 @@ namespace Mirage.SocketLayer
     /// </summary>
     public interface IEndPoint
     {
-
+        IEndPoint CreateCopy();
     }
 }

--- a/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
@@ -20,7 +20,7 @@ namespace Mirage.SocketLayer
         public abstract ISocket CreateServerSocket();
 
         /// <summary>Creates the <see cref="EndPoint"/> that the Server Socket will bind to</summary>
-        public abstract EndPoint GetBindEndPoint();
+        public abstract IEndPoint GetBindEndPoint();
 
 
         /// <summary>Creates a <see cref="ISocket"/> to be used by <see cref="Peer"/> on the client</summary>
@@ -28,6 +28,6 @@ namespace Mirage.SocketLayer
         public abstract ISocket CreateClientSocket();
 
         /// <summary>Creates the <see cref="EndPoint"/> that the Client Socket will connect to using the parameter given</summary>
-        public abstract EndPoint GetConnectEndPoint(string address = null, ushort? port = null);
+        public abstract IEndPoint GetConnectEndPoint(string address = null, ushort? port = null);
     }
 }

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -67,7 +67,7 @@ namespace Mirage.Sockets.Udp
         private static bool IsWebgl => Application.platform == RuntimePlatform.WebGLPlayer;
     }
 
-    public struct EndPointWrapper : IEndPoint
+    public class EndPointWrapper : IEndPoint
     {
         public EndPoint inner;
 
@@ -93,6 +93,11 @@ namespace Mirage.Sockets.Udp
         public override string ToString()
         {
             return inner.ToString();
+        }
+
+        IEndPoint IEndPoint.CreateCopy()
+        {
+            return new EndPointWrapper(inner);
         }
     }
     public class UdpSocket : ISocket

--- a/Assets/Tests/Common/Mirage.Tests.Common.asmdef
+++ b/Assets/Tests/Common/Mirage.Tests.Common.asmdef
@@ -13,7 +13,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "NSubstitute.dll"
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Assets/Tests/Common/TestSocketFactory.cs
+++ b/Assets/Tests/Common/TestSocketFactory.cs
@@ -52,7 +52,7 @@ namespace Mirage.Tests
         public TestSocket(string name, IEndPoint endPoint = null)
         {
             this.name = name;
-            this.endPoint = endPoint ?? Substitute.For<IEndPoint>();
+            this.endPoint = endPoint ?? TestEndPoint.CreateSubstitute();
         }
 
 
@@ -125,10 +125,19 @@ namespace Mirage.Tests
         }
     }
 
+    public static class TestEndPoint
+    {
+        public static IEndPoint CreateSubstitute()
+        {
+            IEndPoint endpoint = Substitute.For<IEndPoint>();
+            endpoint.CreateCopy().Returns(endpoint);
+            return endpoint;
+        }
+    }
 
     public class TestSocketFactory : SocketFactory
     {
-        public IEndPoint serverEndpoint = Substitute.For<IEndPoint>();
+        public IEndPoint serverEndpoint = TestEndPoint.CreateSubstitute();
 
         int clientNameIndex;
         int serverNameIndex;

--- a/Assets/Tests/Common/TestSocketFactory.cs
+++ b/Assets/Tests/Common/TestSocketFactory.cs
@@ -76,17 +76,17 @@ namespace Mirage.Tests
             return received.Count > 0;
         }
 
-        int ISocket.Receive(byte[] data, out IEndPoint endPoint)
+        int ISocket.Receive(byte[] buffer, out IEndPoint endPoint)
         {
             Packet next = received.Dequeue();
             endPoint = next.endPoint;
             int length = next.length;
 
-            Buffer.BlockCopy(next.data, 0, data, 0, length);
+            Buffer.BlockCopy(next.data, 0, buffer, 0, length);
             return length;
         }
 
-        void ISocket.Send(IEndPoint remoteEndPoint, byte[] data, int length)
+        void ISocket.Send(IEndPoint remoteEndPoint, byte[] packet, int length)
         {
             AddThisSocket();
 
@@ -97,7 +97,7 @@ namespace Mirage.Tests
             }
 
             // create copy because data is from buffer
-            byte[] clone = data.Take(length).ToArray();
+            byte[] clone = packet.Take(length).ToArray();
             Sent.Add(new Packet
             {
                 endPoint = remoteEndPoint,

--- a/Assets/Tests/Common/TestSocketFactory.cs
+++ b/Assets/Tests/Common/TestSocketFactory.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using Mirage.SocketLayer;
 using NSubstitute;
-using UnityEngine;
 
 namespace Mirage.Tests
 {
@@ -16,14 +14,14 @@ namespace Mirage.Tests
         /// <summary>
         /// this static dictionary will act as the internet
         /// </summary>
-        public static Dictionary<EndPoint, TestSocket> allSockets = new Dictionary<EndPoint, TestSocket>();
+        public static Dictionary<IEndPoint, TestSocket> allSockets = new Dictionary<IEndPoint, TestSocket>();
 
         /// <summary>
         /// Can be useful to fake timeouts or dropped messages
         /// </summary>
         public static bool StopAllMessages;
 
-        public static bool EndpointInUse(EndPoint endPoint) => allSockets.ContainsKey(endPoint);
+        public static bool EndpointInUse(IEndPoint endPoint) => allSockets.ContainsKey(endPoint);
 
         /// <summary>
         /// adds this socket as an option to receive data
@@ -44,26 +42,26 @@ namespace Mirage.Tests
         }
 
 
-        public readonly EndPoint endPoint;
+        public readonly IEndPoint endPoint;
 
         readonly Queue<Packet> received = new Queue<Packet>();
         public List<Packet> Sent = new List<Packet>();
 
         public readonly string name;
 
-        public TestSocket(string name, EndPoint endPoint = null)
+        public TestSocket(string name, IEndPoint endPoint = null)
         {
             this.name = name;
-            this.endPoint = endPoint ?? Substitute.For<EndPoint>();
+            this.endPoint = endPoint ?? Substitute.For<IEndPoint>();
         }
 
 
-        void ISocket.Bind(EndPoint endPoint)
+        void ISocket.Bind(IEndPoint endPoint)
         {
             AddThisSocket();
         }
 
-        void ISocket.Connect(EndPoint endPoint)
+        void ISocket.Connect(IEndPoint endPoint)
         {
             AddThisSocket();
         }
@@ -78,7 +76,7 @@ namespace Mirage.Tests
             return received.Count > 0;
         }
 
-        int ISocket.Receive(byte[] data, out EndPoint endPoint)
+        int ISocket.Receive(byte[] data, out IEndPoint endPoint)
         {
             Packet next = received.Dequeue();
             endPoint = next.endPoint;
@@ -88,7 +86,7 @@ namespace Mirage.Tests
             return length;
         }
 
-        void ISocket.Send(EndPoint remoteEndPoint, byte[] data, int length)
+        void ISocket.Send(IEndPoint remoteEndPoint, byte[] data, int length)
         {
             AddThisSocket();
 
@@ -121,7 +119,7 @@ namespace Mirage.Tests
 
         public struct Packet
         {
-            public EndPoint endPoint;
+            public IEndPoint endPoint;
             public byte[] data;
             public int length;
         }
@@ -130,7 +128,7 @@ namespace Mirage.Tests
 
     public class TestSocketFactory : SocketFactory
     {
-        public EndPoint serverEndpoint = Substitute.For<EndPoint>();
+        public IEndPoint serverEndpoint = Substitute.For<IEndPoint>();
 
         int clientNameIndex;
         int serverNameIndex;
@@ -150,12 +148,12 @@ namespace Mirage.Tests
             return new TestSocket($"Server {serverNameIndex++}", serverEndpoint);
         }
 
-        public override EndPoint GetBindEndPoint()
+        public override IEndPoint GetBindEndPoint()
         {
             return default;
         }
 
-        public override EndPoint GetConnectEndPoint(string address = null, ushort? port = null)
+        public override IEndPoint GetConnectEndPoint(string address = null, ushort? port = null)
         {
             return serverEndpoint;
         }

--- a/Assets/Tests/Runtime/ClientServer/NetworkClientDisconnectTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkClientDisconnectTest.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Linq;
-using System.Net;
 using Mirage.SocketLayer;
 using NUnit.Framework;
 using UnityEngine;
@@ -81,7 +80,7 @@ namespace Mirage.Tests.Runtime.ClientServer.DisconnectTests
         [UnityTest]
         public IEnumerator DisconnectEventWhenSentInvalidPacket()
         {
-            (ISocket clientSocket, EndPoint serverEndPoint) = GetSocketAndEndPoint();
+            (ISocket clientSocket, IEndPoint serverEndPoint) = GetSocketAndEndPoint();
             byte[] badMessage = CreateInvalidPacket();
 
             clientSocket.Send(serverEndPoint, badMessage, 20);
@@ -100,12 +99,12 @@ namespace Mirage.Tests.Runtime.ClientServer.DisconnectTests
             Assert.That(called, Is.EqualTo(1));
         }
 
-        private (ISocket clientSocket, EndPoint serverEndPoint) GetSocketAndEndPoint()
+        private (ISocket clientSocket, IEndPoint serverEndPoint) GetSocketAndEndPoint()
         {
-            EndPoint clientEndPoint = server.Players.First().Connection.EndPoint;
+            IEndPoint clientEndPoint = server.Players.First().Connection.EndPoint;
             TestSocket clientSocket = TestSocket.allSockets[clientEndPoint];
 
-            EndPoint serverEndPoint = ((TestSocketFactory)server.SocketFactory).serverEndpoint;
+            IEndPoint serverEndPoint = ((TestSocketFactory)server.SocketFactory).serverEndpoint;
 
             return (clientSocket, serverEndPoint);
         }

--- a/Assets/Tests/SocketLayer/PeerTest.cs
+++ b/Assets/Tests/SocketLayer/PeerTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -68,7 +67,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void IgnoresMessageThatIsTooShort()
         {
-            peer.Bind(Substitute.For<EndPoint>());
+            peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
@@ -87,7 +86,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ThrowsIfSocketGivesLengthThatIsTooHigh()
         {
-            peer.Bind(Substitute.For<EndPoint>());
+            peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
@@ -107,12 +106,12 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Repeat(10)]
         public void IgnoresRandomData()
         {
-            peer.Bind(Substitute.For<EndPoint>());
+            peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
 
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
 
             // 2 is min length of a message
             byte[] randomData = new byte[UnityEngine.Random.Range(2, 20)];

--- a/Assets/Tests/SocketLayer/PeerTest.cs
+++ b/Assets/Tests/SocketLayer/PeerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using Mirage.Tests;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -67,7 +68,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void IgnoresMessageThatIsTooShort()
         {
-            peer.Bind(Substitute.For<IEndPoint>());
+            peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
@@ -86,7 +87,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ThrowsIfSocketGivesLengthThatIsTooHigh()
         {
-            peer.Bind(Substitute.For<IEndPoint>());
+            peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
@@ -106,12 +107,12 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Repeat(10)]
         public void IgnoresRandomData()
         {
-            peer.Bind(Substitute.For<IEndPoint>());
+            peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
 
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
 
             // 2 is min length of a message
             byte[] randomData = new byte[UnityEngine.Random.Range(2, 20)];

--- a/Assets/Tests/SocketLayer/PeerTestAsClient.cs
+++ b/Assets/Tests/SocketLayer/PeerTestAsClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Net;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -14,7 +13,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ConnectShouldSendMessageToSocket()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             peer.Connect(endPoint);
 
             byte[] expected = connectRequest;
@@ -29,7 +28,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ConnectShouldReturnANewConnection()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             IConnection conn = peer.Connect(endPoint);
             Assert.That(conn, Is.TypeOf<Connection>(), "returned type should be connection");
             Assert.That(conn.State, Is.EqualTo(ConnectionState.Connecting), "new connection should be connecting");
@@ -45,7 +44,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [UnityTest]
         public IEnumerator ShouldResendConnectMessageIfNoReply()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             _ = peer.Connect(endPoint);
 
             byte[] expected = connectRequest;
@@ -86,7 +85,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [UnityTest]
         public IEnumerator ShouldInvokeConnectionFailedIfNoReplyAfterMax()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             IConnection conn = peer.Connect(endPoint);
 
             // wait enough time so that  would have been called
@@ -106,7 +105,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ShouldInvokeConnectionFailedIfServerRejects()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             IConnection conn = peer.Connect(endPoint);
 
             socket.SetupReceiveCall(new byte[3] {
@@ -125,7 +124,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [UnityTest]
         public IEnumerator InvokesConnectFailedIfClosedBeforeConnect()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             IConnection conn = peer.Connect(endPoint);
 
             peer.Close();
@@ -154,7 +153,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             // todo test as client with 1 connection
             Assert.Ignore("new NotImplementedException(What should happen if close / disconnect is called while still connecting)");
 
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             IConnection conn = peer.Connect(endPoint);
 
             peer.Close();
@@ -176,13 +175,13 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         public void IgnoresRequestToConnect()
         {
             Assert.Ignore("not implemented");
-            peer.Connect(Substitute.For<EndPoint>());
+            peer.Connect(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
 
             byte[] expected = connectRequest;
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             socket.SetupReceiveCall(expected, endPoint);
             peer.Update();
 

--- a/Assets/Tests/SocketLayer/PeerTestAsClient.cs
+++ b/Assets/Tests/SocketLayer/PeerTestAsClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using Mirage.Tests;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -13,7 +14,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ConnectShouldSendMessageToSocket()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             peer.Connect(endPoint);
 
             byte[] expected = connectRequest;
@@ -28,7 +29,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ConnectShouldReturnANewConnection()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             IConnection conn = peer.Connect(endPoint);
             Assert.That(conn, Is.TypeOf<Connection>(), "returned type should be connection");
             Assert.That(conn.State, Is.EqualTo(ConnectionState.Connecting), "new connection should be connecting");
@@ -44,7 +45,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [UnityTest]
         public IEnumerator ShouldResendConnectMessageIfNoReply()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             _ = peer.Connect(endPoint);
 
             byte[] expected = connectRequest;
@@ -85,7 +86,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [UnityTest]
         public IEnumerator ShouldInvokeConnectionFailedIfNoReplyAfterMax()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             IConnection conn = peer.Connect(endPoint);
 
             // wait enough time so that  would have been called
@@ -105,7 +106,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ShouldInvokeConnectionFailedIfServerRejects()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             IConnection conn = peer.Connect(endPoint);
 
             socket.SetupReceiveCall(new byte[3] {
@@ -124,7 +125,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [UnityTest]
         public IEnumerator InvokesConnectFailedIfClosedBeforeConnect()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             IConnection conn = peer.Connect(endPoint);
 
             peer.Close();
@@ -153,7 +154,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             // todo test as client with 1 connection
             Assert.Ignore("new NotImplementedException(What should happen if close / disconnect is called while still connecting)");
 
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             IConnection conn = peer.Connect(endPoint);
 
             peer.Close();
@@ -175,13 +176,13 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         public void IgnoresRequestToConnect()
         {
             Assert.Ignore("not implemented");
-            peer.Connect(Substitute.For<IEndPoint>());
+            peer.Connect(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
 
             byte[] expected = connectRequest;
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             socket.SetupReceiveCall(expected, endPoint);
             peer.Update();
 

--- a/Assets/Tests/SocketLayer/PeerTestAsServer.cs
+++ b/Assets/Tests/SocketLayer/PeerTestAsServer.cs
@@ -1,4 +1,5 @@
 using System;
+using Mirage.Tests;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -11,7 +12,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void BindShoudlCallSocketBind()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             peer.Bind(endPoint);
 
             socket.Received(1).Bind(Arg.Is(endPoint));
@@ -20,13 +21,13 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void CloseSendsDisconnectMessageToAllConnections()
         {
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             peer.Bind(endPoint);
 
             var endPoints = new IEndPoint[maxConnections];
             for (int i = 0; i < maxConnections; i++)
             {
-                endPoints[i] = Substitute.For<IEndPoint>();
+                endPoints[i] = TestEndPoint.CreateSubstitute();
 
                 socket.SetupReceiveCall(connectRequest, endPoints[i]);
                 peer.Update();
@@ -58,12 +59,12 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void AcceptsConnectionForValidMessage()
         {
-            peer.Bind(Substitute.For<IEndPoint>());
+            peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
 
-            IEndPoint endPoint = Substitute.For<IEndPoint>();
+            IEndPoint endPoint = TestEndPoint.CreateSubstitute();
             socket.SetupReceiveCall(connectRequest, endPoint);
             peer.Update();
 
@@ -79,7 +80,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void AcceptsConnectionsUpToMax()
         {
-            peer.Bind(Substitute.For<IEndPoint>());
+            peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
@@ -88,7 +89,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             var endPoints = new IEndPoint[maxConnections];
             for (int i = 0; i < maxConnections; i++)
             {
-                endPoints[i] = Substitute.For<IEndPoint>();
+                endPoints[i] = TestEndPoint.CreateSubstitute();
 
                 socket.SetupReceiveCall(connectRequest, endPoints[i]);
                 peer.Update();
@@ -110,7 +111,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void RejectsConnectionOverMax()
         {
-            peer.Bind(Substitute.For<IEndPoint>());
+            peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
@@ -125,7 +126,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             socket.ClearReceivedCalls();
             connectAction.ClearReceivedCalls();
 
-            IEndPoint overMaxEndpoint = Substitute.For<IEndPoint>();
+            IEndPoint overMaxEndpoint = TestEndPoint.CreateSubstitute();
             socket.SetupReceiveCall(connectRequest, overMaxEndpoint);
 
 
@@ -151,7 +152,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test, Description("Should reject with no reason given")]
         public void IgnoresMessageThatIsInvalid()
         {
-            peer.Bind(Substitute.For<IEndPoint>());
+            peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;

--- a/Assets/Tests/SocketLayer/PeerTestAsServer.cs
+++ b/Assets/Tests/SocketLayer/PeerTestAsServer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -12,7 +11,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void BindShoudlCallSocketBind()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             peer.Bind(endPoint);
 
             socket.Received(1).Bind(Arg.Is(endPoint));
@@ -21,13 +20,13 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void CloseSendsDisconnectMessageToAllConnections()
         {
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             peer.Bind(endPoint);
 
-            var endPoints = new EndPoint[maxConnections];
+            var endPoints = new IEndPoint[maxConnections];
             for (int i = 0; i < maxConnections; i++)
             {
-                endPoints[i] = Substitute.For<EndPoint>();
+                endPoints[i] = Substitute.For<IEndPoint>();
 
                 socket.SetupReceiveCall(connectRequest, endPoints[i]);
                 peer.Update();
@@ -59,12 +58,12 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void AcceptsConnectionForValidMessage()
         {
-            peer.Bind(Substitute.For<EndPoint>());
+            peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
 
-            EndPoint endPoint = Substitute.For<EndPoint>();
+            IEndPoint endPoint = Substitute.For<IEndPoint>();
             socket.SetupReceiveCall(connectRequest, endPoint);
             peer.Update();
 
@@ -80,16 +79,16 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void AcceptsConnectionsUpToMax()
         {
-            peer.Bind(Substitute.For<EndPoint>());
+            peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
 
 
-            var endPoints = new EndPoint[maxConnections];
+            var endPoints = new IEndPoint[maxConnections];
             for (int i = 0; i < maxConnections; i++)
             {
-                endPoints[i] = Substitute.For<EndPoint>();
+                endPoints[i] = Substitute.For<IEndPoint>();
 
                 socket.SetupReceiveCall(connectRequest, endPoints[i]);
                 peer.Update();
@@ -111,7 +110,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void RejectsConnectionOverMax()
         {
-            peer.Bind(Substitute.For<EndPoint>());
+            peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;
@@ -126,7 +125,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             socket.ClearReceivedCalls();
             connectAction.ClearReceivedCalls();
 
-            EndPoint overMaxEndpoint = Substitute.For<EndPoint>();
+            IEndPoint overMaxEndpoint = Substitute.For<IEndPoint>();
             socket.SetupReceiveCall(connectRequest, overMaxEndpoint);
 
 
@@ -152,7 +151,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test, Description("Should reject with no reason given")]
         public void IgnoresMessageThatIsInvalid()
         {
-            peer.Bind(Substitute.For<EndPoint>());
+            peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             peer.OnConnected += connectAction;

--- a/Assets/Tests/SocketLayer/PeerTestBase.cs
+++ b/Assets/Tests/SocketLayer/PeerTestBase.cs
@@ -134,7 +134,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
                    {
                        dataArg[i] = data[i];
                    }
-                   x[1] = endPoint ?? Substitute.For<IEndPoint>();
+                   x[1] = endPoint ?? TestEndPoint.CreateSubstitute();
                });
             socket.Receive(Arg.Any<byte[]>(), out Arg.Any<IEndPoint>()).Returns(length ?? data.Length);
         }

--- a/Assets/Tests/SocketLayer/PeerTestBase.cs
+++ b/Assets/Tests/SocketLayer/PeerTestBase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using Mirage.Tests;
 using NSubstitute;
 using NUnit.Framework;
@@ -85,7 +84,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         /// <summary>
         /// endpoint that other sockets use to send to this
         /// </summary>
-        public EndPoint endPoint;
+        public IEndPoint endPoint;
 
         public PeerInstanceWithSocket(Config config = null) : base(config, socket: new TestSocket("TestInstance"))
         {
@@ -121,12 +120,12 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             return true;
         }
 
-        public static void SetupReceiveCall(this ISocket socket, byte[] data, EndPoint endPoint = null, int? length = null)
+        public static void SetupReceiveCall(this ISocket socket, byte[] data, IEndPoint endPoint = null, int? length = null)
         {
             socket.Poll().Returns(true, false);
             socket
                // when any call
-               .When(x => x.Receive(Arg.Any<byte[]>(), out Arg.Any<EndPoint>()))
+               .When(x => x.Receive(Arg.Any<byte[]>(), out Arg.Any<IEndPoint>()))
                // return the data from endpoint
                .Do(x =>
                {
@@ -135,9 +134,9 @@ namespace Mirage.SocketLayer.Tests.PeerTests
                    {
                        dataArg[i] = data[i];
                    }
-                   x[1] = endPoint ?? Substitute.For<EndPoint>();
+                   x[1] = endPoint ?? Substitute.For<IEndPoint>();
                });
-            socket.Receive(Arg.Any<byte[]>(), out Arg.Any<EndPoint>()).Returns(length ?? data.Length);
+            socket.Receive(Arg.Any<byte[]>(), out Arg.Any<IEndPoint>()).Returns(length ?? data.Length);
         }
     }
 }

--- a/Assets/Tests/SocketLayer/PeerTestConnecting.cs
+++ b/Assets/Tests/SocketLayer/PeerTestConnecting.cs
@@ -29,7 +29,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ServerAcceptsAllClients()
         {
-            server.peer.Bind(Substitute.For<IEndPoint>());
+            server.peer.Bind(TestEndPoint.CreateSubstitute());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             server.peer.OnConnected += connectAction;
@@ -71,7 +71,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void EachServerConnectionIsANewInstance()
         {
-            server.peer.Bind(Substitute.For<IEndPoint>());
+            server.peer.Bind(TestEndPoint.CreateSubstitute());
             var serverConnections = new List<IConnection>();
 
             Action<IConnection> connectAction = (conn) =>

--- a/Assets/Tests/SocketLayer/PeerTestConnecting.cs
+++ b/Assets/Tests/SocketLayer/PeerTestConnecting.cs
@@ -29,7 +29,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void ServerAcceptsAllClients()
         {
-            server.peer.Bind(Substitute.For<EndPoint>());
+            server.peer.Bind(Substitute.For<IEndPoint>());
 
             Action<IConnection> connectAction = Substitute.For<Action<IConnection>>();
             server.peer.OnConnected += connectAction;
@@ -71,7 +71,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         [Test]
         public void EachServerConnectionIsANewInstance()
         {
-            server.peer.Bind(Substitute.For<EndPoint>());
+            server.peer.Bind(Substitute.For<IEndPoint>());
             var serverConnections = new List<IConnection>();
 
             Action<IConnection> connectAction = (conn) =>

--- a/Assets/Tests/SocketLayer/PeerTestSendReceive.cs
+++ b/Assets/Tests/SocketLayer/PeerTestSendReceive.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
+using Mirage.Tests;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine.TestTools;
@@ -38,7 +38,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             Action<IConnection> serverConnect = (conn) => serverConnections.Add(conn);
             server.peer.OnConnected += serverConnect;
 
-            server.peer.Bind(Substitute.For<IEndPoint>());
+            server.peer.Bind(TestEndPoint.CreateSubstitute());
             for (int i = 0; i < ClientCount; i++)
             {
                 clients[i] = new PeerInstanceWithSocket(config);

--- a/Assets/Tests/SocketLayer/PeerTestSendReceive.cs
+++ b/Assets/Tests/SocketLayer/PeerTestSendReceive.cs
@@ -38,7 +38,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             Action<IConnection> serverConnect = (conn) => serverConnections.Add(conn);
             server.peer.OnConnected += serverConnect;
 
-            server.peer.Bind(Substitute.For<EndPoint>());
+            server.peer.Bind(Substitute.For<IEndPoint>());
             for (int i = 0; i < ClientCount; i++)
             {
                 clients[i] = new PeerInstanceWithSocket(config);


### PR DESCRIPTION
Peer EndPoint is now an interface that has a method to create a copy. This will allow Sockets to re-use a single endpoint inside receive and Peer will create a copy of it when a new connection is accepted

BREAKING CHANGE: Socket functions now use an interface instead of the EndPoint class, Socket Implementations should not create a custom Endpoint class for their socket.