### PR TITLE
(DONT SQUASH) fix: adding method to remove character without destroying the object

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -126,7 +126,7 @@ namespace Mirage
             Client.MessageHandler.RegisterHandler<ObjectDestroyMessage>(msg => { });
             Client.MessageHandler.RegisterHandler<ObjectHideMessage>(msg => { });
             Client.MessageHandler.RegisterHandler<SpawnMessage>(OnHostClientSpawn);
-            Client.MessageHandler.RegisterHandler<RemoveAuthorityMessage>(msg => { });
+            Client.MessageHandler.RegisterHandler<RemoveAuthorityMessage>(OnRemoveAuthority);
             Client.MessageHandler.RegisterHandler<RemoveCharacterMessage>(OnRemoveCharacter);
             Client.MessageHandler.RegisterHandler<ServerRpcReply>(msg => { });
             Client.MessageHandler.RegisterHandler<RpcMessage>(msg => { });

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -127,6 +127,7 @@ namespace Mirage
             Client.MessageHandler.RegisterHandler<ObjectHideMessage>(msg => { });
             Client.MessageHandler.RegisterHandler<SpawnMessage>(OnHostClientSpawn);
             Client.MessageHandler.RegisterHandler<RemoveAuthorityMessage>(msg => { });
+            Client.MessageHandler.RegisterHandler<RemoveCharacterMessage>(OnRemoveCharacter);
             Client.MessageHandler.RegisterHandler<ServerRpcReply>(msg => { });
             Client.MessageHandler.RegisterHandler<RpcMessage>(msg => { });
         }
@@ -137,6 +138,7 @@ namespace Mirage
             Client.MessageHandler.RegisterHandler<ObjectHideMessage>(OnObjectHide);
             Client.MessageHandler.RegisterHandler<SpawnMessage>(OnSpawn);
             Client.MessageHandler.RegisterHandler<RemoveAuthorityMessage>(OnRemoveAuthority);
+            Client.MessageHandler.RegisterHandler<RemoveCharacterMessage>(OnRemoveCharacter);
             Client.MessageHandler.RegisterHandler<ServerRpcReply>(OnServerRpcReply);
             Client.MessageHandler.RegisterHandler<RpcMessage>(OnRpcMessage);
         }
@@ -493,7 +495,25 @@ namespace Mirage
 
             identity.HasAuthority = false;
 
-            // objects spawned as part of initial state are started on a second pass
+            identity.NotifyAuthority();
+        }
+
+        internal void OnRemoveCharacter(RemoveCharacterMessage msg)
+        {
+            if (logger.LogEnabled()) logger.Log($"Client remove character handler");
+
+            INetworkPlayer player = Client.Player;
+            NetworkIdentity identity = player.Identity;
+
+            if (identity == null)
+            {
+                logger.LogWarning($"Could not find player's character");
+                return;
+            }
+
+            player.Identity = null;
+            identity.HasAuthority = msg.keepAuthority;
+
             identity.NotifyAuthority();
         }
 

--- a/Assets/Mirage/Runtime/IServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/IServerObjectManager.cs
@@ -12,6 +12,9 @@ namespace Mirage
         void ReplaceCharacter(INetworkPlayer player, GameObject character, int prefabHash, bool keepAuthority = false);
         void ReplaceCharacter(INetworkPlayer player, NetworkIdentity identity, bool keepAuthority = false);
 
+        void RemoveCharacter(INetworkPlayer player, bool keepAuthority = false);
+        void DestroyCharacter(INetworkPlayer player, bool destroyServerObject = true);
+
         void Spawn(GameObject obj, INetworkPlayer owner = null);
         void Spawn(GameObject obj, GameObject ownerObject);
         void Spawn(GameObject obj, int prefabHash, INetworkPlayer owner = null);

--- a/Assets/Mirage/Runtime/Messages.cs
+++ b/Assets/Mirage/Runtime/Messages.cs
@@ -121,6 +121,12 @@ namespace Mirage
     }
 
     [NetworkMessage]
+    public struct RemoveCharacterMessage
+    {
+        public bool keepAuthority;
+    }
+
+    [NetworkMessage]
     public struct ObjectDestroyMessage
     {
         public uint netId;

--- a/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkIdentityTests.cs
@@ -124,7 +124,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void SpawnWithAssetId()
         {
-            var hash = Guid.NewGuid().GetHashCode();
+            int hash = Guid.NewGuid().GetHashCode();
             serverObjectManager.Spawn(gameObject, hash, server.LocalPlayer);
             Assert.That(testIdentity.PrefabHash, Is.EqualTo(hash));
         }
@@ -187,6 +187,8 @@ namespace Mirage.Tests.Runtime.Host
             testIdentity.AssignClientAuthority(server.LocalPlayer);
             testIdentity.RemoveClientAuthority();
             Assert.That(testIdentity.Owner, Is.Null);
+            Assert.That(testIdentity.HasAuthority, Is.False);
+            Assert.That(testIdentity.IsLocalPlayer, Is.False);
         }
 
         [UnityTest]


### PR DESCRIPTION
fixes: #883

BREAKING CHANGE: RemovePlayerForConnection removed, use RemoveCharacter or DestroyCharacter instead