### PR TITLE
fix(ServerRpc): fixing sender for server rpc in host mode

### DIFF
--- a/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/ClientServerComponentTests.cs
@@ -23,12 +23,34 @@ namespace Mirage.Tests.Runtime.ClientServer
         [UnityTest]
         public IEnumerator ServerRpc() => UniTask.ToCoroutine(async () =>
         {
-            clientComponent.Test(1, "hello");
+            clientComponent.Send2Args(1, "hello");
 
             await AsyncUtil.WaitUntilWithTimeout(() => serverComponent.cmdArg1 != 0);
 
             Assert.That(serverComponent.cmdArg1, Is.EqualTo(1));
             Assert.That(serverComponent.cmdArg2, Is.EqualTo("hello"));
+        });
+
+        [UnityTest]
+        public IEnumerator ServerRpcWithSenderOnClient() => UniTask.ToCoroutine(async () =>
+        {
+            clientComponent.SendWithSender(1);
+
+            await AsyncUtil.WaitUntilWithTimeout(() => serverComponent.cmdArg1 != 0);
+
+            Assert.That(serverComponent.cmdArg1, Is.EqualTo(1));
+            Assert.That(serverComponent.cmdSender, Is.EqualTo(serverPlayer), "ServerRpc called on client will have client's player (server version)");
+        });
+
+        [UnityTest]
+        public IEnumerator ServerRpcWithSenderOnServer() => UniTask.ToCoroutine(async () =>
+        {
+            serverComponent.SendWithSender(1);
+
+            await AsyncUtil.WaitUntilWithTimeout(() => serverComponent.cmdArg1 != 0);
+
+            Assert.That(serverComponent.cmdArg1, Is.EqualTo(1));
+            Assert.That(serverComponent.cmdSender, Is.Null, "ServerRPC called on server will have no sender");
         });
 
         [UnityTest]

--- a/Assets/Tests/Runtime/Host/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/Host/HostComponentTests.cs
@@ -12,12 +12,23 @@ namespace Mirage.Tests.Runtime.Host
         [UnityTest]
         public IEnumerator ServerRpc() => UniTask.ToCoroutine(async () =>
         {
-            component.Test(1, "hello");
+            component.Send2Args(1, "hello");
 
             await AsyncUtil.WaitUntilWithTimeout(() => component.cmdArg1 != 0);
 
             Assert.That(component.cmdArg1, Is.EqualTo(1));
             Assert.That(component.cmdArg2, Is.EqualTo("hello"));
+        });
+
+        [UnityTest]
+        public IEnumerator ServerRpcWithSender() => UniTask.ToCoroutine(async () =>
+        {
+            component.SendWithSender(1);
+
+            await AsyncUtil.WaitUntilWithTimeout(() => component.cmdArg1 != 0);
+
+            Assert.That(component.cmdArg1, Is.EqualTo(1));
+            Assert.That(component.cmdSender, Is.EqualTo(server.LocalPlayer), "Server Rpc call on host will have localplayer (server version) as sender");
         });
 
         [UnityTest]

--- a/Assets/Tests/Runtime/MockComponent.cs
+++ b/Assets/Tests/Runtime/MockComponent.cs
@@ -8,10 +8,19 @@ namespace Mirage.Tests.Runtime
         public string cmdArg2;
 
         [ServerRpc]
-        public void Test(int arg1, string arg2)
+        public void Send2Args(int arg1, string arg2)
         {
             cmdArg1 = arg1;
             cmdArg2 = arg2;
+        }
+
+
+        public INetworkPlayer cmdSender;
+        [ServerRpc]
+        public void SendWithSender(int arg1, INetworkPlayer sender = null)
+        {
+            cmdArg1 = arg1;
+            cmdSender = sender;
         }
 
         public NetworkIdentity cmdNi;


### PR DESCRIPTION
called on serverOnly:
- Invoked directly
- Sender will be null

called on Host:
- Invoked directly
- Sender will be Server.LocalPlayer

called on Client:
- Invoked remotely
- Sender will Player that sent it