### PR TITLE
refactor: move networktime to world

### DIFF
--- a/Assets/Mirage/Components/NetworkPingDisplay.cs
+++ b/Assets/Mirage/Components/NetworkPingDisplay.cs
@@ -16,7 +16,7 @@ namespace Mirage
 
         void Update()
         {
-            NetworkPingLabelText.text = string.Format("{0}ms", (int)(Client.Time.Rtt * 1000));
+            NetworkPingLabelText.text = string.Format("{0}ms", (int)(Client.World.Time.Rtt * 1000));
         }
     }
 }

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -38,8 +38,6 @@ namespace Mirage
 
         NetworkWorld World { get; }
 
-        NetworkTime Time { get; }
-
         void Disconnect();
     }
 }

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -59,8 +59,6 @@ namespace Mirage
         /// </summary>
         bool Active { get; }
 
-        NetworkTime Time { get; }
-
         NetworkWorld World { get; }
 
         SyncVarSender SyncVarSender { get; }

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -119,7 +119,7 @@ namespace Mirage
         /// <summary>
         /// Returns the appropriate NetworkTime instance based on if this NetworkBehaviour is running as a Server or Client.
         /// </summary>
-        public NetworkTime NetworkTime => IsClient ? Client.Time : Server.Time;
+        public NetworkTime NetworkTime => World.Time;
 
         protected internal ulong SyncVarDirtyBits { get; private set; }
         ulong syncVarHookGuard;

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -87,11 +87,6 @@ namespace Mirage
         /// </summary>
         public bool IsConnected => connectState == ConnectState.Connected;
 
-        /// <summary>
-        /// Time kept in this client
-        /// </summary>
-        public NetworkTime Time { get; } = new NetworkTime();
-
         public NetworkWorld World { get; private set; }
         public MessageHandler MessageHandler { get; private set; }
 
@@ -137,7 +132,7 @@ namespace Mirage
             // setup all the handlers
             Player = new NetworkPlayer(connection);
             dataHandler.SetConnection(connection, Player);
-            Time.Reset();
+            World.Time.Reset();
 
             RegisterMessageHandlers();
             InitializeAuthEvents();
@@ -160,7 +155,7 @@ namespace Mirage
 
         private void Peer_OnConnected(IConnection conn)
         {
-            Time.UpdateClient(this);
+            World.Time.UpdateClient(this);
             connectState = ConnectState.Connected;
             _connected.Invoke(Player);
         }
@@ -282,7 +277,7 @@ namespace Mirage
             if (!IsLocalClient && Active && connectState == ConnectState.Connected)
             {
                 // only update things while connected
-                Time.UpdateClient(this);
+                World.Time.UpdateClient(this);
             }
             peer?.Update();
         }
@@ -294,7 +289,7 @@ namespace Mirage
 
         internal void RegisterMessageHandlers()
         {
-            MessageHandler.RegisterHandler<NetworkPongMessage>(Time.OnClientPong);
+            MessageHandler.RegisterHandler<NetworkPongMessage>(World.Time.OnClientPong);
         }
 
 

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -132,7 +132,6 @@ namespace Mirage
             // setup all the handlers
             Player = new NetworkPlayer(connection);
             dataHandler.SetConnection(connection, Player);
-            World.Time.Reset();
 
             RegisterMessageHandlers();
             InitializeAuthEvents();
@@ -204,7 +203,6 @@ namespace Mirage
             // invoke started event after everything is set up, but before peer has connected
             _started.Invoke();
 
-
             // we need add server connection to server's dictionary first
             // then invoke connected event on client (client has to connect first or it will miss message in NetworkScenemanager)
             // then invoke connected event on server
@@ -229,7 +227,6 @@ namespace Mirage
                 Connected.AddListener(OnAuthenticated);
             }
         }
-
 
         internal void OnAuthenticated(INetworkPlayer player)
         {
@@ -292,7 +289,6 @@ namespace Mirage
             MessageHandler.RegisterHandler<NetworkPongMessage>(World.Time.OnClientPong);
         }
 
-
         /// <summary>
         /// Shut down a client.
         /// <para>This should be done when a client is no longer going to be used.</para>
@@ -331,7 +327,6 @@ namespace Mirage
                 peer = null;
             }
         }
-
 
         internal class DataHandler : IDataHandler
         {

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -136,11 +136,6 @@ namespace Mirage
         /// </summary>
         public bool Active { get; private set; }
 
-        /// <summary>
-        /// Time kept in this server
-        /// </summary>
-        public NetworkTime Time { get; } = new NetworkTime();
-
         public NetworkWorld World { get; private set; }
         public SyncVarSender SyncVarSender { get; private set; }
         public MessageHandler MessageHandler { get; private set; }
@@ -198,7 +193,7 @@ namespace Mirage
 
             LocalClient = localClient;
             MessageHandler = new MessageHandler(DisconnectOnException);
-            MessageHandler.RegisterHandler<NetworkPingMessage>(Time.OnServerPing);
+            MessageHandler.RegisterHandler<NetworkPingMessage>(World.Time.OnServerPing);
 
             ISocket socket = SocketFactory.CreateServerSocket();
             var dataHandler = new DataHandler(MessageHandler, connections);

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -19,6 +19,11 @@ namespace Mirage
         /// </summary>
         public event Action<NetworkIdentity> onUnspawn;
 
+        /// <summary>
+        /// Time kept in this world
+        /// </summary>
+        public NetworkTime Time { get; } = new NetworkTime();
+
         private readonly Dictionary<uint, NetworkIdentity> SpawnedObjects = new Dictionary<uint, NetworkIdentity>();
 
         public IReadOnlyCollection<NetworkIdentity> SpawnedIdentities => SpawnedObjects.Values;

--- a/Assets/Mirage/Runtime/NetworkWorld.cs
+++ b/Assets/Mirage/Runtime/NetworkWorld.cs
@@ -66,7 +66,6 @@ namespace Mirage
                 onUnspawn?.Invoke(identity);
         }
 
-
         internal void ClearSpawnedObjects()
         {
             SpawnedObjects.Clear();

--- a/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
@@ -100,13 +100,6 @@ namespace Mirage.Tests.Runtime.Host
         }
 
         [Test]
-        public void TimeTest()
-        {
-            SampleBehavior behaviour1 = playerGO.AddComponent<SampleBehavior>();
-            Assert.That(behaviour1.NetworkTime, Is.EqualTo(client.World.Time));
-        }
-
-        [Test]
         public void HasIdentitysOwner()
         {
             (_, identity.Owner) = PipedConnections(ClientMessageHandler, ServerMessageHandler);

--- a/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkBehaviourTests.cs
@@ -103,7 +103,7 @@ namespace Mirage.Tests.Runtime.Host
         public void TimeTest()
         {
             SampleBehavior behaviour1 = playerGO.AddComponent<SampleBehavior>();
-            Assert.That(behaviour1.NetworkTime, Is.EqualTo(client.Time));
+            Assert.That(behaviour1.NetworkTime, Is.EqualTo(client.World.Time));
         }
 
         [Test]

--- a/Assets/Tests/Runtime/Host/NetworkClientTest.cs
+++ b/Assets/Tests/Runtime/Host/NetworkClientTest.cs
@@ -74,7 +74,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void TimeNotNullTest()
         {
-            Assert.That(client.Time, Is.Not.Null);
+            Assert.That(client.World.Time, Is.Not.Null);
         }
     }
 }

--- a/Assets/Tests/Runtime/Host/NetworkServerTest.cs
+++ b/Assets/Tests/Runtime/Host/NetworkServerTest.cs
@@ -95,7 +95,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void TimeNotNullTest()
         {
-            Assert.That(server.Time, Is.Not.Null);
+            Assert.That(server.World.Time, Is.Not.Null);
         }
     }
 }


### PR DESCRIPTION
still works in host situations. another steps towards allowing multiple worlds per client/server.