### PR TITLE
feat: improving network scene manager

### DIFF
--- a/Assets/Mirage/Runtime/CharacterSpawner.cs
+++ b/Assets/Mirage/Runtime/CharacterSpawner.cs
@@ -43,7 +43,7 @@ namespace Mirage
             {
                 if (SceneManager != null)
                 {
-                    SceneManager.ClientSceneChanged.AddListener(OnClientSceneChanged);
+                    SceneManager.ClientFinishedSceneChange.AddListener(OnClientSceneChanged);
                 }
                 else
                 {
@@ -73,7 +73,7 @@ namespace Mirage
         {
             if (Client != null && SceneManager != null)
             {
-                SceneManager.ClientSceneChanged.RemoveListener(OnClientSceneChanged);
+                SceneManager.ClientFinishedSceneChange.RemoveListener(OnClientSceneChanged);
                 Client.Authenticated.RemoveListener(c => Client.Send(new AddCharacterMessage()));
             }
             if (Server != null)

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -57,7 +57,7 @@ namespace Mirage
                 Client.Disconnected.AddListener(OnClientDisconnected);
 
                 if (NetworkSceneManager != null)
-                    NetworkSceneManager.ClientSceneChanged.AddListener(OnClientSceneChanged);
+                    NetworkSceneManager.ClientFinishedSceneChange.AddListener(OnClientSceneChanged);
             }
         }
 

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -81,6 +81,6 @@ namespace Mirage
 
     public interface ISceneLoader
     {
-        bool IsReady { get; set; }
+        bool SceneIsReady { get; set; }
     }
 }

--- a/Assets/Mirage/Runtime/INetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/INetworkSceneManager.cs
@@ -1,6 +1,6 @@
 using System;
-using Cysharp.Threading.Tasks;
 using UnityEngine.Events;
+using UnityEngine.SceneManagement;
 
 namespace Mirage
 {
@@ -41,29 +41,25 @@ namespace Mirage
         SceneChangeEvent ServerFinishedSceneChange { get; }
 
         /// <summary>
-        ///     Allows server to fully load new scene or additive load in another scene.
+        ///     Allows server to fully load in a new scene and override current active scene.
         /// </summary>
         /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
-
-        /// <param name="sceneOperation">Choose type of scene loading we are doing <see cref="SceneOperation"/>.</param>
-        void ChangeServerScene(string scenePath, SceneOperation sceneOperation = SceneOperation.Normal);
+        void ServerLoadSceneNormal(string scenePath);
 
         /// <summary>
-        ///     Load our scene up in a normal unity fashion.
+        ///     Allows server to fully load in another scene on top of current active scene.
         /// </summary>
         /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
-        UniTask LoadSceneNormalAsync(string scenePath);
+        /// <param name="players">List of player's that are receiving the new scene load.</param>
+        /// <param name="shouldClientLoadNormally">Should the clients load this additively too or load it full normal scene change.</param>
+        void ServerLoadSceneAdditively(string scenePath, INetworkPlayer[] players, bool shouldClientLoadNormally = false);
 
         /// <summary>
-        ///     Load our scene additively.
+        ///     Allows server to fully unload a scene additively.
         /// </summary>
-        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
-        UniTask LoadSceneAdditiveAsync(string scenePath);
-
-        /// <summary>
-        ///     Unload our scene additively.
-        /// </summary>
-        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
-        UniTask UnLoadSceneAdditiveAsync(string scenePath);
+        /// <param name="scene">The scene handle which we want to unload additively.</param>
+        /// <param name="players">List of player's that are receiving the new scene unload.</param>
+        /// <param name="shouldClientUnloadNormally">Should the clients unload this additively too or unload it full normal scene change.</param>
+        void ServerUnloadSceneAdditively(Scene scene, INetworkPlayer[] players, bool shouldClientUnloadNormally = false);
     }
 }

--- a/Assets/Mirage/Runtime/INetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/INetworkSceneManager.cs
@@ -52,21 +52,18 @@ namespace Mirage
         ///     Load our scene up in a normal unity fashion.
         /// </summary>
         /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
-        /// <param name="player">Whether or not we should move the player.</param>
-        UniTask LoadSceneNormalAsync(string scenePath, INetworkPlayer player);
+        UniTask LoadSceneNormalAsync(string scenePath);
 
         /// <summary>
         ///     Load our scene additively.
         /// </summary>
         /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
-        /// <param name="player">Whether or not we should move the player.</param>
-        UniTask LoadSceneAdditiveAsync(string scenePath, INetworkPlayer player);
+        UniTask LoadSceneAdditiveAsync(string scenePath);
 
         /// <summary>
         ///     Unload our scene additively.
         /// </summary>
         /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
-        /// <param name="player">Whether or not we should move the player.</param>
-        UniTask UnLoadSceneAdditiveAsync(string scenePath, INetworkPlayer player);
+        UniTask UnLoadSceneAdditiveAsync(string scenePath);
     }
 }

--- a/Assets/Mirage/Runtime/INetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/INetworkSceneManager.cs
@@ -1,4 +1,5 @@
 using System;
+using Cysharp.Threading.Tasks;
 using UnityEngine.Events;
 
 namespace Mirage
@@ -22,23 +23,50 @@ namespace Mirage
         /// <summary>
         /// Event fires when the Client starts changing scene.
         /// </summary>
-        SceneChangeEvent ClientChangeScene { get; }
+        SceneChangeEvent ClientStartedSceneChange { get; }
 
         /// <summary>
         /// Event fires after the Client has completed its scene change.
         /// </summary>
-        SceneChangeEvent ClientSceneChanged { get; }
+        SceneChangeEvent ClientFinishedSceneChange { get; }
 
         /// <summary>
         /// Event fires before Server changes scene.
         /// </summary>
-        SceneChangeEvent ServerChangeScene { get; }
+        SceneChangeEvent ServerStartedSceneChange { get; }
 
         /// <summary>
         /// Event fires after Server has completed scene change.
         /// </summary>
-        SceneChangeEvent ServerSceneChanged { get; }
+        SceneChangeEvent ServerFinishedSceneChange { get; }
 
+        /// <summary>
+        ///     Allows server to fully load new scene or additive load in another scene.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+
+        /// <param name="sceneOperation">Choose type of scene loading we are doing <see cref="SceneOperation"/>.</param>
         void ChangeServerScene(string scenePath, SceneOperation sceneOperation = SceneOperation.Normal);
+
+        /// <summary>
+        ///     Load our scene up in a normal unity fashion.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        UniTask LoadSceneNormalAsync(string scenePath, INetworkPlayer player);
+
+        /// <summary>
+        ///     Load our scene additively.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        UniTask LoadSceneAdditiveAsync(string scenePath, INetworkPlayer player);
+
+        /// <summary>
+        ///     Unload our scene additively.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        UniTask UnLoadSceneAdditiveAsync(string scenePath, INetworkPlayer player);
     }
 }

--- a/Assets/Mirage/Runtime/Messages.cs
+++ b/Assets/Mirage/Runtime/Messages.cs
@@ -18,10 +18,10 @@ namespace Mirage
     [NetworkMessage]
     public struct SceneMessage
     {
-        public string scenePath;
+        public string MainActivateScene;
         // Normal = 0, LoadAdditive = 1, UnloadAdditive = 2
-        public SceneOperation sceneOperation;
-        public string[] additiveScenes;
+        public SceneOperation SceneOperation;
+        public string[] AdditiveScenes;
     }
 
     [NetworkMessage]

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -1009,12 +1009,12 @@ namespace Mirage
             // add all server connections
             foreach (INetworkPlayer player in Server.Players)
             {
-                if (player.IsReady)
+                if (player.SceneIsReady)
                     AddObserver(player);
             }
 
             // add local host connection (if any)
-            if (Server.LocalPlayer != null && Server.LocalPlayer.IsReady)
+            if (Server.LocalPlayer != null && Server.LocalPlayer.SceneIsReady)
             {
                 AddObserver(Server.LocalPlayer);
             }
@@ -1038,7 +1038,7 @@ namespace Mirage
             // -> fixes https://github.com/vis2k/Mirror/issues/692 where a
             //    player might teleport out of the ProximityChecker's cast,
             //    losing the own connection as observer.
-            if (ConnectionToClient != null && ConnectionToClient.IsReady)
+            if (ConnectionToClient != null && ConnectionToClient.SceneIsReady)
             {
                 newObservers.Add(ConnectionToClient);
             }
@@ -1064,7 +1064,7 @@ namespace Mirage
                 observers.Clear();
                 foreach (INetworkPlayer player in newObservers)
                 {
-                    if (player != null && player.IsReady)
+                    if (player != null && player.SceneIsReady)
                         observers.Add(player);
                 }
             }
@@ -1096,7 +1096,7 @@ namespace Mirage
             {
                 // only add ready connections.
                 // otherwise the player might not be in the world yet or anymore
-                if (player != null && player.IsReady && (initialize || !observers.Contains(player)))
+                if (player != null && player.SceneIsReady && (initialize || !observers.Contains(player)))
                 {
                     // new observer
                     player.AddToVisList(this);
@@ -1247,7 +1247,7 @@ namespace Mirage
                     if (ownerWritten > 0)
                     {
                         varsMessage.payload = ownerWriter.ToArraySegment();
-                        if (ConnectionToClient != null && ConnectionToClient.IsReady)
+                        if (ConnectionToClient != null && ConnectionToClient.SceneIsReady)
                             ConnectionToClient.Send(varsMessage);
                     }
 

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -56,7 +56,7 @@ namespace Mirage
         /// <para>This property is read-only. It is set by the system on the client when ClientScene.Ready() is called, and set by the system on the server when a ready message is received from a client.</para>
         /// <para>A client that is ready is sent spawned objects by the server and updates to the state of spawned objects. A client that is not ready is not sent spawned objects.</para>
         /// </summary>
-        public bool IsReady { get; set; }
+        public bool SceneIsReady { get; set; }
 
         /// <summary>
         /// The IP address / URL / FQDN associated with the connection.

--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -246,9 +246,9 @@ namespace Mirage
                     "[NetworkSceneManager] - ServerChangeScene: " + nameof(scenePath) + " cannot be empty or null");
             }
 
-            if(players == null || players.Length == 0)
-                throw new ArgumentNullException(nameof(scenePath),
-                    "[NetworkSceneManager] - list of player's cannot be null or no players.");
+            //if(players == null || players.Length == 0)
+            //    throw new ArgumentNullException(nameof(scenePath),
+            //        "[NetworkSceneManager] - list of player's cannot be null or no players.");
 
 
             if (logger.LogEnabled()) logger.Log("[NetworkSceneManager] - ServerChangeScene " + scenePath);
@@ -364,9 +364,9 @@ namespace Mirage
 
                 Scene scene = SceneManager.GetSceneAt(sceneIndex);
 
-                if (scene.Equals(SceneManager.GetActiveScene())) continue;
+                if (scene.name.Equals(SceneManager.GetActiveScene().name)) continue;
 
-                scenesPaths[sceneIndex - 1] = scene.path;
+                scenesPaths[sceneIndex == 0 ? sceneIndex : sceneIndex - 1] = scene.path;
             }
 
             player.Send(new SceneMessage { MainActivateScene = ActiveScenePath, AdditiveScenes = scenesPaths });

--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cysharp.Threading.Tasks;
 using Mirage.Logging;
 using UnityEngine;
@@ -19,51 +20,24 @@ namespace Mirage
     [DisallowMultipleComponent]
     public class NetworkSceneManager : MonoBehaviour, INetworkSceneManager
     {
+        #region Fields
+
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkSceneManager));
+
+        [Header("Setup Settings")]
 
         [FormerlySerializedAs("client")]
         public NetworkClient Client;
+
         [FormerlySerializedAs("server")]
         public NetworkServer Server;
 
         /// <summary>
-        /// Sets the NetworksSceneManagers GameObject to DontDestroyOnLoad. Default = true.
+        ///     Sets the NetworksSceneManagers GameObject to DontDestroyOnLoad. Default = true.
         /// </summary>
         public bool DontDestroy = true;
 
-        [Header("Events")]
-
-        [FormerlySerializedAs("ClientChangeScene")]
-        [SerializeField] SceneChangeEvent _clientChangeScene = new SceneChangeEvent();
-
-        [FormerlySerializedAs("ClientSceneChanged")]
-        [SerializeField] SceneChangeEvent _clientSceneChanged = new SceneChangeEvent();
-
-        [FormerlySerializedAs("ServerChangeScene")]
-        [SerializeField] SceneChangeEvent _serverChangeScene = new SceneChangeEvent();
-
-        [FormerlySerializedAs("ServerSceneChanged")]
-        [SerializeField] SceneChangeEvent _serverSceneChanged = new SceneChangeEvent();
-
-        /// <summary>
-        /// Event fires when the Client starts changing scene.
-        /// </summary>
-        public SceneChangeEvent ClientChangeScene => _clientChangeScene;
-
-        /// <summary>
-        /// Event fires after the Client has completed its scene change.
-        /// </summary>
-        public SceneChangeEvent ClientSceneChanged => _clientSceneChanged;
-
-        /// <summary>
-        /// Event fires before Server changes scene.
-        /// </summary>
-        public SceneChangeEvent ServerChangeScene => _serverChangeScene;
-
-        /// <summary>
-        /// Event fires after Server has completed scene change.
-        /// </summary>
-        public SceneChangeEvent ServerSceneChanged => _serverSceneChanged;
+        protected readonly Dictionary<Scene, List<INetworkPlayer>> ServerSceneData = new Dictionary<Scene, List<INetworkPlayer>>();
 
         /// <summary>
         /// The path of the current active scene.
@@ -76,104 +50,122 @@ namespace Mirage
         /// </remarks>
         public string ActiveScenePath => SceneManager.GetActiveScene().path;
 
-        AsyncOperation clientLoadingOperation;
-
-        /// <summary>
-        /// Used by the server to track all additive scenes. To notify clients upon connection 
-        /// </summary>
-        internal List<string> additiveSceneList = new List<string>();
-
         /// <summary>
         /// Used by the client to load the full additive scene list that the server has upon connection
         /// </summary>
-        internal List<string> pendingAdditiveSceneList = new List<string>();
+        internal readonly List<string> ClientPendingAdditiveSceneLoadingList = new List<string>();
 
-        public void Start()
+        /// <summary>
+        ///     Information on any scene that is currently being loaded.
+        /// </summary>
+        public AsyncOperation SceneLoadingAsyncOperationInfo;
+
+        #endregion
+
+        #region Events
+
+        [Header("Events")]
+
+        [FormerlySerializedAs("ClientChangeScene")]
+        [SerializeField] SceneChangeEvent _clientStartedSceneChange = new SceneChangeEvent();
+
+        [FormerlySerializedAs("ClientSceneChanged")]
+        [SerializeField] SceneChangeEvent _clientFinishedSceneChange = new SceneChangeEvent();
+
+        [FormerlySerializedAs("ServerChangeScene")]
+        [SerializeField] SceneChangeEvent _serverStartedSceneChange = new SceneChangeEvent();
+
+        [FormerlySerializedAs("ServerSceneChanged")]
+        [SerializeField] SceneChangeEvent _serverFinishedSceneChange = new SceneChangeEvent();
+
+        /// <summary>
+        /// Event fires when the Client starts changing scene.
+        /// </summary>
+        public SceneChangeEvent ClientStartedSceneChange => _clientStartedSceneChange;
+
+        /// <summary>
+        /// Event fires after the Client has completed its scene change.
+        /// </summary>
+        public SceneChangeEvent ClientFinishedSceneChange => _clientFinishedSceneChange;
+
+        /// <summary>
+        /// Event fires before Server changes scene.
+        /// </summary>
+        public SceneChangeEvent ServerStartedSceneChange => _serverStartedSceneChange;
+
+        /// <summary>
+        /// Event fires after Server has completed scene change.
+        /// </summary>
+        public SceneChangeEvent ServerFinishedSceneChange => _serverFinishedSceneChange;
+
+        #endregion
+
+        #region Client Side
+
+        /// <summary>
+        ///     Register incoming client messages.
+        /// </summary>
+        private void RegisterClientMessages()
         {
-            if (DontDestroy)
-                DontDestroyOnLoad(gameObject);
+            Client.MessageHandler.RegisterHandler<SceneMessage>(ClientStartSceneMessage);
 
-            if (Client != null)
-            {
-                Client.Started.AddListener(RegisterClientMessages);
-            }
-            if (Server != null)
-            {
-                Server.Authenticated.AddListener(OnServerAuthenticated);
-            }
-        }
+            if (Client.IsLocalClient) return;
 
-        void OnDestroy()
-        {
-            if (Client != null)
-                Client.Started.RemoveListener(RegisterClientMessages);
-        }
-
-        #region Client
-
-        void RegisterClientMessages()
-        {
-            Client.MessageHandler.RegisterHandler<SceneMessage>(ClientSceneMessage);
-            if (!Client.IsLocalClient)
-            {
-                Client.MessageHandler.RegisterHandler<SceneReadyMessage>(ClientSceneReadyMessage);
-                Client.MessageHandler.RegisterHandler<NotReadyMessage>(ClientNotReadyMessage);
-            }
-        }
-
-        internal void ClientSceneMessage(INetworkPlayer player, SceneMessage msg)
-        {
-            if (!Client.IsConnected)
-            {
-                throw new InvalidOperationException("ClientSceneMessage: cannot change network scene while client is disconnected");
-            }
-            if (string.IsNullOrEmpty(msg.scenePath))
-            {
-                throw new ArgumentNullException(nameof(msg.scenePath), $"ClientSceneMessage: {nameof(msg.scenePath)} cannot be empty or null");
-            }
-
-            if (logger.LogEnabled()) logger.Log($"ClientSceneMessage: changing scenes from: {ActiveScenePath} to: {msg.scenePath}");
-
-            //Additive are scenes loaded on server and this client is not a host client
-            if (msg.additiveScenes != null && msg.additiveScenes.Length > 0 && Client && !Client.IsLocalClient)
-            {
-                foreach (string scene in msg.additiveScenes)
-                {
-                    pendingAdditiveSceneList.Add(scene);
-                }
-            }
-
-            // Let client prepare for scene change
-            OnClientChangeScene(msg.scenePath, msg.sceneOperation);
-
-            ApplyOperationAsync(msg.scenePath, msg.sceneOperation).Forget();
-        }
-
-        internal void ClientSceneReadyMessage(INetworkPlayer player, SceneReadyMessage msg)
-        {
-            logger.Log("ClientSceneReadyMessage");
-
-            //Server has finished changing scene. Allow the client to finish.
-            if (clientLoadingOperation != null)
-                clientLoadingOperation.allowSceneActivation = true;
-        }
-
-        internal void ClientNotReadyMessage(INetworkPlayer player, NotReadyMessage msg)
-        {
-            logger.Log("NetworkSceneManager.OnClientNotReadyMessageInternal");
-
-            Client.Player.IsReady = false;
+            Client.MessageHandler.RegisterHandler<SceneReadyMessage>(ClientFinishedLoadingSceneMessage);
+            Client.MessageHandler.RegisterHandler<NotReadyMessage>(ClientNotReadyMessage);
         }
 
         /// <summary>
-        /// Called from ClientChangeScene immediately before SceneManager.LoadSceneAsync is executed
-        /// <para>This allows client to do work / cleanup / prep before the scene changes.</para>
+        ///     Received message from server to start loading scene or scenes.
+        ///
+        ///     <para>Default implementation is to load main activate scene server is using and load any
+        ///     other additive scenes in background and notify event handler. If this is not intended
+        ///     behavior you need please override this function.</para>
         /// </summary>
-        /// <param name="scenePath">Path of the scene that's about to be loaded</param>
-        /// <param name="sceneOperation">Scene operation that's about to happen</param>
-        internal void OnClientChangeScene(string scenePath, SceneOperation sceneOperation)
+        /// <param name="player"></param>
+        /// <param name="message"></param>
+        public virtual void ClientStartSceneMessage(INetworkPlayer player, SceneMessage message)
         {
-            ClientChangeScene?.Invoke(scenePath, sceneOperation);
+            if (!Client.IsConnected)
+                throw new InvalidOperationException("[NetworkSceneManager] - SceneLoadStartedMessage: cannot change network scene while client is disconnected");
+
+            if (string.IsNullOrEmpty(message.MainActivateScene))
+                throw new ArgumentNullException(nameof(message.MainActivateScene), $"[NetworkSceneManager] - SceneLoadStartedMessage: {nameof(message.MainActivateScene)} cannot be empty or null");
+
+            if (logger.LogEnabled()) logger.Log($"[NetworkSceneManager] - SceneLoadStartedMessage: changing scenes from: {ActiveScenePath} to: {message.MainActivateScene}");
+
+            //Additive are scenes loaded on server and this client is not a host client
+            if (message.AdditiveScenes != null && message.AdditiveScenes.Length > 0 && Client && !Client.IsLocalClient)
+            {
+                for (int index = message.AdditiveScenes.Length - 1; index >= 0; index--)
+                {
+                    string scene = message.AdditiveScenes[index];
+
+                    ClientPendingAdditiveSceneLoadingList.Add(scene);
+                }
+            }
+
+            // Notify others that client has started to change scenes.
+            ClientStartedSceneChange?.Invoke(message.MainActivateScene, message.SceneOperation);
+
+            LoadSceneAsync(message.MainActivateScene, player, message.SceneOperation).Forget();
+        }
+
+        /// <summary>
+        ///     Received message from server that it has finished loading the scene.
+        ///
+        ///     <para>Default implementation will set AllowSceneActivation = true and invoke event handler.
+        ///     If this is not good enough intended behavior then override this method.</para>
+        /// </summary>
+        /// <param name="player">The player who sent the message.</param>
+        /// <param name="message">The message data coming back from server.</param>
+        public virtual void ClientFinishedLoadingSceneMessage(INetworkPlayer player, SceneReadyMessage message)
+        {
+            logger.Log("[NetworkSceneManager] - ClientSceneReadyMessage");
+
+            //Server has finished changing scene. Allow the client to finish.
+            if (SceneLoadingAsyncOperationInfo != null)
+                SceneLoadingAsyncOperationInfo.allowSceneActivation = true;
         }
 
         /// <summary>
@@ -182,21 +174,37 @@ namespace Mirage
         /// </summary>
         /// <param name="scenePath">Path of the scene that was just loaded</param>
         /// <param name="sceneOperation">Scene operation that was just  happen</param>
-        internal void OnClientSceneChanged(string scenePath, SceneOperation sceneOperation)
+        internal void OnClientSceneLoadFinished(string scenePath, SceneOperation sceneOperation)
         {
-            if (pendingAdditiveSceneList.Count > 0 && Client && !Client.IsLocalClient)
+            if (ClientPendingAdditiveSceneLoadingList.Count > 0 && Client && !Client.IsLocalClient)
             {
-                ApplyOperationAsync(pendingAdditiveSceneList[0], SceneOperation.LoadAdditive).Forget();
-                pendingAdditiveSceneList.RemoveAt(0);
+                LoadSceneAsync(ClientPendingAdditiveSceneLoadingList[0], Client.Player, SceneOperation.LoadAdditive).Forget();
+
+                ClientPendingAdditiveSceneLoadingList.RemoveAt(0);
+
                 return;
             }
 
             //set ready after scene change has completed
-            if (!Client.Player.IsReady)
-                SetClientReady();
+            if (!Client.Player.SceneIsReady)
+                SetSceneIsReady();
 
             //Call event once all scene related actions (subscenes and ready) are done.
-            ClientSceneChanged?.Invoke(scenePath, sceneOperation);
+            ClientFinishedSceneChange?.Invoke(scenePath, sceneOperation);
+        }
+
+        /// <summary>
+        ///     Received message that player is not ready.
+        ///
+        ///     <para>Default implementation is to set player to not ready.</para>
+        /// </summary>
+        /// <param name="player">The player that is currently not ready.</param>
+        /// <param name="message">The message data coming in.</param>
+        public virtual void ClientNotReadyMessage(INetworkPlayer player, NotReadyMessage message)
+        {
+            logger.Log("[NetworkSceneManager] - OnClientNotReadyMessageInternal");
+
+            Client.Player.SceneIsReady = false;
         }
 
         /// <summary>
@@ -204,16 +212,16 @@ namespace Mirage
         /// <para>This could be for example when a client enters an ongoing game and has finished loading the current scene. The server should respond to the message with an appropriate handler which instantiates the players object for example.</para>
         /// </summary>
         /// <exception cref="InvalidOperationException">When called with an null or disconnected client</exception>
-        public void SetClientReady()
+        public void SetSceneIsReady()
         {
             if (!Client || !Client.Active)
-                throw new InvalidOperationException("Ready() called with an null or disconnected client");
+                throw new InvalidOperationException("[NetworkSceneManager] - Ready() called with an null or disconnected client");
 
-            if (logger.LogEnabled()) logger.Log("ClientScene.Ready() called.");
+            if (logger.LogEnabled()) logger.Log("[NetworkSceneManager] - ClientScene.Ready() called.");
 
             // Set these before sending the ReadyMessage, otherwise host client
             // will fail in InternalAddPlayer with null readyConnection.
-            Client.Player.IsReady = true;
+            Client.Player.SceneIsReady = true;
 
             // Tell server we're ready to have a player object spawned
             Client.Player.Send(new ReadyMessage());
@@ -221,169 +229,262 @@ namespace Mirage
 
         #endregion
 
-        #region Server
+        #region Server Side
 
-        // called after successful authentication
-        void OnServerAuthenticated(INetworkPlayer player)
+        /// <summary>
+        ///     Creates a new physics scene on server and transfer specific player's to that scene.
+        /// </summary>
+        /// <param name="scenePath">The scene to use as base for the new physics scene.</param>
+        /// <param name="sceneParameters">The scene parameter data we want to use.</param>
+        /// <param name="players"></param>
+        public virtual async void CreatePhysicsScene(string scenePath, LoadSceneParameters sceneParameters, IEnumerable<INetworkPlayer> players)
         {
-            logger.Log("NetworkSceneManager.OnServerAuthenticated");
+            await SceneManager.LoadSceneAsync(scenePath, sceneParameters);
 
-            player.Send(new SceneMessage { scenePath = ActiveScenePath, additiveScenes = additiveSceneList.ToArray() });
-            player.Send(new SceneReadyMessage());
+            // Since this is new scene loading this should be count -1 to get newest scene?
+            IEnumerable<INetworkPlayer> networkPlayers = players as INetworkPlayer[] ?? players.ToArray();
+            Scene newScene = SceneManager.GetSceneAt(SceneManager.sceneCount - 1);
+
+            ServerSceneData.Add(SceneManager.GetSceneAt(SceneManager.sceneCount - 1),
+                new List<INetworkPlayer>(networkPlayers));
+
+            NetworkServer.SendToMany(networkPlayers, new SceneMessage { MainActivateScene = newScene.path, SceneOperation = SceneOperation.LoadAdditive });
         }
 
         /// <summary>
-        /// This causes the server to switch scenes and sets the ActiveScenePath.
-        /// <para>Clients that connect to this server will automatically switch to this scene. This automatically sets clients to be not-ready. The clients must call Ready() again to participate in the new scene.</para>
+        ///     Creates a new physics scene on server but does not transfer any player's to it.
         /// </summary>
-        /// <param name="scenePath"></param>
-        /// <param name="operation"></param>
-        /// <exception cref="ArgumentNullException">Scene path was not valid.</exception>
+        /// <param name="scenePath">The scene to use as base for the new physics scene.</param>
+        /// <param name="sceneParameters">The scene parameter data we want to use.</param>
+        public void CreatePhysicsScene(string scenePath, LoadSceneParameters sceneParameters)
+        {
+            SceneManager.LoadSceneAsync(GetSceneByPathOrName(scenePath), sceneParameters);
+        }
+
+        /// <summary>
+        ///     Allows server to fully load new scene or additive load in another scene.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scenes files or the names of the scenes.</param>
+        /// <param name="sceneOperation">Choose type of scene loading we are doing <see cref="SceneOperation"/>.</param>
         public void ChangeServerScene(string scenePath, SceneOperation sceneOperation = SceneOperation.Normal)
         {
             if (string.IsNullOrEmpty(scenePath))
             {
-                throw new ArgumentNullException(nameof(scenePath), "ServerChangeScene: " + nameof(scenePath) + " cannot be empty or null");
+                throw new ArgumentNullException(nameof(scenePath), "[NetworkSceneManager] - ServerChangeScene: " + nameof(scenePath) + " cannot be empty or null");
             }
 
-            if (logger.LogEnabled()) logger.Log("ServerChangeScene " + scenePath);
+            if (logger.LogEnabled()) logger.Log("[NetworkSceneManager] - ServerChangeScene " + scenePath);
 
             // Let server prepare for scene change
-            OnServerChangeScene(scenePath, sceneOperation);
+            logger.Log("[NetworkSceneManager] - OnServerChangeScene");
+
+            ServerStartedSceneChange?.Invoke(scenePath, sceneOperation);
 
             if (!Server.LocalClientActive)
-                ApplyOperationAsync(scenePath, sceneOperation).Forget();
+                LoadSceneAsync(scenePath, null, sceneOperation).Forget();
 
             // notify all clients about the new scene
-            Server.SendToAll(new SceneMessage { scenePath = scenePath, sceneOperation = sceneOperation });
+            Server.SendToAll(new SceneMessage { MainActivateScene = GetSceneByPathOrName(scenePath), SceneOperation = sceneOperation });
         }
 
         /// <summary>
-        /// Called from ChangeServerScene immediately before NetworkSceneManager's LoadSceneAsync is executed
-        /// <para>This allows server to do work / cleanup / prep before the scene changes.</para>
+        ///     When player authenticates to server we send a message to them to load up main scene and
+        ///     any other scenes that are loaded on server.
+        ///
+        ///     <para>Default implementation takes main activate scene as main and any other loaded scenes and sends it to player's
+        ///     Please override this function if this is not intended behavior for you.</para>
         /// </summary>
-        /// <param name="scenePath">Path of the scene that's about to be loaded</param>
-        internal void OnServerChangeScene(string scenePath, SceneOperation operation)
+        /// <param name="player">The current player that finished authenticating.</param>
+        public virtual void OnServerAuthenticated(INetworkPlayer player)
         {
-            logger.Log("OnServerChangeScene");
+            logger.Log("[NetworkSceneManager] - OnServerAuthenticated");
 
-            ServerChangeScene?.Invoke(scenePath, operation);
+            string[] scenesPaths = new string[] { };
+
+            for (int sceneIndex = 0; sceneIndex < SceneManager.sceneCount; sceneIndex++)
+            {
+                Scene scene = SceneManager.GetSceneAt(sceneIndex);
+
+                if (scene.Equals(SceneManager.GetActiveScene())) continue;
+
+                scenesPaths[sceneIndex] = scene.path;
+            }
+
+            player.Send(new SceneMessage { MainActivateScene = ActiveScenePath, AdditiveScenes = scenesPaths });
+            player.Send(new SceneReadyMessage());
         }
 
         /// <summary>
-        /// Called on the server when a scene is completed loaded, when the scene load was initiated by the server with ChangeServerScene().
+        ///     Called on the server when a scene is completed loaded, when the scene load was initiated by the server with ChangeServerScene().
         /// </summary>
         /// <param name="scenePath">The name of the new scene.</param>
-        internal void OnServerSceneChanged(string scenePath, SceneOperation operation)
+        /// <param name="operation">The type of scene loading we want to do.</param>
+        internal void OnServerFinishedSceneLoad(string scenePath, SceneOperation operation)
         {
-            logger.Log("OnServerSceneChanged");
+            logger.Log(" [NetworkSceneManager] - OnServerSceneChanged");
 
             Server.SendToAll(new SceneReadyMessage());
 
-            ServerSceneChanged?.Invoke(scenePath, operation);
+            ServerFinishedSceneChange?.Invoke(scenePath, operation);
+        }
+
+        #endregion
+
+        #region Unity Methods
+
+        public virtual void Start()
+        {
+            if (DontDestroy)
+                DontDestroyOnLoad(gameObject);
+
+            if (Client != null)
+                Client.Started.AddListener(RegisterClientMessages);
+
+            if (Server != null)
+                Server.Authenticated.AddListener(OnServerAuthenticated);
+        }
+
+        public virtual void OnDestroy()
+        {
+            if (Client != null)
+                Client.Started.RemoveListener(RegisterClientMessages);
+
+            if (Server != null)
+                Server.Authenticated.RemoveListener(OnServerAuthenticated);
         }
 
         #endregion
 
         #region Scene Operations
 
-        UniTask ApplyOperationAsync(string scenePath, SceneOperation sceneOperation = SceneOperation.Normal)
+        /// <summary>
+        ///     Finish loading the scene.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene that is finishing.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        /// <param name="sceneOperation">Choose type of scene loading we are doing <see cref="SceneOperation"/>.</param>
+        internal void CompleteLoadingScene(string scenePath, INetworkPlayer player, SceneOperation sceneOperation)
         {
-            switch (sceneOperation)
+            // If server mode call this to make sure scene finishes loading
+            if (Server && Server.Active)
             {
-                case SceneOperation.Normal: return ApplyNormalOperationAsync(scenePath);
-                case SceneOperation.LoadAdditive: return ApplyAdditiveLoadOperationAsync(scenePath);
-                case SceneOperation.UnloadAdditive: return ApplyUnloadAdditiveOperationAsync(scenePath);
-                default:
-                    // Should never happen
-                    throw new InvalidEnumArgumentException(nameof(sceneOperation), (int)sceneOperation, typeof(SceneOperation));
+                if (logger.LogEnabled())
+                    logger.Log("[NetworkSceneManager] - Host: " + sceneOperation + " operation for scene: " + scenePath);
+
+                // call OnServerSceneChanged
+                OnServerFinishedSceneLoad(scenePath, sceneOperation);
+            }
+
+            // If client let's call this to finish client scene loading too
+            if (Client && Client.Active)
+            {
+                if (logger.LogEnabled())
+                    logger.Log("[NetworkSceneManager] - Client: " + sceneOperation + " operation for scene: " +
+                               scenePath);
+
+                OnClientSceneLoadFinished(scenePath, sceneOperation);
+
             }
         }
 
-        async UniTask ApplyNormalOperationAsync(string scenePath)
+        /// <summary>
+        ///     Internal usage to apply loading a scene correctly. Other api will be available to override things.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        /// <param name="sceneOperation">Choose type of scene loading we are doing <see cref="SceneOperation"/>.</param>
+        private UniTask LoadSceneAsync(string scenePath, INetworkPlayer player, SceneOperation sceneOperation = SceneOperation.Normal)
+        {
+            return sceneOperation switch
+            {
+                SceneOperation.Normal => LoadSceneNormalAsync(scenePath, player),
+                SceneOperation.LoadAdditive => LoadSceneAdditiveAsync(scenePath, player),
+                SceneOperation.UnloadAdditive => UnLoadSceneAdditiveAsync(scenePath, player),
+                _ => throw new InvalidEnumArgumentException(nameof(sceneOperation), (int)sceneOperation,
+                    typeof(SceneOperation))
+            };
+        }
+
+        /// <summary>
+        ///     Load our scene up in a normal unity fashion.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        public virtual async UniTask LoadSceneNormalAsync(string scenePath, INetworkPlayer player)
         {
             //Scene is already active.
-            if (ActiveScenePath.Equals(scenePath))
+            if (ActiveScenePath.Equals(GetSceneByPathOrName(scenePath)))
             {
-                FinishLoadScene(scenePath, SceneOperation.Normal);
+                CompleteLoadingScene(scenePath, player, SceneOperation.Normal);
             }
             else
             {
-                clientLoadingOperation = SceneManager.LoadSceneAsync(scenePath);
+                SceneLoadingAsyncOperationInfo = SceneManager.LoadSceneAsync(scenePath);
 
                 //If non host client. Wait for server to finish scene change
                 if (Client && Client.Active && !Client.IsLocalClient)
                 {
-                    clientLoadingOperation.allowSceneActivation = false;
+                    SceneLoadingAsyncOperationInfo.allowSceneActivation = false;
                 }
 
-                await clientLoadingOperation;
+                await SceneLoadingAsyncOperationInfo;
 
-                logger.Assert(scenePath == ActiveScenePath, "Scene being loaded was not the active scene");
-                FinishLoadScene(ActiveScenePath, SceneOperation.Normal);
+                logger.Assert(scenePath == ActiveScenePath, "[NetworkSceneManager] - Scene being loaded was not the active scene");
+
+                CompleteLoadingScene(ActiveScenePath, player, SceneOperation.Normal);
             }
         }
 
-        async UniTask ApplyAdditiveLoadOperationAsync(string scenePath)
+        /// <summary>
+        ///     Load our scene additively.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        public virtual async UniTask LoadSceneAdditiveAsync(string scenePath, INetworkPlayer player)
         {
             // Ensure additive scene is not already loaded
-            if (SceneManager.GetSceneByPath(scenePath).IsValid())
+            if (SceneManager.GetSceneByPath(GetSceneByPathOrName(scenePath)).IsValid())
             {
-                logger.LogWarning($"Scene {scenePath} is already loaded");
+                logger.LogWarning($"[NetworkSceneManager] - Scene {scenePath} is already loaded");
             }
             else
             {
                 await SceneManager.LoadSceneAsync(scenePath, LoadSceneMode.Additive);
-                additiveSceneList.Add(scenePath);
-                FinishLoadScene(scenePath, SceneOperation.LoadAdditive);
+
+                CompleteLoadingScene(scenePath, player, SceneOperation.LoadAdditive);
             }
         }
 
-        async UniTask ApplyUnloadAdditiveOperationAsync(string scenePath)
+        /// <summary>
+        ///     Unload our scene additively.
+        /// </summary>
+        /// <param name="scenePath">The full path to the scene file or the name of the scene.</param>
+        /// <param name="player">Whether or not we should move the player.</param>
+        public virtual async UniTask UnLoadSceneAdditiveAsync(string scenePath, INetworkPlayer player)
         {
             // Ensure additive scene is actually loaded
-            if (SceneManager.GetSceneByPath(scenePath).IsValid())
+            if (SceneManager.GetSceneByPath(GetSceneByPathOrName(scenePath)).IsValid())
             {
                 await SceneManager.UnloadSceneAsync(scenePath, UnloadSceneOptions.UnloadAllEmbeddedSceneObjects);
-                additiveSceneList.Remove(scenePath);
-                FinishLoadScene(scenePath, SceneOperation.UnloadAdditive);
+
+                CompleteLoadingScene(scenePath, player, SceneOperation.UnloadAdditive);
             }
             else
             {
-                logger.LogWarning($"Cannot unload {scenePath} with UnloadAdditive operation");
+                logger.LogWarning($"[NetworkSceneManager] - Cannot unload {scenePath} with UnloadAdditive operation");
             }
         }
 
-        internal void FinishLoadScene(string scenePath, SceneOperation sceneOperation)
+        /// <summary>
+        ///     Let's us get scene by full path or by its name.
+        /// </summary>
+        /// <param name="scenePath">The path or name representing the scene.</param>
+        /// <returns>Returns back correct scene data.</returns>
+        public string GetSceneByPathOrName(string scenePath)
         {
-            // host mode?
-            if (Client && Client.IsLocalClient)
-            {
-                if (logger.LogEnabled()) logger.Log("Host: " + sceneOperation.ToString() + " operation for scene: " + scenePath);
+            Scene scene = SceneManager.GetSceneByPath(scenePath);
 
-                // call OnServerSceneChanged
-                OnServerSceneChanged(scenePath, sceneOperation);
-
-                if (Client.IsConnected)
-                {
-                    // let client know that we changed scene
-                    OnClientSceneChanged(scenePath, sceneOperation);
-                }
-            }
-            // server-only mode?
-            else if (Server && Server.Active)
-            {
-                if (logger.LogEnabled()) logger.Log("Server: " + sceneOperation.ToString() + " operation for scene: " + scenePath);
-
-                OnServerSceneChanged(scenePath, sceneOperation);
-            }
-            // client-only mode?
-            else if (Client && Client.Active && !Client.IsLocalClient)
-            {
-                if (logger.LogEnabled()) logger.Log("Client: " + sceneOperation.ToString() + " operation for scene: " + scenePath);
-
-                OnClientSceneChanged(scenePath, sceneOperation);
-            }
+            return !string.IsNullOrEmpty(scene.name) ? scene.path : SceneManager.GetSceneByName(scenePath).path;
         }
 
         #endregion

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -59,8 +59,8 @@ namespace Mirage
 
                 if (NetworkSceneManager != null)
                 {
-                    NetworkSceneManager.ServerChangeScene.AddListener(OnServerChangeScene);
-                    NetworkSceneManager.ServerSceneChanged.AddListener(OnServerSceneChanged);
+                    NetworkSceneManager.ServerStartedSceneChange.AddListener(OnServerChangeScene);
+                    NetworkSceneManager.ServerFinishedSceneChange.AddListener(OnServerSceneChanged);
                 }
             }
         }
@@ -220,7 +220,7 @@ namespace Mirage
         {
             if (logger.LogEnabled()) logger.Log("Spawning " + Server.World.SpawnedIdentities.Count + " objects for conn " + player);
 
-            if (!player.IsReady)
+            if (!player.SceneIsReady)
             {
                 // client needs to finish initializing before we can spawn objects
                 // otherwise it would not find them.
@@ -327,7 +327,7 @@ namespace Mirage
 
         internal void ShowForConnection(NetworkIdentity identity, INetworkPlayer player)
         {
-            if (player.IsReady)
+            if (player.SceneIsReady)
                 SendSpawnMessage(identity, player);
         }
 
@@ -649,7 +649,7 @@ namespace Mirage
             if (logger.LogEnabled()) logger.Log("SetClientReadyInternal for conn:" + player);
 
             // set ready
-            player.IsReady = true;
+            player.SceneIsReady = true;
 
             // client is ready to start spawning objects
             if (player.Identity != null)
@@ -675,10 +675,10 @@ namespace Mirage
         /// <param name="player">The connection of the client to make not ready.</param>
         public void SetClientNotReady(INetworkPlayer player)
         {
-            if (player.IsReady)
+            if (player.SceneIsReady)
             {
                 if (logger.LogEnabled()) logger.Log("PlayerNotReady " + player);
-                player.IsReady = false;
+                player.SceneIsReady = false;
                 player.RemoveObservers();
 
                 player.Send(new NotReadyMessage());

--- a/Assets/Mirage/Samples~/AdditiveScenes/Scripts/ZoneHandler.cs
+++ b/Assets/Mirage/Samples~/AdditiveScenes/Scripts/ZoneHandler.cs
@@ -22,7 +22,7 @@ namespace Mirage.Examples.Additive
             if (logger.LogEnabled()) logger.LogFormat(LogType.Log, "Loading {0}", subScene);
 
             NetworkIdentity networkIdentity = other.gameObject.GetComponent<NetworkIdentity>();
-            networkIdentity.ConnectionToClient.Send(new SceneMessage { scenePath = subScene, sceneOperation = SceneOperation.LoadAdditive });
+            networkIdentity.ConnectionToClient.Send(new SceneMessage { MainActivateScene = subScene, SceneOperation = SceneOperation.LoadAdditive });
         }
 
         [Server]
@@ -31,7 +31,7 @@ namespace Mirage.Examples.Additive
             if (logger.LogEnabled()) logger.LogFormat(LogType.Log, "Unloading {0}", subScene);
 
             NetworkIdentity networkIdentity = other.gameObject.GetComponent<NetworkIdentity>();
-            networkIdentity.ConnectionToClient.Send(new SceneMessage { scenePath = subScene, sceneOperation = SceneOperation.UnloadAdditive });
+            networkIdentity.ConnectionToClient.Send(new SceneMessage { MainActivateScene = subScene, SceneOperation = SceneOperation.UnloadAdditive });
         }
     }
 }

--- a/Assets/Mirage/Samples~/ChangeScene/Scenes/Main.unity
+++ b/Assets/Mirage/Samples~/ChangeScene/Scenes/Main.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -118,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -173,6 +175,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -239,16 +242,16 @@ MonoBehaviour:
   Client: {fileID: 450078216}
   Server: {fileID: 450078217}
   DontDestroy: 1
-  _clientChangeScene:
+  _clientStartedSceneChange:
     m_PersistentCalls:
       m_Calls: []
-  _clientSceneChanged:
+  _clientFinishedSceneChange:
     m_PersistentCalls:
       m_Calls: []
-  _serverChangeScene:
+  _serverStartedSceneChange:
     m_PersistentCalls:
       m_Calls: []
-  _serverSceneChanged:
+  _serverFinishedSceneChange:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &450078213
@@ -310,7 +313,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   EnablePeerMetrics: 0
   SocketFactory: {fileID: 450078214}
+  DisconnectOnException: 1
   authenticator: {fileID: 0}
+  _started:
+    _event:
+      m_PersistentCalls:
+        m_Calls: []
   _connected:
     _event:
       m_PersistentCalls:
@@ -337,6 +345,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   EnablePeerMetrics: 0
   MaxConnections: 4
+  DisconnectOnException: 1
   Listening: 1
   SocketFactory: {fileID: 450078214}
   authenticator: {fileID: 0}
@@ -396,8 +405,7 @@ MonoBehaviour:
   SceneManager: {fileID: 450078212}
   ClientObjectManager: {fileID: 450078220}
   ServerObjectManager: {fileID: 450078213}
-  PlayerPrefab: {fileID: 3878225662718291898, guid: 234985fef22d66a4ca2dba0e688f1743,
-    type: 3}
+  PlayerPrefab: {fileID: 3878225662718291898, guid: 234985fef22d66a4ca2dba0e688f1743, type: 3}
   AutoSpawn: 1
   startPositionIndex: 0
   startPositions:
@@ -598,6 +606,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -628,6 +637,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1141063017}
+        m_TargetAssemblyTypeName: 
         m_MethodName: AdditiveButtonHandler
         m_Mode: 1
         m_Arguments:
@@ -653,6 +663,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -823,6 +834,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -881,7 +893,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 43d53bca23122b54fb0ebaddebf2e987, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sceneManager: {fileID: 0}
+  sceneManager: {fileID: 450078212}
   AdditiveButtonText: {fileID: 1173114603}
 --- !u!114 &1141063018
 MonoBehaviour:
@@ -922,6 +934,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &1141063020
 Canvas:
   m_ObjectHideFlags: 0
@@ -1017,6 +1030,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1096,6 +1110,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1126,6 +1141,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1141063017}
+        m_TargetAssemblyTypeName: 
         m_MethodName: Room1ButtonHandler
         m_Mode: 1
         m_Arguments:
@@ -1151,6 +1167,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1226,6 +1243,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1256,6 +1274,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1141063017}
+        m_TargetAssemblyTypeName: 
         m_MethodName: Room2ButtonHandler
         m_Mode: 1
         m_Arguments:
@@ -1281,6 +1300,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1441,6 +1461,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.15686275}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1488,68 +1509,55 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalPosition.x
       value: -5
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: sceneId
       value: 4160360001
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344372, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344372, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_Name
       value: SceneObject
       objectReference: {fileID: 0}
@@ -1562,73 +1570,59 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 6727010246441667690, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667690, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_Name
       value: ServerOnlySceneObject
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667693, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667693, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: sceneId
       value: 3166183123
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667693, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667693, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_AssetId
       value: a6be402bdabdcda42927e4593587fefb
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb,
-        type: 3}
+    - target: {fileID: 6727010246441667695, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -1694,6 +1688,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1848,6 +1843,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1908,6 +1904,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1957,6 +1954,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1996,10 +1994,14 @@ MonoBehaviour:
   m_OnEndEdit:
     m_PersistentCalls:
       m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 695766755316128326}
+        m_TargetAssemblyTypeName: 
         m_MethodName: OnNetworkAddressInputUpdate
         m_Mode: 1
         m_Arguments:
@@ -2017,6 +2019,7 @@ MonoBehaviour:
   m_CaretBlinkRate: 0.85
   m_CaretWidth: 1
   m_ReadOnly: 0
+  m_ShouldActivateOnSelect: 1
 --- !u!114 &7413922469818467064
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2031,6 +2034,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -2061,6 +2065,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 695766755316128326}
+        m_TargetAssemblyTypeName: 
         m_MethodName: StartHostButtonHandler
         m_Mode: 1
         m_Arguments:
@@ -2133,6 +2138,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2189,6 +2195,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2217,6 +2224,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -2247,6 +2255,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 695766755316128326}
+        m_TargetAssemblyTypeName: 
         m_MethodName: StartServerOnlyButtonHandler
         m_Mode: 1
         m_Arguments:
@@ -2300,6 +2309,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2388,6 +2398,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2475,6 +2486,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2503,6 +2515,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -2533,6 +2546,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 695766755316128326}
+        m_TargetAssemblyTypeName: 
         m_MethodName: StartClientButtonHandler
         m_Mode: 1
         m_Arguments:
@@ -2586,6 +2600,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2614,6 +2629,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -2644,6 +2660,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 695766755316128326}
+        m_TargetAssemblyTypeName: 
         m_MethodName: StopButtonHandler
         m_Mode: 1
         m_Arguments:
@@ -2708,6 +2725,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2831,6 +2849,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2912,6 +2931,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.078431375}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2986,6 +3006,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/Assets/Mirage/Samples~/ChangeScene/Scripts/SceneSwitcherHud.cs
+++ b/Assets/Mirage/Samples~/ChangeScene/Scripts/SceneSwitcherHud.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 namespace Mirage.Examples.SceneChange
@@ -8,6 +9,7 @@ namespace Mirage.Examples.SceneChange
         public NetworkSceneManager sceneManager;
         public Text AdditiveButtonText;
         bool additiveLoaded;
+        private Scene _additiveLoadedScene;
 
         public void Update()
         {
@@ -23,27 +25,32 @@ namespace Mirage.Examples.SceneChange
 
         public void Room1ButtonHandler()
         {
-            sceneManager.ChangeServerScene("Room1");
+            sceneManager.ServerLoadSceneNormal("Room1");
             additiveLoaded = false;
         }
 
         public void Room2ButtonHandler()
         {
-            sceneManager.ChangeServerScene("Room2");
+            sceneManager.ServerLoadSceneNormal("Room2");
             additiveLoaded = false;
         }
 
         public void AdditiveButtonHandler()
         {
+            var players = new INetworkPlayer[sceneManager.Server.Players.Count];
+            sceneManager.Server.Players.CopyTo(players);
+
             if (additiveLoaded)
             {
                 additiveLoaded = false;
-                sceneManager.ChangeServerScene("Additive", SceneOperation.UnloadAdditive);
+
+                sceneManager.ServerUnloadSceneAdditively(_additiveLoadedScene, players);
             }
             else
             {
                 additiveLoaded = true;
-                sceneManager.ChangeServerScene("Additive", SceneOperation.LoadAdditive);
+                sceneManager.ServerLoadSceneAdditively("Additive", players);
+                _additiveLoadedScene = SceneManager.GetSceneAt(SceneManager.sceneCount - 1);
             }
         }
     }

--- a/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
+++ b/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
@@ -46,7 +46,13 @@ namespace Mirage.Examples.MultipleAdditiveScenes
         IEnumerator AddPlayerDelayed(INetworkPlayer player)
         {
             yield return new WaitForSeconds(.5f);
-            player.Send(new SceneMessage { MainActivateScene = gameScene, SceneOperation = SceneOperation.LoadAdditive });
+
+            var players = new INetworkPlayer[Server.Players.Count];
+            Server.Players.CopyTo(players);
+
+            ServerObjectManager.NetworkSceneManager.ServerLoadSceneAdditively(gameScene, players);
+
+            //player.Send(new SceneMessage { MainActivateScene = gameScene, SceneOperation = SceneOperation.LoadAdditive });
 
             PlayerScore playerScore = player.Identity.GetComponent<PlayerScore>();
             playerScore.playerNumber = playerId;

--- a/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
+++ b/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
@@ -46,7 +46,7 @@ namespace Mirage.Examples.MultipleAdditiveScenes
         IEnumerator AddPlayerDelayed(INetworkPlayer player)
         {
             yield return new WaitForSeconds(.5f);
-            player.Send(new SceneMessage { scenePath = gameScene, sceneOperation = SceneOperation.LoadAdditive });
+            player.Send(new SceneMessage { MainActivateScene = gameScene, SceneOperation = SceneOperation.LoadAdditive });
 
             PlayerScore playerScore = player.Identity.GetComponent<PlayerScore>();
             playerScore.playerNumber = playerId;
@@ -79,7 +79,7 @@ namespace Mirage.Examples.MultipleAdditiveScenes
         /// </summary>
         public void OnStopServer()
         {
-            Server.SendToAll(new SceneMessage { scenePath = gameScene, sceneOperation = SceneOperation.UnloadAdditive });
+            Server.SendToAll(new SceneMessage { MainActivateScene = gameScene, SceneOperation = SceneOperation.UnloadAdditive });
             StartCoroutine(UnloadSubScenes());
         }
 

--- a/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
@@ -755,7 +755,7 @@ namespace Mirage
             // one with a ready connection, one with no ready connection, one with null connection
             RebuildObserversNetworkBehaviour comp = gameObject.AddComponent<RebuildObserversNetworkBehaviour>();
             comp.observer = Substitute.For<INetworkPlayer>();
-            comp.observer.IsReady.Returns(true);
+            comp.observer.SceneIsReady.Returns(true);
 
             // rebuild observers should add all component's ready observers
             identity.RebuildObservers(true);
@@ -770,7 +770,7 @@ namespace Mirage
             // one with a ready connection, one with no ready connection, one with null connection
             RebuildObserversNetworkBehaviour comp = gameObject.AddComponent<RebuildObserversNetworkBehaviour>();
             comp.observer = Substitute.For<INetworkPlayer>();
-            comp.observer.IsReady.Returns(false);
+            comp.observer.SceneIsReady.Returns(false);
 
             // rebuild observers should add all component's ready observers
             identity.RebuildObservers(true);
@@ -781,9 +781,9 @@ namespace Mirage
         public void RebuildObserversAddsReadyServerConnectionsIfNotImplemented()
         {
             INetworkPlayer readyConnection = Substitute.For<INetworkPlayer>();
-            readyConnection.IsReady.Returns(true);
+            readyConnection.SceneIsReady.Returns(true);
             INetworkPlayer notReadyConnection = Substitute.For<INetworkPlayer>();
-            notReadyConnection.IsReady.Returns(false);
+            notReadyConnection.SceneIsReady.Returns(false);
 
             // add some server connections
             server.Players.Add(readyConnection);

--- a/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
@@ -41,7 +41,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             UnityAction<string, SceneOperation> func2 = Substitute.For<UnityAction<string, SceneOperation>>();
             clientSceneManager.ClientFinishedSceneChange.AddListener(func2);
-            clientSceneManager.CompleteLoadingScene("Assets/Mirror/Tests/Runtime/testScene.unity", null,SceneOperation.Normal);
+            clientSceneManager.CompleteLoadingScene("Assets/Mirror/Tests/Runtime/testScene.unity",SceneOperation.Normal);
 
             func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }

--- a/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerTests.cs
@@ -32,7 +32,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                clientSceneManager.ClientSceneMessage(null, new SceneMessage());
+                clientSceneManager.ClientStartSceneMessage(null, new SceneMessage());
             });
         }
 
@@ -40,8 +40,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         public void FinishLoadSceneTest()
         {
             UnityAction<string, SceneOperation> func2 = Substitute.For<UnityAction<string, SceneOperation>>();
-            clientSceneManager.ClientSceneChanged.AddListener(func2);
-            clientSceneManager.FinishLoadScene("Assets/Mirror/Tests/Runtime/testScene.unity", SceneOperation.Normal);
+            clientSceneManager.ClientFinishedSceneChange.AddListener(func2);
+            clientSceneManager.CompleteLoadingScene("Assets/Mirror/Tests/Runtime/testScene.unity", null,SceneOperation.Normal);
 
             func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
@@ -55,7 +55,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                clientSceneManager.ClientSceneMessage(null, new SceneMessage());
+                clientSceneManager.ClientStartSceneMessage(null, new SceneMessage());
             });
         });
 
@@ -65,9 +65,9 @@ namespace Mirage.Tests.Runtime.ClientServer
             int startInvoked = 0;
             int endInvoked = 0;
 
-            clientSceneManager.ClientChangeScene.AddListener((_, __) => startInvoked++);
-            clientSceneManager.ClientSceneChanged.AddListener((_, __) => endInvoked++);
-            clientSceneManager.ClientSceneMessage(null, new SceneMessage { scenePath = "Assets/Mirror/Tests/Runtime/testScene.unity" });
+            clientSceneManager.ClientStartedSceneChange.AddListener((_, __) => startInvoked++);
+            clientSceneManager.ClientFinishedSceneChange.AddListener((_, __) => endInvoked++);
+            clientSceneManager.ClientStartSceneMessage(null, new SceneMessage { MainActivateScene = "Assets/Mirror/Tests/Runtime/testScene.unity" });
 
             await AsyncUtil.WaitUntilWithTimeout(() => startInvoked == 1);
 
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.ClientServer
             Assert.That(startInvoked == 1, "Start should only be called once");
             Assert.That(endInvoked == 0, "Should wait for ready before end is called");
 
-            clientSceneManager.ClientSceneReadyMessage(clientPlayer, new SceneReadyMessage());
+            clientSceneManager.ClientFinishedLoadingSceneMessage(clientPlayer, new SceneReadyMessage());
 
             await AsyncUtil.WaitUntilWithTimeout(() => endInvoked == 1);
 
@@ -92,16 +92,16 @@ namespace Mirage.Tests.Runtime.ClientServer
             int startInvoked = 0;
             int endInvoked = 0;
 
-            clientSceneManager.ClientChangeScene.AddListener((_, __) => startInvoked++);
-            clientSceneManager.ClientSceneChanged.AddListener((_, __) => endInvoked++);
+            clientSceneManager.ClientStartedSceneChange.AddListener((_, __) => startInvoked++);
+            clientSceneManager.ClientFinishedSceneChange.AddListener((_, __) => endInvoked++);
 
             var invalidOperation = (SceneOperation)10;
             InvalidEnumArgumentException exception = Assert.Throws<InvalidEnumArgumentException>(() =>
             {
-                clientSceneManager.ClientSceneMessage(null, new SceneMessage
+                clientSceneManager.ClientStartSceneMessage(null, new SceneMessage
                 {
-                    scenePath = "Assets/Mirror/Tests/Runtime/testScene.unity",
-                    sceneOperation = invalidOperation
+                    MainActivateScene = "Assets/Mirror/Tests/Runtime/testScene.unity",
+                    SceneOperation = invalidOperation
                 });
             });
 
@@ -119,8 +119,8 @@ namespace Mirage.Tests.Runtime.ClientServer
         public void ServerChangeSceneTest()
         {
             UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
-            serverSceneManager.ServerChangeScene.AddListener(func1);
-            serverSceneManager.OnServerChangeScene("test", SceneOperation.Normal);
+            serverSceneManager.ServerStartedSceneChange.AddListener(func1);
+            serverSceneManager.ServerStartedSceneChange.Invoke("test", SceneOperation.Normal);
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
 
@@ -128,25 +128,25 @@ namespace Mirage.Tests.Runtime.ClientServer
         public void ServerSceneChangedTest()
         {
             UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
-            serverSceneManager.ServerSceneChanged.AddListener(func1);
-            serverSceneManager.OnServerSceneChanged("test", SceneOperation.Normal);
+            serverSceneManager.ServerFinishedSceneChange.AddListener(func1);
+            serverSceneManager.ServerFinishedSceneChange.Invoke("test", SceneOperation.Normal);
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
 
         [Test]
         public void OnClientSceneChangedAdditiveListTest()
         {
-            clientSceneManager.pendingAdditiveSceneList.Add("Assets/Mirror/Tests/Runtime/testScene.unity");
-            clientSceneManager.OnClientSceneChanged(null, SceneOperation.Normal);
-            Assert.That(clientSceneManager.pendingAdditiveSceneList.Count == 0);
+            clientSceneManager.ClientPendingAdditiveSceneLoadingList.Add("Assets/Mirror/Tests/Runtime/testScene.unity");
+            clientSceneManager.OnClientSceneLoadFinished(null, SceneOperation.Normal);
+            Assert.That(clientSceneManager.ClientPendingAdditiveSceneLoadingList.Count == 0);
         }
 
         [Test]
         public void ClientSceneMessagePendingAdditiveSceneListTest()
         {
             //Check for the additive scene in the pending list at the time of ClientChangeScene before its removed as part of it being loaded.
-            clientSceneManager.ClientChangeScene.AddListener(CheckForAdditiveScene);
-            clientSceneManager.ClientSceneMessage(client.Player, new SceneMessage { scenePath = "Assets/Mirror/Tests/Runtime/testScene.unity", additiveScenes = new[] { "Assets/Mirror/Tests/Runtime/testScene.unity" } });
+            clientSceneManager.ClientStartedSceneChange.AddListener(CheckForAdditiveScene);
+            clientSceneManager.ClientStartSceneMessage(client.Player, new SceneMessage { MainActivateScene = "Assets/Mirror/Tests/Runtime/testScene.unity", AdditiveScenes = new[] { "Assets/Mirror/Tests/Runtime/testScene.unity" } });
 
             Assert.That(additiveSceneWasFound);
         }
@@ -154,7 +154,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         bool additiveSceneWasFound;
         void CheckForAdditiveScene(string scenePath, SceneOperation sceneOperation)
         {
-            if (clientSceneManager.pendingAdditiveSceneList.Contains("Assets/Mirror/Tests/Runtime/testScene.unity"))
+            if (clientSceneManager.ClientPendingAdditiveSceneLoadingList.Contains("Assets/Mirror/Tests/Runtime/testScene.unity"))
             {
                 additiveSceneWasFound = true;
             }

--- a/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
@@ -47,10 +47,10 @@ namespace Mirage.Tests.Runtime.ClientServer
         {
             clientPlayer.Send(new ReadyMessage());
 
-            await AsyncUtil.WaitUntilWithTimeout(() => serverPlayer.IsReady);
+            await AsyncUtil.WaitUntilWithTimeout(() => serverPlayer.SceneIsReady);
 
             // ready?
-            Assert.That(serverPlayer.IsReady, Is.True);
+            Assert.That(serverPlayer.SceneIsReady, Is.True);
         });
 
         [UnityTest]

--- a/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ServerObjectManagerTests.cs
@@ -75,7 +75,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             ClientMessageHandler.RegisterHandler<SpawnMessage>(msg => invoked = true);
 
-            serverPlayer.IsReady = true;
+            serverPlayer.SceneIsReady = true;
 
             // call ShowForConnection
             serverObjectManager.ShowForConnection(serverIdentity, serverPlayer);

--- a/Assets/Tests/Runtime/Host/CharacterSpawnerTest.cs
+++ b/Assets/Tests/Runtime/Host/CharacterSpawnerTest.cs
@@ -43,7 +43,7 @@ namespace Mirage.Tests.Runtime.Host
             bool invokeAddPlayerMessage = false;
             ServerMessageHandler.RegisterHandler<AddCharacterMessage>(msg => invokeAddPlayerMessage = true);
 
-            sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity");
+            sceneManager.ServerLoadSceneNormal("Assets/Mirror/Tests/Runtime/testScene.unity");
             // wait for messages to be processed
             await UniTask.Yield();
 

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -101,7 +101,7 @@ namespace Mirage.Tests.Runtime.Host
             await UniTask.WaitUntil(() => !server.Active);
 
             UnityAction<string, SceneOperation> mockListener = Substitute.For<UnityAction<string, SceneOperation>>();
-            sceneManager.ClientChangeScene.AddListener(mockListener);
+            sceneManager.ClientStartedSceneChange.AddListener(mockListener);
             await StartHost();
 
             client.Update();

--- a/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
@@ -148,7 +148,7 @@ namespace Mirage.Tests.Runtime.Host
         [UnityTest]
         public IEnumerator ChangeSceneAdditiveLoadTest() => UniTask.ToCoroutine(async () =>
         {
-            sceneManager.ServerLoadSceneAdditively("Assets/Mirror/Tests/Runtime/testScene.unity", null);
+            sceneManager.ServerLoadSceneAdditively("Assets/Mirror/Tests/Runtime/testScene.unity", new[] {client.Player});
 
             await AsyncUtil.WaitUntilWithTimeout(() => SceneManager.GetSceneByName("testScene") != null);
 

--- a/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
@@ -21,7 +21,7 @@ namespace Mirage.Tests.Runtime.Host
             bundle = AssetBundle.LoadFromFile("Assets/Tests/Runtime/TestScene/testscene");
 
             sceneEventFunction = Substitute.For<UnityAction<string, SceneOperation>>();
-            sceneManager.ServerSceneChanged.AddListener(sceneEventFunction);
+            sceneManager.ServerFinishedSceneChange.AddListener(sceneEventFunction);
         }
 
         public override void ExtraTearDown()
@@ -35,10 +35,10 @@ namespace Mirage.Tests.Runtime.Host
             UnityAction<string, SceneOperation> func2 = Substitute.For<UnityAction<string, SceneOperation>>();
             UnityAction<string, SceneOperation> func3 = Substitute.For<UnityAction<string, SceneOperation>>();
 
-            sceneManager.ServerSceneChanged.AddListener(func2);
-            sceneManager.ClientSceneChanged.AddListener(func3);
+            sceneManager.ServerFinishedSceneChange.AddListener(func2);
+            sceneManager.ClientFinishedSceneChange.AddListener(func3);
 
-            sceneManager.FinishLoadScene("test", SceneOperation.Normal);
+            sceneManager.CompleteLoadingScene("test", null, SceneOperation.Normal);
 
             func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
             func3.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
@@ -53,9 +53,9 @@ namespace Mirage.Tests.Runtime.Host
 
             await AsyncUtil.WaitUntilWithTimeout(() => !client.Active);
 
-            sceneManager.ServerSceneChanged.AddListener(func1);
+            sceneManager.ServerFinishedSceneChange.AddListener(func1);
 
-            sceneManager.FinishLoadScene("test", SceneOperation.Normal);
+            sceneManager.CompleteLoadingScene("test", null, SceneOperation.Normal);
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         });
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Host
             UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
             ClientMessageHandler.RegisterHandler<SceneMessage>(msg => invokeClientSceneMessage = true);
             ClientMessageHandler.RegisterHandler<NotReadyMessage>(msg => invokeNotReadyMessage = true);
-            sceneManager.ServerChangeScene.AddListener(func1);
+            sceneManager.ServerStartedSceneChange.AddListener(func1);
 
             sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity");
 
@@ -98,8 +98,8 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void ReadyTest()
         {
-            sceneManager.SetClientReady();
-            Assert.That(client.Player.IsReady);
+            sceneManager.SetSceneIsReady();
+            Assert.That(client.Player.SceneIsReady);
         }
 
         [UnityTest]
@@ -111,7 +111,7 @@ namespace Mirage.Tests.Runtime.Host
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                sceneManager.SetClientReady();
+                sceneManager.SetSceneIsReady();
             });
         });
 
@@ -119,9 +119,9 @@ namespace Mirage.Tests.Runtime.Host
         public void ClientChangeSceneTest()
         {
             UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
-            sceneManager.ClientChangeScene.AddListener(func1);
+            sceneManager.ClientStartedSceneChange.AddListener(func1);
 
-            sceneManager.OnClientChangeScene("", SceneOperation.Normal);
+            sceneManager.ClientStartedSceneChange.Invoke("", SceneOperation.Normal);
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
@@ -130,8 +130,8 @@ namespace Mirage.Tests.Runtime.Host
         public void ClientSceneChangedTest()
         {
             UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
-            sceneManager.ClientSceneChanged.AddListener(func1);
-            sceneManager.OnClientSceneChanged("test", SceneOperation.Normal);
+            sceneManager.ClientFinishedSceneChange.AddListener(func1);
+            sceneManager.ClientFinishedSceneChange.Invoke("test", SceneOperation.Normal);
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
 
@@ -139,8 +139,8 @@ namespace Mirage.Tests.Runtime.Host
         public void ClientSceneReadyAfterChangedTest()
         {
             bool _readyAfterSceneChanged = false;
-            sceneManager.ClientSceneChanged.AddListener((string name, SceneOperation operation) => _readyAfterSceneChanged = client.Player.IsReady);
-            sceneManager.OnClientSceneChanged("test", SceneOperation.Normal);
+            sceneManager.ClientFinishedSceneChange.AddListener((string name, SceneOperation operation) => _readyAfterSceneChanged = client.Player.SceneIsReady);
+            sceneManager.ClientFinishedSceneChange.Invoke("test", SceneOperation.Normal);
 
             Assert.That(_readyAfterSceneChanged, Is.True);
         }
@@ -158,25 +158,25 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void ClientChangeSceneNotNullTest()
         {
-            Assert.That(sceneManager.ClientChangeScene, Is.Not.Null);
+            Assert.That(sceneManager.ClientStartedSceneChange, Is.Not.Null);
         }
 
         [Test]
         public void ClientSceneChangedNotNullTest()
         {
-            Assert.That(sceneManager.ClientSceneChanged, Is.Not.Null);
+            Assert.That(sceneManager.ClientFinishedSceneChange, Is.Not.Null);
         }
 
         [Test]
         public void ServerChangeSceneNotNullTest()
         {
-            Assert.That(sceneManager.ServerChangeScene, Is.Not.Null);
+            Assert.That(sceneManager.ServerStartedSceneChange, Is.Not.Null);
         }
 
         [Test]
         public void ServerSceneChangedNotNullTest()
         {
-            Assert.That(sceneManager.ServerSceneChanged, Is.Not.Null);
+            Assert.That(sceneManager.ServerFinishedSceneChange, Is.Not.Null);
         }
     }
 }

--- a/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
@@ -70,7 +70,7 @@ namespace Mirage.Tests.Runtime.Host
             ClientMessageHandler.RegisterHandler<NotReadyMessage>(msg => invokeNotReadyMessage = true);
             sceneManager.ServerStartedSceneChange.AddListener(func1);
 
-            sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity");
+            sceneManager.ServerLoadSceneNormal("Assets/Mirror/Tests/Runtime/testScene.unity");
 
             await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.ActiveScenePath.Equals("Assets/Mirror/Tests/Runtime/testScene.unity"));
 
@@ -91,7 +91,7 @@ namespace Mirage.Tests.Runtime.Host
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                sceneManager.ChangeServerScene(string.Empty);
+                sceneManager.ServerLoadSceneNormal(string.Empty);
             });
         }
 
@@ -148,7 +148,7 @@ namespace Mirage.Tests.Runtime.Host
         [UnityTest]
         public IEnumerator ChangeSceneAdditiveLoadTest() => UniTask.ToCoroutine(async () =>
         {
-            sceneManager.ChangeServerScene("Assets/Mirror/Tests/Runtime/testScene.unity", SceneOperation.LoadAdditive);
+            sceneManager.ServerLoadSceneAdditively("Assets/Mirror/Tests/Runtime/testScene.unity", null);
 
             await AsyncUtil.WaitUntilWithTimeout(() => SceneManager.GetSceneByName("testScene") != null);
 

--- a/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
@@ -38,7 +38,7 @@ namespace Mirage.Tests.Runtime.Host
             sceneManager.ServerFinishedSceneChange.AddListener(func2);
             sceneManager.ClientFinishedSceneChange.AddListener(func3);
 
-            sceneManager.CompleteLoadingScene("test", null, SceneOperation.Normal);
+            sceneManager.CompleteLoadingScene("test", SceneOperation.Normal);
 
             func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
             func3.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
@@ -55,7 +55,7 @@ namespace Mirage.Tests.Runtime.Host
 
             sceneManager.ServerFinishedSceneChange.AddListener(func1);
 
-            sceneManager.CompleteLoadingScene("test", null, SceneOperation.Normal);
+            sceneManager.CompleteLoadingScene("test", SceneOperation.Normal);
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         });

--- a/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
@@ -17,13 +17,13 @@ namespace Mirage.Tests.Runtime.Host
         public void SetClientReadyAndNotReadyTest()
         {
             (_, NetworkPlayer connection) = PipedConnections(ClientMessageHandler, ServerMessageHandler);
-            Assert.That(connection.IsReady, Is.False);
+            Assert.That(connection.SceneIsReady, Is.False);
 
             serverObjectManager.SetClientReady(connection);
-            Assert.That(connection.IsReady, Is.True);
+            Assert.That(connection.SceneIsReady, Is.True);
 
             serverObjectManager.SetClientNotReady(connection);
-            Assert.That(connection.IsReady, Is.False);
+            Assert.That(connection.SceneIsReady, Is.False);
         }
 
         [Test]
@@ -31,18 +31,18 @@ namespace Mirage.Tests.Runtime.Host
         {
             // add first ready client
             (_, NetworkPlayer first) = PipedConnections(ClientMessageHandler, ServerMessageHandler);
-            first.IsReady = true;
+            first.SceneIsReady = true;
             server.Players.Add(first);
 
             // add second ready client
             (_, NetworkPlayer second) = PipedConnections(ClientMessageHandler, ServerMessageHandler);
-            second.IsReady = true;
+            second.SceneIsReady = true;
             server.Players.Add(second);
 
             // set all not ready
             serverObjectManager.SetAllClientsNotReady();
-            Assert.That(first.IsReady, Is.False);
-            Assert.That(second.IsReady, Is.False);
+            Assert.That(first.SceneIsReady, Is.False);
+            Assert.That(second.SceneIsReady, Is.False);
         }
 
 

--- a/Assets/Tests/Runtime/MessagePackerTest.cs
+++ b/Assets/Tests/Runtime/MessagePackerTest.cs
@@ -28,16 +28,16 @@ namespace Mirage.Tests.Runtime.Serialization
         {
             var message = new SceneMessage
             {
-                scenePath = "Hello world",
-                sceneOperation = SceneOperation.LoadAdditive
+                MainActivateScene = "Hello world",
+                SceneOperation = SceneOperation.LoadAdditive
             };
 
             byte[] data = MessagePacker.Pack(message);
 
             SceneMessage unpacked = MessagePacker.Unpack<SceneMessage>(data);
 
-            Assert.That(unpacked.scenePath, Is.EqualTo("Hello world"));
-            Assert.That(unpacked.sceneOperation, Is.EqualTo(SceneOperation.LoadAdditive));
+            Assert.That(unpacked.MainActivateScene, Is.EqualTo("Hello world"));
+            Assert.That(unpacked.SceneOperation, Is.EqualTo(SceneOperation.LoadAdditive));
         }
 
         [Test]
@@ -61,8 +61,8 @@ namespace Mirage.Tests.Runtime.Serialization
 
             var message = new SceneMessage
             {
-                scenePath = "Hello world",
-                sceneOperation = SceneOperation.LoadAdditive
+                MainActivateScene = "Hello world",
+                SceneOperation = SceneOperation.LoadAdditive
             };
 
             byte[] data = MessagePacker.Pack(message);
@@ -84,8 +84,8 @@ namespace Mirage.Tests.Runtime.Serialization
             // try a regular message
             var message = new SceneMessage
             {
-                scenePath = "Hello world",
-                sceneOperation = SceneOperation.LoadAdditive
+                MainActivateScene = "Hello world",
+                SceneOperation = SceneOperation.LoadAdditive
             };
 
             byte[] data = MessagePacker.Pack(message);

--- a/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
@@ -60,8 +60,8 @@ namespace Mirage.Tests.Runtime
         [Test]
         public void AddAllReadyServerConnectionsToObservers()
         {
-            player1.IsReady.Returns(true);
-            player2.IsReady.Returns(false);
+            player1.SceneIsReady.Returns(true);
+            player2.SceneIsReady.Returns(false);
 
             // add some server connections
             server.Players.Add(player1);
@@ -70,7 +70,7 @@ namespace Mirage.Tests.Runtime
             // add a host connection
             server.AddLocalConnection(client, Substitute.For<SocketLayer.IConnection>());
             server.InvokeLocalConnected();
-            server.LocalPlayer.IsReady = true;
+            server.LocalPlayer.SceneIsReady = true;
 
             // call OnStartServer so that observers dict is created
             identity.StartServer();
@@ -94,7 +94,7 @@ namespace Mirage.Tests.Runtime
 
             // add own player connection
             (NetworkPlayer serverPlayer, NetworkPlayer _) = PipedConnections(Substitute.For<IMessageReceiver>(), Substitute.For<IMessageReceiver>());
-            serverPlayer.IsReady = true;
+            serverPlayer.SceneIsReady = true;
             identity.ConnectionToClient = serverPlayer;
 
             // call OnStartServer so that observers dict is created

--- a/Assets/Tests/Runtime/NetworkMatchCheckerTest.cs
+++ b/Assets/Tests/Runtime/NetworkMatchCheckerTest.cs
@@ -71,7 +71,7 @@ namespace Mirage.Tests.Runtime
                 Identity = character.GetComponent<NetworkIdentity>()
             };
             player.Identity.ConnectionToClient = player;
-            player.IsReady = true;
+            player.SceneIsReady = true;
             return player;
         }
 


### PR DESCRIPTION
feat: Implemented new tracking list to know what players are in what scene and what scenes are loaded on server
feature: Implemented 2 new methods to allow end users to create new physic's scene directly from scene manager and load them on server and even tell player's to load them up.

Use Cases CheckList

- [x] load scene on start for server and client (onlineOffline script currently doesn't do this very well depending on order of some stuff)
- [x] addative scenes, eg load inside of building when close (server/client could both have multiple loaded
- [x] large world split into multiple scenes, (many loaded on server, 1 loaded on client)
- [x] multiple rooms (same scene) that players can change between, (many loaded on server, 1 loaded on client)
- [x] multiple matches (same scene) that players cant change between, (many loaded on server, 1 loaded on client)