### PR TITLE
fix: fixing use of network identity in network message

### DIFF
--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -12,6 +12,7 @@ namespace Mirage
         static readonly ILogger logger = LogFactory.GetLogger(typeof(MessageHandler));
 
         readonly bool disconnectOnException;
+        readonly IObjectLocator objectLocator;
 
         /// <summary>
         /// Handles network messages on client and server
@@ -22,9 +23,10 @@ namespace Mirage
 
         internal readonly Dictionary<int, NetworkMessageDelegate> messageHandlers = new Dictionary<int, NetworkMessageDelegate>();
 
-        public MessageHandler(bool disconnectOnException)
+        public MessageHandler(IObjectLocator objectLocator, bool disconnectOnException)
         {
             this.disconnectOnException = disconnectOnException;
+            this.objectLocator = objectLocator;
         }
 
         private static NetworkMessageDelegate MessageWrapper<T>(MessageDelegateWithPlayer<T> handler)
@@ -109,6 +111,9 @@ namespace Mirage
         {
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(packet))
             {
+                // set ObjectLocator so that message can use NetworkIdentity
+                networkReader.ObjectLocator = objectLocator;
+
                 // protect against attackers trying to send invalid data packets
                 // exception could be throw if:
                 // - invalid headers

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -114,7 +114,7 @@ namespace Mirage
             if (logger.LogEnabled()) logger.Log($"Client connecting to endpoint: {endPoint}");
 
             ISocket socket = SocketFactory.CreateClientSocket();
-            MessageHandler = new MessageHandler(DisconnectOnException);
+            MessageHandler = new MessageHandler(World, DisconnectOnException);
             var dataHandler = new DataHandler(MessageHandler);
             Metrics = EnablePeerMetrics ? new Metrics() : null;
 
@@ -190,7 +190,7 @@ namespace Mirage
             World = server.World;
 
             // create local connection objects and connect them
-            MessageHandler = new MessageHandler(DisconnectOnException);
+            MessageHandler = new MessageHandler(World, DisconnectOnException);
             var dataHandler = new DataHandler(MessageHandler);
             (IConnection clientConn, IConnection serverConn) = PipePeerConnection.Create(dataHandler, serverDataHandler, OnHostDisconnected, null);
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -192,7 +192,7 @@ namespace Mirage
             SyncVarSender = new SyncVarSender();
 
             LocalClient = localClient;
-            MessageHandler = new MessageHandler(DisconnectOnException);
+            MessageHandler = new MessageHandler(World, DisconnectOnException);
             MessageHandler.RegisterHandler<NetworkPingMessage>(World.Time.OnServerPing);
 
             ISocket socket = SocketFactory.CreateServerSocket();

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentityMessageTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentityMessageTest.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+
+namespace Mirage.Tests.Runtime.ClientServer
+{
+    public class NetworkIdentityMessageTest : ClientServerSetup<MockComponent>
+    {
+        [NetworkMessage]
+        public struct MyMessage
+        {
+            public NetworkIdentity player1;
+        }
+
+        [Test]
+        public void MessageFindsNetworkIdentities()
+        {
+            NetworkIdentity found = null;
+            client.MessageHandler.RegisterHandler((MyMessage msg) =>
+            {
+                found = msg.player1;
+            });
+            serverPlayer.Send(new MyMessage { player1 = serverPlayer.Identity });
+
+            server.Update();
+            client.Update();
+
+            Assert.That(found == clientPlayer.Identity, "Could not find client version of object");
+        }
+    }
+}

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentityMessageTest.cs.meta
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentityMessageTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc64392b6d6a5844890c4633d6af8b13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/Serialization/MessageHandlerTest.cs
+++ b/Assets/Tests/Runtime/Serialization/MessageHandlerTest.cs
@@ -23,7 +23,7 @@ namespace Mirage.Tests.Runtime
             reader = new NetworkReader();
             reader.Reset(new byte[] { 1, 2, 3, 4 });
 
-            messageHandler = new MessageHandler(true);
+            messageHandler = new MessageHandler(null, true);
         }
 
 
@@ -44,7 +44,7 @@ namespace Mirage.Tests.Runtime
         [TestCase(false)]
         public void DisconnectsIfHandlerHasException(bool disconnectOnThrow)
         {
-            messageHandler = new MessageHandler(disconnectOnThrow);
+            messageHandler = new MessageHandler(null, disconnectOnThrow);
 
             int invoked = 0;
             messageHandler.RegisterHandler<SceneReadyMessage>(_ => { invoked++; throw new InvalidOperationException("Fun Exception"); });


### PR DESCRIPTION
adding objectLocator to object locator so that it can be used to find objects when reading network messages