### PR TITLE
test: use existing fixtures

### DIFF
--- a/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Runtime/NetworkIdentityCallbackTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Mirage.Tests.Runtime.ClientServer;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -7,7 +8,7 @@ using Object = UnityEngine.Object;
 
 namespace Mirage.Tests.Runtime
 {
-    public class NetworkIdentityCallbackTests
+    public class NetworkIdentityCallbackTests : ClientServerSetup<MockComponent>
     {
         #region test components
         class RebuildEmptyObserversNetworkBehaviour : NetworkVisibility
@@ -21,23 +22,13 @@ namespace Mirage.Tests.Runtime
 
         GameObject gameObject;
         NetworkIdentity identity;
-        private NetworkServer server;
-        private ServerObjectManager serverObjectManager;
-        private NetworkClient client;
-        private GameObject networkServerGameObject;
 
         INetworkPlayer player1;
         INetworkPlayer player2;
 
         [SetUp]
-        public void SetUp()
+        public override void ExtraSetup()
         {
-            networkServerGameObject = new GameObject();
-            server = networkServerGameObject.AddComponent<NetworkServer>();
-            serverObjectManager = networkServerGameObject.AddComponent<ServerObjectManager>();
-            serverObjectManager.Server = server;
-            client = networkServerGameObject.AddComponent<NetworkClient>();
-
             gameObject = new GameObject();
             identity = gameObject.AddComponent<NetworkIdentity>();
             identity.Server = server;
@@ -48,12 +39,11 @@ namespace Mirage.Tests.Runtime
         }
 
         [TearDown]
-        public void TearDown()
+        public override void ExtraTearDown()
         {
             // set isServer is false. otherwise Destroy instead of
             // DestroyImmediate is called internally, giving an error in Editor
             Object.DestroyImmediate(gameObject);
-            Object.DestroyImmediate(networkServerGameObject);
         }
 
 
@@ -77,7 +67,7 @@ namespace Mirage.Tests.Runtime
 
             // add all to observers. should have the two ready connections then.
             identity.AddAllReadyServerConnectionsToObservers();
-            Assert.That(identity.observers, Is.EquivalentTo(new[] { player1, server.LocalPlayer }));
+            Assert.That(identity.observers, Is.EquivalentTo(new[] { player1, server.LocalPlayer, serverPlayer }));
 
             // clean up
             server.Stop();


### PR DESCRIPTION
this makes the code easier to maintain.