### PR TITLE
feat(NetworkVisibility): adding default implementation for OnRebuildObservers

### DIFF
--- a/Assets/Mirage/Runtime/NetworkVisibility.cs
+++ b/Assets/Mirage/Runtime/NetworkVisibility.cs
@@ -23,10 +23,22 @@ namespace Mirage
         /// <summary>
         /// Callback used by the visibility system to (re)construct the set of observers that can see this object.
         /// <para>Implementations of this callback should add network connections of players that can see this object to the observers set.</para>
+        /// <para>
+        /// NOTE: override this function if you want to optimize this loop in your visibility,
+        /// for example if you need to call GetComponent on this object you can call it once at the start of the loop
+        /// </para>
         /// </summary>
         /// <param name="observers">The new set of observers for this object.</param>
         /// <param name="initialize">True if the set of observers is being built for the first time.</param>
-        public abstract void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize);
-
+        public virtual void OnRebuildObservers(HashSet<INetworkPlayer> observers, bool initialize)
+        {
+            foreach (INetworkPlayer player in Server.Players)
+            {
+                if (OnCheckObserver(player))
+                {
+                    observers.Add(player);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
simplifies create a new NetworkVisibility because only `OnCheckObserver` will need to be overriden