### PR TITLE
refactor(NetworkIdentity): removing clientAuthorityCallback

### DIFF
--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -381,21 +381,6 @@ namespace Mirage
         }
 
         /// <summary>
-        /// The delegate type for the clientAuthorityCallback.
-        /// </summary>
-        /// <param name="player">The network connection that is gaining or losing authority.</param>
-        /// <param name="identity">The object whose client authority status is being changed.</param>
-        /// <param name="authorityState">The new state of client authority of the object for the connection.</param>
-        public delegate void ClientAuthorityCallback(INetworkPlayer player, NetworkIdentity identity, bool authorityState);
-
-        /// <summary>
-        /// A callback that can be populated to be notified when the client-authority state of objects changes.
-        /// <para>Whenever an object is spawned with client authority, or the client authority status of an object is changed with AssignClientAuthority or RemoveClientAuthority, then this callback will be invoked.</para>
-        /// <para>This callback is only invoked on the server.</para>
-        /// </summary>
-        public static event ClientAuthorityCallback clientAuthorityCallback;
-
-        /// <summary>
         /// this is used when a connection is destroyed, since the "observers" property is read-only
         /// </summary>
         /// <param name="player"></param>
@@ -1132,8 +1117,6 @@ namespace Mirage
             // The client will match to the existing object
             // update all variables and assign authority
             ServerObjectManager.SendSpawnMessage(this, player);
-
-            clientAuthorityCallback?.Invoke(player, this, true);
         }
 
         /// <summary>
@@ -1155,8 +1138,6 @@ namespace Mirage
 
             if (Owner != null)
             {
-                clientAuthorityCallback?.Invoke(Owner, this, false);
-
                 INetworkPlayer previousOwner = Owner;
 
                 Owner = null;

--- a/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
@@ -71,32 +71,6 @@ namespace Mirage.Tests.Runtime.Host
         }
 
         [Test]
-        public void AssignClientAuthorityCallback()
-        {
-            // create a networkidentity with our test component
-            serverObjectManager.Spawn(gameObject);
-
-            // test the callback too
-            int callbackCalled = 0;
-
-            void Callback(INetworkPlayer player, NetworkIdentity networkIdentity, bool state)
-            {
-                ++callbackCalled;
-                Assert.That(networkIdentity, Is.EqualTo(testIdentity));
-                Assert.That(state, Is.True);
-            }
-
-            NetworkIdentity.clientAuthorityCallback += Callback;
-
-            // assign authority
-            testIdentity.AssignClientAuthority(server.LocalPlayer);
-
-            Assert.That(callbackCalled, Is.EqualTo(1));
-
-            NetworkIdentity.clientAuthorityCallback -= Callback;
-        }
-
-        [Test]
         public void DefaultAuthority()
         {
             // create a networkidentity with our test component


### PR DESCRIPTION
Leftover static event from Mirror. It is unlikely anyone uses this event. If they do we can always add it back in a more appropriate place

BREAKING CHANGE: NetworkIdentity.clientAuthorityCallback removed