### PR TITLE
perf: replacing assetid with prefab hash

### DIFF
--- a/Assets/Mirage/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirage/Editor/NetworkInformationPreview.cs
@@ -277,12 +277,13 @@ namespace Mirage
 
         NetworkIdentityInfo GetAssetId(NetworkIdentity identity)
         {
-            string assetId = identity.AssetId.ToString();
-            if (string.IsNullOrEmpty(assetId))
-            {
-                assetId = "<object has no prefab>";
-            }
-            return GetString("Asset ID", assetId);
+            int prefabHash = identity.PrefabHash;
+
+            string value = prefabHash != 0
+                ? prefabHash.ToString("X")
+                : "<object has no prefab>";
+
+            return GetString("Asset ID", value);
         }
 
         static NetworkIdentityInfo GetString(string name, string value)

--- a/Assets/Mirage/Runtime/IClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/IClientObjectManager.cs
@@ -13,19 +13,19 @@ namespace Mirage
 
     public interface IClientObjectManager
     {
-        NetworkIdentity GetPrefab(Guid assetId);
+        NetworkIdentity GetPrefab(int prefabHash);
 
         void RegisterPrefab(NetworkIdentity identity);
 
-        void RegisterPrefab(NetworkIdentity identity, Guid newAssetId);
+        void RegisterPrefab(NetworkIdentity identity, int newPrefabHash);
 
         void RegisterPrefab(NetworkIdentity identity, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
 
         void UnregisterPrefab(NetworkIdentity identity);
 
-        void RegisterSpawnHandler(Guid assetId, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
+        void RegisterSpawnHandler(int prefabHash, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
 
-        void UnregisterSpawnHandler(Guid assetId);
+        void UnregisterSpawnHandler(int prefabHash);
 
         void ClearSpawners();
 

--- a/Assets/Mirage/Runtime/IServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/IServerObjectManager.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 namespace Mirage
@@ -6,16 +5,16 @@ namespace Mirage
     public interface IServerObjectManager
     {
         void AddCharacter(INetworkPlayer player, GameObject character);
-        void AddCharacter(INetworkPlayer player, GameObject character, Guid assetId);
+        void AddCharacter(INetworkPlayer player, GameObject character, int prefabHash);
         void AddCharacter(INetworkPlayer player, NetworkIdentity identity);
 
         void ReplaceCharacter(INetworkPlayer player, GameObject character, bool keepAuthority = false);
-        void ReplaceCharacter(INetworkPlayer player, GameObject character, Guid assetId, bool keepAuthority = false);
+        void ReplaceCharacter(INetworkPlayer player, GameObject character, int prefabHash, bool keepAuthority = false);
         void ReplaceCharacter(INetworkPlayer player, NetworkIdentity identity, bool keepAuthority = false);
 
         void Spawn(GameObject obj, INetworkPlayer owner = null);
         void Spawn(GameObject obj, GameObject ownerObject);
-        void Spawn(GameObject obj, Guid assetId, INetworkPlayer owner = null);
+        void Spawn(GameObject obj, int prefabHash, INetworkPlayer owner = null);
         void Spawn(NetworkIdentity identity);
         void Spawn(NetworkIdentity identity, INetworkPlayer owner);
 

--- a/Assets/Mirage/Runtime/Messages.cs
+++ b/Assets/Mirage/Runtime/Messages.cs
@@ -94,7 +94,7 @@ namespace Mirage
         /// The id of the prefab to spawn
         /// <para>If sceneId != 0 then it is used instead of assetId</para>
         /// </summary>
-        public Guid assetId;
+        public int? prefabHash;
         /// <summary>
         /// Local position
         /// </summary>

--- a/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
+++ b/Assets/Tests/Editor/NetworkIdentityCallbackTests.cs
@@ -180,59 +180,59 @@ namespace Mirage.Tests
         public void GetSetAssetId()
         {
             // assign a guid
-            var guid = new Guid(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B);
-            identity.AssetId = guid;
+            int hash = 123456789;
+            identity.PrefabHash = hash;
 
             // did it work?
-            Assert.That(identity.AssetId, Is.EqualTo(guid));
+            Assert.That(identity.PrefabHash, Is.EqualTo(hash));
         }
 
         [Test]
         public void SetAssetId_GivesErrorIfOneExists()
         {
-            var guid1 = Guid.NewGuid();
-            identity.AssetId = guid1;
+            int hash1 = "Assets/Prefab/myPrefab.asset".GetStableHashCode();
+            identity.PrefabHash = hash1;
 
             // assign a guid
-            var guid2 = Guid.NewGuid();
+            int hash2 = "Assets/Prefab/myPrefab2.asset".GetStableHashCode();
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
             {
-                identity.AssetId = guid2;
+                identity.PrefabHash = hash2;
             });
 
-            Assert.That(exception.Message, Is.EqualTo($"Can not Set AssetId on NetworkIdentity '{identity.name}' because it already had an assetId, current assetId '{guid1:N}', attempted new assetId '{guid2:N}'"));
+            Assert.That(exception.Message, Is.EqualTo($"Can not Set AssetId on NetworkIdentity '{identity.name}' because it already had an assetId, current assetId '{hash1:N}', attempted new assetId '{hash2:N}'"));
             // guid was changed
-            Assert.That(identity.AssetId, Is.EqualTo(guid1));
+            Assert.That(identity.PrefabHash, Is.EqualTo(hash1));
         }
 
         [Test]
         public void SetAssetId_GivesErrorForEmptyGuid()
         {
-            var guid1 = Guid.NewGuid();
-            identity.AssetId = guid1;
+            int hash1 = "Assets/Prefab/myPrefab.asset".GetStableHashCode();
+            identity.PrefabHash = hash1;
 
             // assign a guid
-            Guid guid2 = Guid.Empty;
+            int hash2 = 0;
             ArgumentException exception = Assert.Throws<ArgumentException>(() =>
             {
-                identity.AssetId = guid2;
+                identity.PrefabHash = hash2;
             });
 
-            Assert.That(exception.Message, Is.EqualTo($"Can not set AssetId to empty guid on NetworkIdentity '{identity.name}', old assetId '{guid1:N}'"));
+            Assert.That(exception.Message, Is.EqualTo($"Can not set AssetId to empty guid on NetworkIdentity '{identity.name}', old assetId '{hash1:N}'"));
             // guid was NOT changed
-            Assert.That(identity.AssetId, Is.EqualTo(guid1));
+            Assert.That(identity.PrefabHash, Is.EqualTo(hash1));
         }
         [Test]
         public void SetAssetId_DoesNotGiveErrorIfBothOldAndNewAreEmpty()
         {
-            Debug.Assert(identity.AssetId == Guid.Empty, "assetId needs to be empty at the start of this test");
+            Debug.Assert(identity.PrefabHash == 0, "assetId needs to be empty at the start of this test");
             // assign a guid
-            Guid guid2 = Guid.Empty;
+            int hash2 = 0;
             // expect no errors
-            identity.AssetId = guid2;
+            identity.PrefabHash = hash2;
 
             // guid was still empty
-            Assert.That(identity.AssetId, Is.EqualTo(Guid.Empty));
+            Assert.That(identity.PrefabHash, Is.EqualTo(Guid.Empty));
         }
 
         [Test]
@@ -325,7 +325,7 @@ namespace Mirage.Tests
         {
             // OnValidate will have been called. make sure that assetId was set
             // to 0 empty and not anything else, because this is a scene object
-            Assert.That(identity.AssetId, Is.EqualTo(Guid.Empty));
+            Assert.That(identity.PrefabHash, Is.EqualTo(Guid.Empty));
         }
 
         [Test]


### PR DESCRIPTION
Using hash of prefab path instead of asset id given by unity. This will make it more effecient to send because we dont need to convert between string and guid.

BREAKING CHANGE: prefab Id is now an int instead of a guid