### PR TITLE
I think mirror is written in place of mirage

### DIFF
--- a/doc/Articles/Guides/FAQ.md
+++ b/doc/Articles/Guides/FAQ.md
@@ -9,7 +9,7 @@
   
   Mirage can automatically create Serialization functions for many custom data types when your scripts are compiled.
 
-  For example, mirror will automatically create a functions for `MyCustomStruct` so that it can be sent without any extra work.
+  For example, Mirage will automatically create a functions for `MyCustomStruct` so that it can be sent without any extra work.
   ```cs
   [ClientRpc]
   public void RpcDoSomething(MyCustomStruct data)


### PR DESCRIPTION
Afaik mirror don't support custom types and we need to create custom writers and readers in it.