### PR TITLE
fix(NetworkBehaviour): make NetworkBehaviour always look for NetworkIdentity in parents

### DIFF
--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -148,20 +148,6 @@ namespace Mirage
         /// </summary>
         NetworkIdentity _identity;
 
-
-#if !UNITY_2020_1_OR_NEWER
-        /// <summary>
-        /// Cache list for the results of GetComponentsInParent calls when looking up NetworkIdentity for NetworkBehaviour.
-        /// Used to avoid runtime allocations.
-        /// </summary>
-        /// <remarks>
-        /// This is required only for pre-2020.1 Unity versions, as they don't have an option to include inactive objects when calling non-allocating GetComponentInParent().
-        /// Setting the list's initial size to 1 prevents new allocations because GetComponentsInParent() can never find more than one NetworkIdentity
-        /// (given the fact that only 1 NetworkIdentity per hierarchy is currently allowed in Mirage).
-        /// </remarks>
-        private static List<NetworkIdentity> networkIdentityGetComponentCacheList = new List<NetworkIdentity>(1);
-#endif
-
         /// <summary>
         /// Returns the NetworkIdentity of this object
         /// </summary>
@@ -176,14 +162,7 @@ namespace Mirage
                 {
                     // we look up NetworkIdentity on this GO or any of its parents;
                     // this allows placing NetworkBehaviours on children of NetworkIdentity
-#if UNITY_2021_2_OR_NEWER
-                    _identity = GetComponentInParent<NetworkIdentity>(true);
-#elif UNITY_2020_1_OR_NEWER
                     _identity = gameObject.GetComponentInParent<NetworkIdentity>(true);
-#else
-                    GetComponentsInParent<NetworkIdentity>(true, networkIdentityGetComponentCacheList);
-                    _identity = networkIdentityGetComponentCacheList[0];
-#endif
 
                     // do this 2nd check inside first if so that we are not checking == twice on unity Object
                     if (_identity is null)

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -148,6 +148,20 @@ namespace Mirage
         /// </summary>
         NetworkIdentity _identity;
 
+
+#if !UNITY_2020_1_OR_NEWER
+        /// <summary>
+        /// Cache list for the results of GetComponentsInParent calls when looking up NetworkIdentity for NetworkBehaviour.
+        /// Used to avoid runtime allocations.
+        /// </summary>
+        /// <remarks>
+        /// This is required only for pre-2020.1 Unity versions, as they don't have an option to include inactive objects when calling non-allocating GetComponentInParent().
+        /// Setting the list's initial size to 1 prevents new allocations because GetComponentsInParent() can never find more than one NetworkIdentity
+        /// (given the fact that only 1 NetworkIdentity per hierarchy is currently allowed in Mirage).
+        /// </remarks>
+        private static List<NetworkIdentity> networkIdentityGetComponentCacheList = new List<NetworkIdentity>(1);
+#endif
+
         /// <summary>
         /// Returns the NetworkIdentity of this object
         /// </summary>
@@ -162,7 +176,14 @@ namespace Mirage
                 {
                     // we look up NetworkIdentity on this GO or any of its parents;
                     // this allows placing NetworkBehaviours on children of NetworkIdentity
+#if UNITY_2021_2_OR_NEWER
+                    _identity = GetComponentInParent<NetworkIdentity>(true);
+#elif UNITY_2020_1_OR_NEWER
                     _identity = gameObject.GetComponentInParent<NetworkIdentity>(true);
+#else
+                    GetComponentsInParent<NetworkIdentity>(true, networkIdentityGetComponentCacheList);
+                    _identity = networkIdentityGetComponentCacheList[0];
+#endif
 
                     // do this 2nd check inside first if so that we are not checking == twice on unity Object
                     if (_identity is null)

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -149,6 +149,7 @@ namespace Mirage
         NetworkIdentity _identity;
 
 
+        // TODO: remove this bit once Unity drops support for 2019 LTS
 #if !UNITY_2020_1_OR_NEWER
         /// <summary>
         /// Cache list for the results of GetComponentsInParent calls when looking up NetworkIdentity for NetworkBehaviour.
@@ -181,6 +182,7 @@ namespace Mirage
 #elif UNITY_2020_1_OR_NEWER
                     _identity = gameObject.GetComponentInParent<NetworkIdentity>(true);
 #else
+                    // TODO: remove this bit once Unity drops support for 2019 LTS
                     GetComponentsInParent<NetworkIdentity>(true, networkIdentityGetComponentCacheList);
                     _identity = networkIdentityGetComponentCacheList[0];
 #endif

--- a/Assets/Mirage/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviour.cs
@@ -175,17 +175,7 @@ namespace Mirage
                 // instead of calling unity's MonoBehaviour == operator
                 if (_identity is null)
                 {
-                    // we look up NetworkIdentity on this GO or any of its parents;
-                    // this allows placing NetworkBehaviours on children of NetworkIdentity
-#if UNITY_2021_2_OR_NEWER
-                    _identity = GetComponentInParent<NetworkIdentity>(true);
-#elif UNITY_2020_1_OR_NEWER
-                    _identity = gameObject.GetComponentInParent<NetworkIdentity>(true);
-#else
-                    // TODO: remove this bit once Unity drops support for 2019 LTS
-                    GetComponentsInParent<NetworkIdentity>(true, networkIdentityGetComponentCacheList);
-                    _identity = networkIdentityGetComponentCacheList[0];
-#endif
+                    _identity = TryFindIdentity();
 
                     // do this 2nd check inside first if so that we are not checking == twice on unity Object
                     if (_identity is null)
@@ -225,6 +215,26 @@ namespace Mirage
 
                 return COMPONENT_INDEX_NOT_FOUND;
             }
+        }
+
+        /// <summary>
+        /// Tries to find <see cref="NetworkIdentity"/> which is responsible for this <see cref="NetworkBehaviour"/>.
+        /// </summary>
+        /// <remarks>We look up NetworkIdentity on this GameObject or any of its parents. This allows placing NetworkBehaviours on children of NetworkIdentity.</remarks>
+        /// <returns><see cref="NetworkIdentity"/> if found, null otherwise.</returns>
+        private NetworkIdentity TryFindIdentity()
+        {
+#if UNITY_2021_2_OR_NEWER
+            var identity = GetComponentInParent<NetworkIdentity>(true);
+#elif UNITY_2020_1_OR_NEWER
+            var identity = gameObject.GetComponentInParent<NetworkIdentity>(true);
+#else
+            // TODO: remove this bit once Unity drops support for 2019 LTS
+            GetComponentsInParent<NetworkIdentity>(true, networkIdentityGetComponentCacheList);
+            var identity = networkIdentityGetComponentCacheList[0];
+#endif
+
+            return identity;
         }
 
         // this gets called in the constructor by the weaver


### PR DESCRIPTION
### Reason for change:

Current implementation of NetworkBehaviour (NB) looks for its NetworkIdentity (NI) in parent objects only if the host GameObject is active in hierarchy. If the parent is disabled, however, NB will look for NI only on the same GameObject. This behaviour is inconsistent and can be misleading.

In current codebase, this behaviour is reasoned by the fact that `GetComponentInParent()` does not support inactive GameObjects; `GetComponentsInParent()` does support them, but results in runtime memory allocations. However, [starting from Unity 2020.1](https://docs.unity3d.com/ScriptReference/GameObject.GetComponentInParent.html), `GetComponentInParent()` allows to set `includeInactive` parameter. In older Unity versions, runtime allocations can be prevented by passing a pre-allocated List to `GetComponentsInParent()`.



### What was changed:

Now NetworkBehaviour always uses `GetComponentInParent()` to find its NetworkIdentity. This allows to have NetworkIdentity on the same GameObject or any parent objects, and works even if they are disabled.

The code was also updated to prevent runtime allocations when calling `GetComponentsInParent()` in Unity versions pre-2020.1. New versions use non-allocating `GetComponentInParent()` method.



### Why this change is useful?

Updated logic allows to consistently place NBs in child objects of NI, not only on the same GameObject. This allows to keep hierarchy cleaner and more structured.



**P.S.** Let me know if anything else should be changed to support this. Open for discussion :)

**EDIT:** Typo.