### PR TITLE
fix: weaver error on guard attributes put on awake

### DIFF
--- a/Assets/Mirage/Weaver/Processors/AttributeProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/AttributeProcessor.cs
@@ -7,7 +7,7 @@ namespace Mirage.Weaver
     /// <summary>
     /// Processes methods and fields to check their attrbiutes to make sure they are allowed on the type
     /// <para>
-    /// Injects server/client active checks for [Server/Client] attributes 
+    /// Injects server/client active checks for [Server/Client] attributes
     /// </para>
     /// </summary>
     class AttributeProcessor
@@ -132,6 +132,12 @@ namespace Mirage.Weaver
             if (!foundType.IsNetworkBehaviour)
             {
                 logger.Error($"{attribute.AttributeType.Name} method {md.Name} must be declared in a NetworkBehaviour", md);
+                return;
+            }
+
+            if (md.Name == "Awake" && !md.HasParameters)
+            {
+                logger.Error($"{attribute.AttributeType.Name} will not work on the Awake method.", md);
                 return;
             }
 

--- a/Assets/Tests/Weaver/ClientServerAttributeTests.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests.cs
@@ -21,12 +21,45 @@ namespace Mirage.Tests.Weaver
         }
 
         [Test]
+        public void NetworkBehaviourServerOnAwake()
+        {
+            HasError("ServerAttribute will not work on the Awake method.",
+                "System.Void ClientServerAttributeTests.NetworkBehaviourServer.NetworkBehaviourServerOnAwake::Awake()");
+        }
+
+        [Test]
+        public void NetworkBehaviourServerOnAwakeWithParameters()
+        {
+            IsSuccess();
+            CheckAddedCode(
+                (NetworkBehaviour nb) => nb.IsServer,
+                "ClientServerAttributeTests.NetworkBehaviourServer.NetworkBehaviourServerOnAwakeWithParameters", "Awake");
+
+        }
+
+        [Test]
         public void NetworkBehaviourClient()
         {
             IsSuccess();
             CheckAddedCode(
                 (NetworkBehaviour nb) => nb.IsClient,
                 "ClientServerAttributeTests.NetworkBehaviourClient.NetworkBehaviourClient", "ClientOnlyMethod");
+        }
+
+        [Test]
+        public void NetworkBehaviourClientOnAwake()
+        {
+            HasError("ClientAttribute will not work on the Awake method.",
+                "System.Void ClientServerAttributeTests.NetworkBehaviourClient.NetworkBehaviourClientOnAwake::Awake()");
+        }
+
+        [Test]
+        public void NetworkBehaviourClientOnAwakeWithParameters()
+        {
+            IsSuccess();
+            CheckAddedCode(
+                (NetworkBehaviour nb) => nb.IsClient,
+                "ClientServerAttributeTests.NetworkBehaviourClient.NetworkBehaviourClientOnAwakeWithParameters", "Awake");
         }
 
         [Test]
@@ -39,12 +72,44 @@ namespace Mirage.Tests.Weaver
         }
 
         [Test]
+        public void NetworkBehaviourHasAuthorityOnAwake()
+        {
+            HasError("HasAuthorityAttribute will not work on the Awake method.",
+                "System.Void ClientServerAttributeTests.NetworkBehaviourHasAuthority.NetworkBehaviourHasAuthorityOnAwake::Awake()");
+        }
+
+        [Test]
+        public void NetworkBehaviourHasAuthorityOnAwakeWithParameters()
+        {
+            IsSuccess();
+            CheckAddedCode(
+                (NetworkBehaviour nb) => nb.HasAuthority,
+                "ClientServerAttributeTests.NetworkBehaviourHasAuthority.NetworkBehaviourHasAuthorityOnAwakeWithParameters", "Awake");
+        }
+
+        [Test]
         public void NetworkBehaviourLocalPlayer()
         {
             IsSuccess();
             CheckAddedCode(
                 (NetworkBehaviour nb) => nb.IsLocalPlayer,
                 "ClientServerAttributeTests.NetworkBehaviourLocalPlayer.NetworkBehaviourLocalPlayer", "LocalPlayerMethod");
+        }
+
+        [Test]
+        public void NetworkBehaviourLocalPlayerOnAwake()
+        {
+            HasError("LocalPlayerAttribute will not work on the Awake method.",
+                "System.Void ClientServerAttributeTests.NetworkBehaviourLocalPlayer.NetworkBehaviourLocalPlayerOnAwake::Awake()");
+        }
+
+        [Test]
+        public void NetworkBehaviourLocalPlayerOnAwakeWithParameters()
+        {
+            IsSuccess();
+            CheckAddedCode(
+                (NetworkBehaviour nb) => nb.IsLocalPlayer,
+                "ClientServerAttributeTests.NetworkBehaviourLocalPlayer.NetworkBehaviourLocalPlayerOnAwakeWithParameters", "Awake");
         }
 
         /// <summary>

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourClientOnAwake.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourClientOnAwake.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourClient
+{
+    class NetworkBehaviourClientOnAwake : NetworkBehaviour
+    {
+        [Client]
+        void Awake()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourClientOnAwakeWithParameters.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourClientOnAwakeWithParameters.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourClient
+{
+    class NetworkBehaviourClientOnAwakeWithParameters : NetworkBehaviour
+    {
+        [Client]
+        void Awake(int fake)
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourHasAuthorityOnAwake.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourHasAuthorityOnAwake.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourHasAuthority
+{
+    class NetworkBehaviourHasAuthorityOnAwake : NetworkBehaviour
+    {
+        [HasAuthority]
+        void Awake()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourHasAuthorityOnAwakeWithParameters.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourHasAuthorityOnAwakeWithParameters.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourHasAuthority
+{
+    class NetworkBehaviourHasAuthorityOnAwakeWithParameters : NetworkBehaviour
+    {
+        [HasAuthority]
+        void Awake(int fake)
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourLocalPlayerOnAwake.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourLocalPlayerOnAwake.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourLocalPlayer
+{
+    class NetworkBehaviourLocalPlayerOnAwake : NetworkBehaviour
+    {
+        [LocalPlayer]
+        void Awake()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourLocalPlayerOnAwakeWithParameters.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourLocalPlayerOnAwakeWithParameters.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourLocalPlayer
+{
+    class NetworkBehaviourLocalPlayerOnAwakeWithParameters : NetworkBehaviour
+    {
+        [LocalPlayer]
+        void Awake(int fake)
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourServerOnAwake.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourServerOnAwake.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourServer
+{
+    class NetworkBehaviourServerOnAwake : NetworkBehaviour
+    {
+        [Server]
+        void Awake()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourServerOnAwakeWithParameters.cs
+++ b/Assets/Tests/Weaver/ClientServerAttributeTests~/NetworkBehaviourServerOnAwakeWithParameters.cs
@@ -1,0 +1,13 @@
+using Mirage;
+
+namespace ClientServerAttributeTests.NetworkBehaviourServer
+{
+    class NetworkBehaviourServerOnAwakeWithParameters : NetworkBehaviour
+    {
+        [Server]
+        void Awake(int fake)
+        {
+            // test method
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the weaver give an error when Server, Client, HasAuthority, and LocalPlayer are put on Awake.

It also includes tests that check for errors when an attribute has been placed on Awake and also that it doesn't error when you have an Awake method with parameters. 

Fixes #984 