### PR TITLE
refactor(NetworkBehaviour): adding assert to check networkbehaviour find Identitiy

### DIFF
--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -219,6 +219,13 @@ namespace Mirage
 
                 NetworkBehaviour[] components = GetComponentsInChildren<NetworkBehaviour>(true);
 
+#if DEBUG
+                foreach (NetworkBehaviour item in components)
+                {
+                    logger.Assert(item.Identity == this, $"Child NetworkBehaviour had a different Identity, this:{name}, Child Identity:{item.Identity.name}");
+                }
+#endif
+
                 if (components.Length > byte.MaxValue)
                     throw new InvalidOperationException("Only 255 NetworkBehaviour per gameobject allowed");
 


### PR DESCRIPTION
If there are Nested NetworkBehaviours and NetworkIdentity then there can be a problem where the parent NetworkIdentity will find Behaviour that belong to another child NetworkIdentity.

This assert will not fix the issue, but will ensure that the problem is an error so that the user work around it