### PR TITLE
feat(Syncvar): adding InitialOnly to syncvar

### DIFF
--- a/Assets/Mirage/Runtime/CustomAttributes.cs
+++ b/Assets/Mirage/Runtime/CustomAttributes.cs
@@ -12,6 +12,8 @@ namespace Mirage
     {
         ///<summary>A function that should be called on the client when the value changes.</summary>
         public string hook;
+        /// <summary>Makes the syncvar only be sent with spawn message, any other changes will not be sent to existing objects</summary>
+        public bool InitialOnly;
     }
 
     /// <summary>

--- a/Assets/Mirage/Runtime/CustomAttributes.cs
+++ b/Assets/Mirage/Runtime/CustomAttributes.cs
@@ -12,8 +12,10 @@ namespace Mirage
     {
         ///<summary>A function that should be called on the client when the value changes.</summary>
         public string hook;
-        /// <summary>Makes the syncvar only be sent with spawn message, any other changes will not be sent to existing objects</summary>
-        public bool InitialOnly;
+        /// <summary>
+        /// If true, this syncvar will only be sent with spawn message, any other changes will not be sent to existing objects
+        /// </summary>
+        public bool initialOnly;
     }
 
     /// <summary>

--- a/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
@@ -36,6 +36,7 @@ namespace Mirage.Weaver.SyncVars
 
         public bool HasHookMethod { get; private set; }
         public MethodDefinition HookMethod { get; private set; }
+        public bool InitialOnly { get; private set; }
 
         /// <summary>
         /// Changing the type of the field to the wrapper type, if one exists
@@ -87,8 +88,15 @@ namespace Mirage.Weaver.SyncVars
         {
             HookMethod = HookMethodFinder.GetHookMethod(FieldDefinition, OriginalType);
             HasHookMethod = HookMethod != null;
+            InitialOnly = GetInitialOnly(FieldDefinition);
 
             ValueSerializer = ValueSerializerFinder.GetSerializer(this, writers, readers);
+        }
+
+        static bool GetInitialOnly(FieldDefinition fieldDefinition)
+        {
+            CustomAttribute attr = fieldDefinition.GetCustomAttribute<SyncVarAttribute>();
+            return attr.GetField(nameof(SyncVarAttribute.InitialOnly), false);
         }
     }
 }

--- a/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
@@ -96,7 +96,7 @@ namespace Mirage.Weaver.SyncVars
         static bool GetInitialOnly(FieldDefinition fieldDefinition)
         {
             CustomAttribute attr = fieldDefinition.GetCustomAttribute<SyncVarAttribute>();
-            return attr.GetField(nameof(SyncVarAttribute.InitialOnly), false);
+            return attr.GetField(nameof(SyncVarAttribute.initialOnly), false);
         }
     }
 }

--- a/Assets/Tests/Runtime/ClientServer/SyncVarInitialOnlyTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/SyncVarInitialOnlyTest.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Mirage.Tests.Runtime.ClientServer
+{
+    public class SyncVarInitialOnly : NetworkBehaviour
+    {
+        [SyncVar(InitialOnly = true)]
+        public int weaponIndex = 1;
+
+        [SyncVar]
+        public int health = 100;
+
+        [SyncVar(InitialOnly = true)]
+        public float otherValue = 13f;
+    }
+
+    public class SyncVarInitialOnlyTest : ClientServerSetup<SyncVarInitialOnly>
+    {
+        [Test]
+        public void ChangingInitOnlyVarWontSetBehaviourDirty()
+        {
+            serverComponent.weaponIndex = 10;
+            Assert.That(serverComponent.IsDirty(), Is.False);
+
+            serverComponent.otherValue = 5.2f;
+            Assert.That(serverComponent.IsDirty(), Is.False);
+
+            serverComponent.health = 20;
+            Assert.That(serverComponent.IsDirty(), Is.True);
+        }
+
+        [UnityTest]
+        public IEnumerator InitOnlyIsntSentToClient()
+        {
+            serverComponent.weaponIndex = 10;
+            serverComponent.health = 50;
+            serverComponent.otherValue = 5.2f;
+
+            yield return new WaitForSeconds(0.2f);
+
+            Assert.That(clientComponent.weaponIndex, Is.EqualTo(1), "Should not have changed");
+            Assert.That(clientComponent.health, Is.EqualTo(50));
+            Assert.That(clientComponent.otherValue, Is.EqualTo(13f));
+        }
+
+        [UnityTest]
+        public IEnumerator BothSyncVarsAreSetIntially()
+        {
+            var prefab = new GameObject("BothSyncVarsAreSet", typeof(NetworkIdentity), typeof(SyncVarInitialOnly));
+            NetworkIdentity identity = prefab.GetComponent<NetworkIdentity>();
+            identity.AssetId = Guid.NewGuid();
+
+            clientObjectManager.RegisterPrefab(identity);
+
+            var clone = GameObject.Instantiate(prefab);
+            SyncVarInitialOnly behaviour = clone.GetComponent<SyncVarInitialOnly>();
+            behaviour.weaponIndex = 3;
+            behaviour.health = 20;
+            behaviour.otherValue = 5.2f;
+
+            serverObjectManager.Spawn(clone);
+            uint netId = behaviour.NetId;
+
+            yield return null;
+            yield return null;
+
+            client.World.TryGetIdentity(netId, out NetworkIdentity clientClient);
+            SyncVarInitialOnly clientBehaviour = clientClient.GetComponent<SyncVarInitialOnly>();
+
+            Assert.That(clientBehaviour.weaponIndex, Is.EqualTo(3));
+            Assert.That(clientBehaviour.health, Is.EqualTo(20));
+            Assert.That(clientBehaviour.otherValue, Is.EqualTo(5.2f));
+
+            behaviour.weaponIndex = 2;
+            behaviour.health = 30;
+            behaviour.otherValue = 7.3f;
+
+            yield return new WaitForSeconds(0.2f);
+
+            Assert.That(clientBehaviour.weaponIndex, Is.EqualTo(3), "does not change");
+            Assert.That(clientBehaviour.health, Is.EqualTo(30));
+            Assert.That(clientBehaviour.otherValue, Is.EqualTo(5.2f));
+        }
+    }
+}

--- a/Assets/Tests/Runtime/ClientServer/SyncVarInitialOnlyTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/SyncVarInitialOnlyTest.cs
@@ -8,13 +8,13 @@ namespace Mirage.Tests.Runtime.ClientServer
 {
     public class SyncVarInitialOnly : NetworkBehaviour
     {
-        [SyncVar(InitialOnly = true)]
+        [SyncVar(initialOnly = true)]
         public int weaponIndex = 1;
 
         [SyncVar]
         public int health = 100;
 
-        [SyncVar(InitialOnly = true)]
+        [SyncVar(initialOnly = true)]
         public float otherValue = 13f;
     }
 

--- a/Assets/Tests/Runtime/ClientServer/SyncVarInitialOnlyTest.cs.meta
+++ b/Assets/Tests/Runtime/ClientServer/SyncVarInitialOnlyTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 304f555a78001134da49edf86e45c18a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Weaver/SyncVarTests.cs
+++ b/Assets/Tests/Weaver/SyncVarTests.cs
@@ -11,6 +11,12 @@ namespace Mirage.Tests.Weaver
         }
 
         [Test]
+        public void SyncVarsValidInitialOnly()
+        {
+            IsSuccess();
+        }
+
+        [Test]
         public void SyncVarArraySegment()
         {
             IsSuccess();

--- a/Assets/Tests/Weaver/SyncVarTests~/SyncVarsValidInitialOnly.cs
+++ b/Assets/Tests/Weaver/SyncVarTests~/SyncVarsValidInitialOnly.cs
@@ -1,0 +1,10 @@
+using Mirage;
+
+namespace SyncVarTests.SyncVarsValidInitialOnly
+{
+    class SyncVarsValidInitialOnly : NetworkBehaviour
+    {
+        [SyncVar(InitialOnly = true)] int var;
+        [SyncVar(InitialOnly = false)] int var2;
+    }
+}

--- a/Assets/Tests/Weaver/SyncVarTests~/SyncVarsValidInitialOnly.cs
+++ b/Assets/Tests/Weaver/SyncVarTests~/SyncVarsValidInitialOnly.cs
@@ -4,7 +4,7 @@ namespace SyncVarTests.SyncVarsValidInitialOnly
 {
     class SyncVarsValidInitialOnly : NetworkBehaviour
     {
-        [SyncVar(InitialOnly = true)] int var;
-        [SyncVar(InitialOnly = false)] int var2;
+        [SyncVar(initialOnly = true)] int var;
+        [SyncVar(initialOnly = false)] int var2;
     }
 }


### PR DESCRIPTION
allows a syncvar to only be used for spawn message, meaning it wont be sent a 2nd time if changed later on server