### PR TITLE
refactor: move localplayer out of networkserver and into network world

### DIFF
--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -39,11 +39,6 @@ namespace Mirage
         IAddLateEvent OnStopHost { get; }
 
         /// <summary>
-        /// The connection to the host mode client (if any).
-        /// </summary>
-        INetworkPlayer LocalPlayer { get; }
-
-        /// <summary>
         /// The host client for this server 
         /// </summary> 
         INetworkClient LocalClient { get; }

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -1014,9 +1014,9 @@ namespace Mirage
             }
 
             // add local host connection (if any)
-            if (Server.LocalPlayer != null && Server.LocalPlayer.IsReady)
+            if (World != null && World.LocalPlayer != null && World.LocalPlayer.IsReady)
             {
-                AddObserver(Server.LocalPlayer);
+                AddObserver(World.LocalPlayer);
             }
         }
 
@@ -1290,7 +1290,7 @@ namespace Mirage
             connectionsExcludeSelf.Clear();
             foreach (INetworkPlayer player in observers)
             {
-                if (player == Server.LocalPlayer)
+                if (player == World.LocalPlayer)
                     continue;
 
                 if (includeOwner || ConnectionToClient != player)

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -99,14 +99,6 @@ namespace Mirage
         public IAddLateEvent OnStopHost => _onStopHost;
 
         /// <summary>
-        /// The connection to the host mode client (if any).
-        /// </summary>
-        // original HLAPI has .localConnections list with only m_LocalConnection in it
-        // (for backwards compatibility because they removed the real localConnections list a while ago)
-        // => removed it for easier code. use .localConnection now!
-        public INetworkPlayer LocalPlayer { get; private set; }
-
-        /// <summary>
         /// The host client for this server 
         /// </summary>
         public INetworkClient LocalClient { get; private set; }
@@ -167,7 +159,7 @@ namespace Mirage
             // just clear list, connections will be disconnected when peer is closed
             Players.Clear();
             connections.Clear();
-            LocalPlayer = null;
+            World.LocalPlayer = null;
 
             Cleanup();
 
@@ -361,13 +353,13 @@ namespace Mirage
         /// </summary>
         internal void AddLocalConnection(INetworkClient client, IConnection connection)
         {
-            if (LocalPlayer != null)
+            if (World.LocalPlayer != null)
             {
                 throw new InvalidOperationException("Local Connection already exists");
             }
 
             var player = new NetworkPlayer(connection);
-            LocalPlayer = player;
+            World.LocalPlayer = player;
             LocalClient = client;
 
             if (logger.LogEnabled()) logger.Log("Server accepted Local client:" + player);
@@ -382,11 +374,11 @@ namespace Mirage
         /// </summary>
         internal void InvokeLocalConnected()
         {
-            if (LocalPlayer == null)
+            if (World.LocalPlayer == null)
             {
                 throw new InvalidOperationException("Local Connection does not exist");
             }
-            Connected?.Invoke(LocalPlayer);
+            Connected?.Invoke(World.LocalPlayer);
         }
 
         /// <summary>
@@ -459,7 +451,7 @@ namespace Mirage
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + player);
 
             //Only allow host client to connect when not Listening for new connections
-            if (!Listening && player != LocalPlayer)
+            if (!Listening && player != World.LocalPlayer)
             {
                 return;
             }
@@ -498,8 +490,8 @@ namespace Mirage
             player.DestroyOwnedObjects();
             player.Identity = null;
 
-            if (player == LocalPlayer)
-                LocalPlayer = null;
+            if (player == World.LocalPlayer)
+                World.LocalPlayer = null;
         }
 
         internal void OnAuthenticated(INetworkPlayer player)

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -353,7 +353,7 @@ namespace Mirage
         /// </summary>
         internal void AddLocalConnection(INetworkClient client, IConnection connection)
         {
-            if (World.LocalPlayer != null)
+            if (World == null || World.LocalPlayer != null)
             {
                 throw new InvalidOperationException("Local Connection already exists");
             }
@@ -374,7 +374,7 @@ namespace Mirage
         /// </summary>
         internal void InvokeLocalConnected()
         {
-            if (World.LocalPlayer == null)
+            if (World == null || World.LocalPlayer == null)
             {
                 throw new InvalidOperationException("Local Connection does not exist");
             }

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -19,6 +19,14 @@ namespace Mirage
         /// </summary>
         public event Action<NetworkIdentity> onUnspawn;
 
+        /// <summary>
+        /// The connection to the host mode client (if any).
+        /// </summary>
+        // original HLAPI has .localConnections list with only m_LocalConnection in it
+        // (for backwards compatibility because they removed the real localConnections list a while ago)
+        // => removed it for easier code. use .localConnection now!
+        public NetworkPlayer LocalPlayer;
+
         private readonly Dictionary<uint, NetworkIdentity> SpawnedObjects = new Dictionary<uint, NetworkIdentity>();
 
         public IReadOnlyCollection<NetworkIdentity> SpawnedIdentities => SpawnedObjects.Values;

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -22,9 +22,6 @@ namespace Mirage
         /// <summary>
         /// The connection to the host mode client (if any).
         /// </summary>
-        // original HLAPI has .localConnections list with only m_LocalConnection in it
-        // (for backwards compatibility because they removed the real localConnections list a while ago)
-        // => removed it for easier code. use .localConnection now!
         public NetworkPlayer LocalPlayer;
 
         private readonly Dictionary<uint, NetworkIdentity> SpawnedObjects = new Dictionary<uint, NetworkIdentity>();

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -46,8 +46,6 @@ namespace Mirage
         [FormerlySerializedAs("networkSceneManager")]
         public NetworkSceneManager NetworkSceneManager;
 
-        public NetworkWorld World;
-
         uint nextNetworkId = 1;
         uint GetNextNetworkId() => checked(nextNetworkId++);
 
@@ -197,7 +195,7 @@ namespace Mirage
             identity.SetClientOwner(player);
 
             // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
-            if (player == World.LocalPlayer)
+            if (player == Server.World.LocalPlayer)
             {
                 identity.HasAuthority = true;
                 Server.LocalClient.Player.Identity = identity;
@@ -299,7 +297,7 @@ namespace Mirage
             identity.SetClientOwner(player);
 
             // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
-            if (player == World.LocalPlayer)
+            if (player == Server.World.LocalPlayer)
             {
                 identity.HasAuthority = true;
                 Server.LocalClient.Player.Identity = identity;
@@ -467,7 +465,7 @@ namespace Mirage
 
             // special case to make sure hasAuthority is set
             // on start server in host mode
-            if (owner == World.LocalPlayer)
+            if (owner == Server.World.LocalPlayer)
                 identity.HasAuthority = true;
 
             if (identity.NetId == 0)

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -46,6 +46,8 @@ namespace Mirage
         [FormerlySerializedAs("networkSceneManager")]
         public NetworkSceneManager NetworkSceneManager;
 
+        public NetworkWorld World;
+
         uint nextNetworkId = 1;
         uint GetNextNetworkId() => checked(nextNetworkId++);
 
@@ -195,7 +197,7 @@ namespace Mirage
             identity.SetClientOwner(player);
 
             // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
-            if (player == Server.LocalPlayer)
+            if (player == World.LocalPlayer)
             {
                 identity.HasAuthority = true;
                 Server.LocalClient.Player.Identity = identity;
@@ -297,7 +299,7 @@ namespace Mirage
             identity.SetClientOwner(player);
 
             // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
-            if (player == Server.LocalPlayer)
+            if (player == World.LocalPlayer)
             {
                 identity.HasAuthority = true;
                 Server.LocalClient.Player.Identity = identity;
@@ -465,7 +467,7 @@ namespace Mirage
 
             // special case to make sure hasAuthority is set
             // on start server in host mode
-            if (owner == Server.LocalPlayer)
+            if (owner == World.LocalPlayer)
                 identity.HasAuthority = true;
 
             if (identity.NetId == 0)

--- a/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/PhysicsCollision.cs
+++ b/Assets/Mirage/Samples~/MultipleAdditiveScenes/Scripts/PhysicsCollision.cs
@@ -34,7 +34,7 @@ namespace Mirage.Examples.MultipleAdditiveScenes
                 direction = direction.normalized;
 
                 // push this away from player...a bit less force for host player
-                if (other.gameObject.GetComponent<NetworkIdentity>().ConnectionToClient == Server.LocalPlayer)
+                if (other.gameObject.GetComponent<NetworkIdentity>().ConnectionToClient == World.LocalPlayer)
                     rigidbody3D.AddForce(direction * force * .5f);
                 else
                     rigidbody3D.AddForce(direction * force);

--- a/Assets/Tests/Runtime/Host/ClientObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ClientObjectManagerTest.cs
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Host
             replacementIdentity.AssetId = Guid.NewGuid();
             clientObjectManager.RegisterPrefab(replacementIdentity);
 
-            serverObjectManager.ReplaceCharacter(server.LocalPlayer, playerReplacement, true);
+            serverObjectManager.ReplaceCharacter(world.LocalPlayer, playerReplacement, true);
 
             Assert.That(server.LocalClient.Player.Identity, Is.EqualTo(replacementIdentity));
         }

--- a/Assets/Tests/Runtime/Host/ClientObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ClientObjectManagerTest.cs
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Host
             replacementIdentity.AssetId = Guid.NewGuid();
             clientObjectManager.RegisterPrefab(replacementIdentity);
 
-            serverObjectManager.ReplaceCharacter(world.LocalPlayer, playerReplacement, true);
+            serverObjectManager.ReplaceCharacter(server.World.LocalPlayer, playerReplacement, true);
 
             Assert.That(server.LocalClient.Player.Identity, Is.EqualTo(replacementIdentity));
         }

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -44,7 +44,7 @@ namespace Mirage.Tests.Runtime.Host
         [UnityTest]
         public IEnumerator ClientConnRpc() => UniTask.ToCoroutine(async () =>
         {
-            component.ClientConnRpcTest(manager.Server.LocalPlayer, 1, "hello");
+            component.ClientConnRpcTest(world.LocalPlayer, 1, "hello");
             // process spawn message from server
             await AsyncUtil.WaitUntilWithTimeout(() => component.targetRpcArg1 != 0);
 
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Host
             // state cleared?
             Assert.That(server.Players, Is.Empty);
             Assert.That(server.Active, Is.False);
-            Assert.That(server.LocalPlayer, Is.Null);
+            Assert.That(world.LocalPlayer, Is.Null);
             Assert.That(server.LocalClientActive, Is.False);
         }
 

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -44,7 +44,7 @@ namespace Mirage.Tests.Runtime.Host
         [UnityTest]
         public IEnumerator ClientConnRpc() => UniTask.ToCoroutine(async () =>
         {
-            component.ClientConnRpcTest(world.LocalPlayer, 1, "hello");
+            component.ClientConnRpcTest(server.World.LocalPlayer, 1, "hello");
             // process spawn message from server
             await AsyncUtil.WaitUntilWithTimeout(() => component.targetRpcArg1 != 0);
 
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Host
             // state cleared?
             Assert.That(server.Players, Is.Empty);
             Assert.That(server.Active, Is.False);
-            Assert.That(world.LocalPlayer, Is.Null);
+            Assert.That(server.World.LocalPlayer, Is.Null);
             Assert.That(server.LocalClientActive, Is.False);
         }
 

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Host
             // state cleared?
             Assert.That(server.Players, Is.Empty);
             Assert.That(server.Active, Is.False);
-            Assert.That(server.World.LocalPlayer, Is.Null);
+            Assert.That(server.World == null);
             Assert.That(server.LocalClientActive, Is.False);
         }
 

--- a/Assets/Tests/Runtime/Host/HostSetup.cs
+++ b/Assets/Tests/Runtime/Host/HostSetup.cs
@@ -18,7 +18,6 @@ namespace Mirage.Tests.Runtime.Host
         protected NetworkSceneManager sceneManager;
         protected ServerObjectManager serverObjectManager;
         protected ClientObjectManager clientObjectManager;
-        protected NetworkWorld world;
 
         protected GameObject playerGO;
         protected NetworkIdentity identity;
@@ -50,8 +49,6 @@ namespace Mirage.Tests.Runtime.Host
             server = manager.Server;
             client = manager.Client;
 
-            world = new NetworkWorld();
-
             if (ServerConfig != null) server.PeerConfig = ServerConfig;
             if (ClientConfig != null) client.PeerConfig = ClientConfig;
 
@@ -75,7 +72,7 @@ namespace Mirage.Tests.Runtime.Host
                 identity = playerGO.AddComponent<NetworkIdentity>();
                 component = playerGO.AddComponent<T>();
 
-                serverObjectManager.AddCharacter(world.LocalPlayer, playerGO);
+                serverObjectManager.AddCharacter(server.World.LocalPlayer, playerGO);
 
                 // wait for client to spawn it
                 await AsyncUtil.WaitUntilWithTimeout(() => client.Player.Identity != null);

--- a/Assets/Tests/Runtime/Host/HostSetup.cs
+++ b/Assets/Tests/Runtime/Host/HostSetup.cs
@@ -18,6 +18,7 @@ namespace Mirage.Tests.Runtime.Host
         protected NetworkSceneManager sceneManager;
         protected ServerObjectManager serverObjectManager;
         protected ClientObjectManager clientObjectManager;
+        protected NetworkWorld world;
 
         protected GameObject playerGO;
         protected NetworkIdentity identity;
@@ -49,6 +50,8 @@ namespace Mirage.Tests.Runtime.Host
             server = manager.Server;
             client = manager.Client;
 
+            world = new NetworkWorld();
+
             if (ServerConfig != null) server.PeerConfig = ServerConfig;
             if (ClientConfig != null) client.PeerConfig = ClientConfig;
 
@@ -72,7 +75,7 @@ namespace Mirage.Tests.Runtime.Host
                 identity = playerGO.AddComponent<NetworkIdentity>();
                 component = playerGO.AddComponent<T>();
 
-                serverObjectManager.AddCharacter(server.LocalPlayer, playerGO);
+                serverObjectManager.AddCharacter(world.LocalPlayer, playerGO);
 
                 // wait for client to spawn it
                 await AsyncUtil.WaitUntilWithTimeout(() => client.Player.Identity != null);

--- a/Assets/Tests/Runtime/Host/LobbyReadyTest.cs
+++ b/Assets/Tests/Runtime/Host/LobbyReadyTest.cs
@@ -84,7 +84,7 @@ namespace Mirage.Tests.Runtime.Host
             readyPlayer.AddComponent<NetworkIdentity>();
             readyComp = readyPlayer.AddComponent<ObjectReady>();
 
-            serverObjectManager.Spawn(readyPlayer, world.LocalPlayer);
+            serverObjectManager.Spawn(readyPlayer, server.World.LocalPlayer);
             readyComp.Ready();
 
             await AsyncUtil.WaitUntilWithTimeout(() => readyComp.IsReady);

--- a/Assets/Tests/Runtime/Host/LobbyReadyTest.cs
+++ b/Assets/Tests/Runtime/Host/LobbyReadyTest.cs
@@ -84,7 +84,7 @@ namespace Mirage.Tests.Runtime.Host
             readyPlayer.AddComponent<NetworkIdentity>();
             readyComp = readyPlayer.AddComponent<ObjectReady>();
 
-            serverObjectManager.Spawn(readyPlayer, server.LocalPlayer);
+            serverObjectManager.Spawn(readyPlayer, world.LocalPlayer);
             readyComp.Ready();
 
             await AsyncUtil.WaitUntilWithTimeout(() => readyComp.IsReady);

--- a/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
@@ -36,7 +36,7 @@ namespace Mirage.Tests.Runtime.Host
         {
             Assert.Throws<InvalidOperationException>(() =>
             {
-                testIdentity.AssignClientAuthority(world.LocalPlayer);
+                testIdentity.AssignClientAuthority(server.World.LocalPlayer);
             });
         }
 
@@ -89,7 +89,7 @@ namespace Mirage.Tests.Runtime.Host
             NetworkIdentity.clientAuthorityCallback += Callback;
 
             // assign authority
-            testIdentity.AssignClientAuthority(world.LocalPlayer);
+            testIdentity.AssignClientAuthority(server.World.LocalPlayer);
 
             Assert.That(callbackCalled, Is.EqualTo(1));
 
@@ -109,23 +109,23 @@ namespace Mirage.Tests.Runtime.Host
         {
             // create a networkidentity with our test component
             serverObjectManager.Spawn(gameObject);
-            testIdentity.AssignClientAuthority(world.LocalPlayer);
+            testIdentity.AssignClientAuthority(server.World.LocalPlayer);
 
-            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(world.LocalPlayer));
+            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(server.World.LocalPlayer));
         }
 
         [Test]
         public void SpawnWithAuthority()
         {
-            serverObjectManager.Spawn(gameObject, world.LocalPlayer);
-            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(world.LocalPlayer));
+            serverObjectManager.Spawn(gameObject, server.World.LocalPlayer);
+            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(server.World.LocalPlayer));
         }
 
         [Test]
         public void SpawnWithAssetId()
         {
             var replacementGuid = Guid.NewGuid();
-            serverObjectManager.Spawn(gameObject, replacementGuid, world.LocalPlayer);
+            serverObjectManager.Spawn(gameObject, replacementGuid, server.World.LocalPlayer);
             Assert.That(testIdentity.AssetId, Is.EqualTo(replacementGuid));
         }
 
@@ -135,7 +135,7 @@ namespace Mirage.Tests.Runtime.Host
             // create a networkidentity with our test component
             serverObjectManager.Spawn(gameObject);
             // assign authority
-            testIdentity.AssignClientAuthority(world.LocalPlayer);
+            testIdentity.AssignClientAuthority(server.World.LocalPlayer);
 
             // shouldn't be able to assign authority while already owned by
             // another connection
@@ -172,7 +172,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void RemoveClientAuthorityOfOwner()
         {
-            serverObjectManager.ReplaceCharacter(world.LocalPlayer, gameObject);
+            serverObjectManager.ReplaceCharacter(server.World.LocalPlayer, gameObject);
 
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -184,7 +184,7 @@ namespace Mirage.Tests.Runtime.Host
         public void RemoveClientAuthority()
         {
             serverObjectManager.Spawn(gameObject);
-            testIdentity.AssignClientAuthority(world.LocalPlayer);
+            testIdentity.AssignClientAuthority(server.World.LocalPlayer);
             testIdentity.RemoveClientAuthority();
             Assert.That(testIdentity.ConnectionToClient, Is.Null);
         }
@@ -222,10 +222,10 @@ namespace Mirage.Tests.Runtime.Host
             var testObj2 = new GameObject();
             var testObj3 = new GameObject();
 
-            world.LocalPlayer.AddOwnedObject(testObj1.AddComponent<NetworkIdentity>());
-            world.LocalPlayer.AddOwnedObject(testObj2.AddComponent<NetworkIdentity>());
-            world.LocalPlayer.AddOwnedObject(testObj3.AddComponent<NetworkIdentity>());
-            world.LocalPlayer.DestroyOwnedObjects();
+            server.World.LocalPlayer.AddOwnedObject(testObj1.AddComponent<NetworkIdentity>());
+            server.World.LocalPlayer.AddOwnedObject(testObj2.AddComponent<NetworkIdentity>());
+            server.World.LocalPlayer.AddOwnedObject(testObj3.AddComponent<NetworkIdentity>());
+            server.World.LocalPlayer.DestroyOwnedObjects();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !testObj1);
             await AsyncUtil.WaitUntilWithTimeout(() => !testObj2);

--- a/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
@@ -36,7 +36,7 @@ namespace Mirage.Tests.Runtime.Host
         {
             Assert.Throws<InvalidOperationException>(() =>
             {
-                testIdentity.AssignClientAuthority(server.LocalPlayer);
+                testIdentity.AssignClientAuthority(world.LocalPlayer);
             });
         }
 
@@ -89,7 +89,7 @@ namespace Mirage.Tests.Runtime.Host
             NetworkIdentity.clientAuthorityCallback += Callback;
 
             // assign authority
-            testIdentity.AssignClientAuthority(server.LocalPlayer);
+            testIdentity.AssignClientAuthority(world.LocalPlayer);
 
             Assert.That(callbackCalled, Is.EqualTo(1));
 
@@ -109,23 +109,23 @@ namespace Mirage.Tests.Runtime.Host
         {
             // create a networkidentity with our test component
             serverObjectManager.Spawn(gameObject);
-            testIdentity.AssignClientAuthority(server.LocalPlayer);
+            testIdentity.AssignClientAuthority(world.LocalPlayer);
 
-            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(server.LocalPlayer));
+            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(world.LocalPlayer));
         }
 
         [Test]
         public void SpawnWithAuthority()
         {
-            serverObjectManager.Spawn(gameObject, server.LocalPlayer);
-            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(server.LocalPlayer));
+            serverObjectManager.Spawn(gameObject, world.LocalPlayer);
+            Assert.That(testIdentity.ConnectionToClient, Is.SameAs(world.LocalPlayer));
         }
 
         [Test]
         public void SpawnWithAssetId()
         {
             var replacementGuid = Guid.NewGuid();
-            serverObjectManager.Spawn(gameObject, replacementGuid, server.LocalPlayer);
+            serverObjectManager.Spawn(gameObject, replacementGuid, world.LocalPlayer);
             Assert.That(testIdentity.AssetId, Is.EqualTo(replacementGuid));
         }
 
@@ -135,7 +135,7 @@ namespace Mirage.Tests.Runtime.Host
             // create a networkidentity with our test component
             serverObjectManager.Spawn(gameObject);
             // assign authority
-            testIdentity.AssignClientAuthority(server.LocalPlayer);
+            testIdentity.AssignClientAuthority(world.LocalPlayer);
 
             // shouldn't be able to assign authority while already owned by
             // another connection
@@ -172,7 +172,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void RemoveClientAuthorityOfOwner()
         {
-            serverObjectManager.ReplaceCharacter(server.LocalPlayer, gameObject);
+            serverObjectManager.ReplaceCharacter(world.LocalPlayer, gameObject);
 
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -184,7 +184,7 @@ namespace Mirage.Tests.Runtime.Host
         public void RemoveClientAuthority()
         {
             serverObjectManager.Spawn(gameObject);
-            testIdentity.AssignClientAuthority(server.LocalPlayer);
+            testIdentity.AssignClientAuthority(world.LocalPlayer);
             testIdentity.RemoveClientAuthority();
             Assert.That(testIdentity.ConnectionToClient, Is.Null);
         }
@@ -222,10 +222,10 @@ namespace Mirage.Tests.Runtime.Host
             var testObj2 = new GameObject();
             var testObj3 = new GameObject();
 
-            server.LocalPlayer.AddOwnedObject(testObj1.AddComponent<NetworkIdentity>());
-            server.LocalPlayer.AddOwnedObject(testObj2.AddComponent<NetworkIdentity>());
-            server.LocalPlayer.AddOwnedObject(testObj3.AddComponent<NetworkIdentity>());
-            server.LocalPlayer.DestroyOwnedObjects();
+            world.LocalPlayer.AddOwnedObject(testObj1.AddComponent<NetworkIdentity>());
+            world.LocalPlayer.AddOwnedObject(testObj2.AddComponent<NetworkIdentity>());
+            world.LocalPlayer.AddOwnedObject(testObj3.AddComponent<NetworkIdentity>());
+            world.LocalPlayer.DestroyOwnedObjects();
 
             await AsyncUtil.WaitUntilWithTimeout(() => !testObj1);
             await AsyncUtil.WaitUntilWithTimeout(() => !testObj2);

--- a/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
@@ -25,6 +25,7 @@ namespace Mirage.Tests.Runtime
         private ServerObjectManager serverObjectManager;
         private NetworkClient client;
         private GameObject networkServerGameObject;
+        private NetworkWorld world;
 
         INetworkPlayer player1;
         INetworkPlayer player2;
@@ -37,6 +38,7 @@ namespace Mirage.Tests.Runtime
             serverObjectManager = networkServerGameObject.AddComponent<ServerObjectManager>();
             serverObjectManager.Server = server;
             client = networkServerGameObject.AddComponent<NetworkClient>();
+            world = new NetworkWorld();
 
             gameObject = new GameObject();
             identity = gameObject.AddComponent<NetworkIdentity>();
@@ -70,14 +72,14 @@ namespace Mirage.Tests.Runtime
             // add a host connection
             server.AddLocalConnection(client, Substitute.For<SocketLayer.IConnection>());
             server.InvokeLocalConnected();
-            server.LocalPlayer.IsReady = true;
+            world.LocalPlayer.IsReady = true;
 
             // call OnStartServer so that observers dict is created
             identity.StartServer();
 
             // add all to observers. should have the two ready connections then.
             identity.AddAllReadyServerConnectionsToObservers();
-            Assert.That(identity.observers, Is.EquivalentTo(new[] { player1, server.LocalPlayer }));
+            Assert.That(identity.observers, Is.EquivalentTo(new[] { player1, world.LocalPlayer }));
 
             // clean up
             server.Stop();


### PR DESCRIPTION
BREAKING!

It just feels like the LocalPlayer should not be at the same layer as the NetworkServer as it could have multiple worlds running. Any one of (or multiple?) could have local players.

companion to #900