### PR TITLE
perf: making transform values option to send with spawn message

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -438,7 +438,10 @@ namespace Mirage
             NetworkIdentity prefab = GetPrefab(msg.prefabHash.Value);
             if (!(prefab is null))
             {
-                NetworkIdentity obj = Instantiate(prefab, msg.position, msg.rotation);
+                // we need to set position and rotation here incase that their values can be used form awake/onenable
+                Vector3 pos = msg.position ?? prefab.transform.position;
+                Quaternion rot = msg.rotation ?? prefab.transform.rotation;
+                NetworkIdentity obj = Instantiate(prefab, pos, rot);
                 if (logger.LogEnabled())
                 {
                     logger.Log($"Client spawn handler instantiating [netId:{msg.netId} asset ID:{msg.prefabHash:X} pos:{msg.position} rotation: {msg.rotation}]");

--- a/Assets/Mirage/Runtime/Messages.cs
+++ b/Assets/Mirage/Runtime/Messages.cs
@@ -98,15 +98,15 @@ namespace Mirage
         /// <summary>
         /// Local position
         /// </summary>
-        public Vector3 position;
+        public Vector3? position;
         /// <summary>
         /// Local rotation
         /// </summary>
-        public Quaternion rotation;
+        public Quaternion? rotation;
         /// <summary>
         /// Local scale
         /// </summary>
-        public Vector3 scale;
+        public Vector3? scale;
         /// <summary>
         /// The serialized component data
         /// <remark>ArraySegment to avoid unnecessary allocations</remark>

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -105,6 +105,8 @@ namespace Mirage
     {
         static readonly ILogger logger = LogFactory.GetLogger<NetworkIdentity>();
 
+        public TransformSpawnSettings SpawnSettings = new TransformSpawnSettings(true, true, true);
+
         [NonSerialized]
         NetworkBehaviour[] networkBehavioursCache;
 
@@ -700,10 +702,10 @@ namespace Mirage
 
         internal void SetClientValues(ClientObjectManager clientObjectManager, SpawnMessage msg)
         {
-            // apply local values for VR support
-            transform.localPosition = msg.position;
-            transform.localRotation = msg.rotation;
-            transform.localScale = msg.scale;
+            if (msg.position.HasValue) transform.localPosition = msg.position.Value;
+            if (msg.rotation.HasValue) transform.localRotation = msg.rotation.Value;
+            if (msg.scale.HasValue) transform.localScale = msg.scale.Value;
+
             NetId = msg.netId;
             HasAuthority = msg.isOwner;
             ClientObjectManager = clientObjectManager;
@@ -1094,6 +1096,21 @@ namespace Mirage
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
                 comp.ResetSyncObjects();
+            }
+        }
+
+        [System.Serializable]
+        public struct TransformSpawnSettings
+        {
+            public bool SendPosition;
+            public bool SendRotation;
+            public bool SendScale;
+
+            public TransformSpawnSettings(bool sendPosition, bool sendRotation, bool sendScale)
+            {
+                SendPosition = sendPosition;
+                SendRotation = sendRotation;
+                SendScale = sendScale;
             }
         }
     }

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -555,21 +555,23 @@ namespace Mirage
 
                 int? prefabHash = identity.IsPrefab ? identity.PrefabHash : default(int?);
                 ulong? sceneId = identity.IsSceneObject ? identity.SceneId : default(ulong?);
-
-                Transform transform = identity.transform;
-
-                player.Send(new SpawnMessage
+                var msg = new SpawnMessage
                 {
                     netId = identity.NetId,
                     isLocalPlayer = player.Identity == identity,
                     isOwner = isOwner,
                     sceneId = sceneId,
                     prefabHash = prefabHash,
-                    position = transform.localPosition,
-                    rotation = transform.localRotation,
-                    scale = transform.localScale,
                     payload = payload,
-                });
+                };
+
+                // values in msg are nullable, so by default they are null
+                // only set those values if the identity's settings say to send them
+                if (identity.SpawnSettings.SendPosition) msg.position = identity.transform.localPosition;
+                if (identity.SpawnSettings.SendRotation) msg.rotation = identity.transform.localRotation;
+                if (identity.SpawnSettings.SendScale) msg.scale = identity.transform.localScale;
+
+                player.Send(msg);
             }
         }
 


### PR DESCRIPTION
Not all objects need their transform values synced when they are spawned.
And many object have it sent twice because the values will also be sent by NT.

This adds the option to disable syncing position for some Identities by disabling the option in the inspector. The values default to true so this will not break any existing projects.

This also makes the values in spawn message nullable so they will take up 3 bits extra when they are all synced. But this should not increase the otherall size because writing the payload will padd to the nearest byte. and there are already 2 bools in this struct