### PR TITLE
feat(Peer): adding send buffer limit

### DIFF
--- a/Assets/Mirage/Runtime/SocketLayer/AckSystem.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/AckSystem.cs
@@ -42,7 +42,6 @@ namespace Mirage.SocketLayer
         readonly Pool<ReliablePacket> reliablePool;
         readonly Metrics metrics;
 
-        //todo implement this
         readonly int maxPacketsInSendBufferPerConnection;
         readonly int maxPacketSize;
         readonly float ackTimeout;
@@ -287,7 +286,6 @@ namespace Mirage.SocketLayer
                 throw new InvalidOperationException("Sent queue is full");
             }
 
-
             if (length + MIN_RELIABLE_HEADER_SIZE > maxPacketSize)
             {
                 if (allowFragmented)
@@ -388,6 +386,11 @@ namespace Mirage.SocketLayer
 
         void SendReliablePacket(ReliablePacket reliable)
         {
+            if (sentAckablePackets.Count > maxPacketsInSendBufferPerConnection)
+            {
+                throw new InvalidOperationException($"Max packets in send buffer reached for {connection}");
+            }
+
             ushort sequence = (ushort)sentAckablePackets.Enqueue(new AckablePacket(reliable));
 
             byte[] final = reliable.buffer.array;

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_BufferSize.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_BufferSize.cs
@@ -1,0 +1,71 @@
+using System;
+using NUnit.Framework;
+
+namespace Mirage.SocketLayer.Tests.AckSystemTests
+{
+    [Category("SocketLayer")]
+    public class AckSystemTest_BufferSize : AckSystemTestBase
+    {
+        [Test]
+        public void ThrowsIfTooManyMessageAreSent()
+        {
+            var time = new Time();
+            var config = new Config
+            {
+                MaxReliablePacketsInSendBufferPerConnection = 50,
+                SequenceSize = 8
+            };
+            var instance = new AckTestInstance
+            {
+                connection = new SubIRawConnection()
+            };
+            instance.ackSystem = new AckSystem(instance.connection, config, time, bufferPool);
+
+            for (int i = 0; i < 50; i++)
+            {
+                instance.ackSystem.SendReliable(createRandomData(i));
+                // update to send batch
+                instance.ackSystem.Update();
+            }
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                instance.ackSystem.SendReliable(createRandomData(51));
+                instance.ackSystem.Update();
+            });
+            var expected = new InvalidOperationException($"Max packets in send buffer reached for {instance.connection}");
+            Assert.That(exception, Has.Message.EqualTo(expected.Message));
+        }
+
+        [Test]
+        public void ThrowIfRingBufferIsfull()
+        {
+            var time = new Time();
+            var config = new Config
+            {
+                MaxReliablePacketsInSendBufferPerConnection = 500,
+                SequenceSize = 8
+            };
+            var instance = new AckTestInstance
+            {
+                connection = new SubIRawConnection()
+            };
+            instance.ackSystem = new AckSystem(instance.connection, config, time, bufferPool);
+
+            for (int i = 0; i < 255; i++)
+            {
+                instance.ackSystem.SendReliable(createRandomData(i));
+                // update to send batch
+                instance.ackSystem.Update();
+            }
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                instance.ackSystem.SendReliable(createRandomData(0));
+                instance.ackSystem.Update();
+            });
+            var expected = new InvalidOperationException($"Sent queue is full for {instance.connection}");
+            Assert.That(exception, Has.Message.EqualTo(expected.Message));
+        }
+    }
+}

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_BufferSize.cs.meta
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_BufferSize.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50cc66f294e076042925a03811f79c01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
stops send buffer getting too large (holding too many packets in memory at once)

*needs testing*