### PR TITLE
fix: adding try/catch for nanosocket

### DIFF
--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -45,12 +45,21 @@ namespace Mirage.Sockets.Udp
         {
             if (!useNanoSocket) return;
 
-            if (initCount == 0)
+            try
             {
-                UDP.Initialize();
-            }
+                if (initCount == 0)
+                {
+                    UDP.Initialize();
+                }
 
-            initCount++;
+                initCount++;
+            }
+            catch (DllNotFoundException)
+            {
+                Debug.LogWarning("Nanosocket dll not found, Using c# Managed Socket instead");
+                SocketLib = SocketLib.Managed;
+                return;
+            }
         }
 
         void OnDestroy()


### PR DESCRIPTION
will catch the error when the dll is not found and then default to the c# socket

resolves: https://github.com/MirageNet/Mirage/issues/929
resolves: https://github.com/MirageNet/Mirage/issues/950