### PR TITLE
feat: feature fire hooks on server too

### DIFF
--- a/Assets/Mirage/Runtime/CustomAttributes.cs
+++ b/Assets/Mirage/Runtime/CustomAttributes.cs
@@ -16,6 +16,11 @@ namespace Mirage
         /// If true, this syncvar will only be sent with spawn message, any other changes will not be sent to existing objects
         /// </summary>
         public bool initialOnly;
+
+        /// <summary>
+        ///     If true this syncvar hook will also fire on the server side.
+        /// </summary>
+        public bool fireOnServer;
     }
 
     /// <summary>

--- a/Assets/Mirage/Runtime/CustomAttributes.cs
+++ b/Assets/Mirage/Runtime/CustomAttributes.cs
@@ -20,7 +20,7 @@ namespace Mirage
         /// <summary>
         ///     If true this syncvar hook will also fire on the server side.
         /// </summary>
-        public bool fireOnServer;
+        public bool invokeHookOnServer;
     }
 
     /// <summary>

--- a/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
@@ -4,7 +4,6 @@ using Mirage.Weaver.Serialization;
 using Mirage.Weaver.SyncVars;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using UnityEngine;
 using FieldAttributes = Mono.Cecil.FieldAttributes;
 using MethodAttributes = Mono.Cecil.MethodAttributes;
 using PropertyAttributes = Mono.Cecil.PropertyAttributes;
@@ -109,10 +108,7 @@ namespace Mirage.Weaver
 
         void ProcessSyncVar(FoundSyncVar syncVar)
         {
-            if (!syncVar.HasHook && syncVar.InvokeHookOnServer)
-                throw new HookMethodException(
-                    $"Parameter {syncVar.InvokeHookOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.InvokeHookOnServer} back to false or remove for default false.",
-                    syncVar.Hook.Method);
+
 
             // process attributes first before creating setting, otherwise it wont know about hook
             syncVar.SetWrapType();

--- a/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
@@ -4,6 +4,7 @@ using Mirage.Weaver.Serialization;
 using Mirage.Weaver.SyncVars;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using UnityEngine;
 using FieldAttributes = Mono.Cecil.FieldAttributes;
 using MethodAttributes = Mono.Cecil.MethodAttributes;
 using PropertyAttributes = Mono.Cecil.PropertyAttributes;
@@ -497,6 +498,11 @@ namespace Mirage.Weaver
                         // Generates: OnValueChanged(oldValue, this.syncVar)
                         WriteCallHookMethodUsingField(worker, syncVar.Hook, oldValue, syncVar);
                     }
+                    else if (syncVar.FireOnServer && !syncVar.HasHook)
+                    {
+                        Debug.LogWarning(
+                            $"Parameter {syncVar.FireOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.FireOnServer} back to false or remove for default false.");
+                    }
                 }
             });
 
@@ -524,6 +530,11 @@ namespace Mirage.Weaver
                     // call the hook
                     // Generates: OnValueChanged(oldValue, this.syncVar)
                     WriteCallHookMethodUsingField(worker, syncVar.Hook, oldValue, syncVar);
+                }
+                else if (syncVar.FireOnServer && !syncVar.HasHook)
+                {
+                    Debug.LogWarning(
+                        $"Parameter {syncVar.FireOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.FireOnServer} back to false or remove for default false.");
                 }
             }
 

--- a/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
@@ -491,6 +491,11 @@ namespace Mirage.Weaver
 
                     if (syncVar.FireOnServer && syncVar.HasHook)
                     {
+                        VariableDefinition oldValue = helper.Method.AddLocal(syncVar.OriginalType);
+
+                        // call the hook
+                        // Generates: OnValueChanged(oldValue, this.syncVar)
+                        WriteCallHookMethodUsingField(worker, syncVar.Hook, oldValue, syncVar);
                     }
                 }
             });

--- a/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
@@ -235,10 +235,12 @@ namespace Mirage.Weaver
                 //if (base.isLocalClient && !getSyncVarHookGuard(dirtyBit))
                 Instruction label = worker.Create(OpCodes.Nop);
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
+                // if invokeOnServer, then `IsServer` will also cover the Host case too so we dont need to use an OR here
                 if (syncVar.InvokeHookOnServer)
                     worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsServer));
                 else
                     worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.IsLocalClient));
+
                 worker.Append(worker.Create(OpCodes.Brfalse, label));
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
                 worker.Append(worker.Create(OpCodes.Ldc_I8, syncVar.DirtyBit));

--- a/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
@@ -108,8 +108,6 @@ namespace Mirage.Weaver
 
         void ProcessSyncVar(FoundSyncVar syncVar)
         {
-
-
             // process attributes first before creating setting, otherwise it wont know about hook
             syncVar.SetWrapType();
             syncVar.ProcessAttributes(writers, readers);

--- a/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
@@ -109,6 +109,11 @@ namespace Mirage.Weaver
 
         void ProcessSyncVar(FoundSyncVar syncVar)
         {
+            if (!syncVar.HasHook && syncVar.InvokeHookOnServer)
+                throw new HookMethodException(
+                    $"Parameter {syncVar.InvokeHookOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.InvokeHookOnServer} back to false or remove for default false.",
+                    syncVar.Hook.Method);
+
             // process attributes first before creating setting, otherwise it wont know about hook
             syncVar.SetWrapType();
             syncVar.ProcessAttributes(writers, readers);
@@ -117,11 +122,6 @@ namespace Mirage.Weaver
 
             string originalName = fd.Name;
             Weaver.DebugLog(fd.DeclaringType, $"Sync Var {fd.Name} {fd.FieldType}");
-
-            if (!syncVar.HasHook && syncVar.InvokeHookOnServer)
-                throw new HookMethodException(
-                    $"Parameter {syncVar.InvokeHookOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.InvokeHookOnServer} back to false or remove for default false.",
-                    syncVar.Hook.Method);
 
             MethodDefinition get = GenerateSyncVarGetter(syncVar);
             MethodDefinition set = syncVar.InitialOnly

--- a/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVarProcessor.cs
@@ -490,18 +490,17 @@ namespace Mirage.Weaver
                 {
                     WriteFromField(worker, helper.WriterParameter, syncVar);
 
-                    if (syncVar.FireOnServer && syncVar.HasHook)
+                    if (syncVar.InvokeHookOnServer && syncVar.HasHook)
                     {
                         VariableDefinition oldValue = helper.Method.AddLocal(syncVar.OriginalType);
 
                         // call the hook
                         // Generates: OnValueChanged(oldValue, this.syncVar)
-                        WriteCallHookMethodUsingField(worker, syncVar.Hook, oldValue, syncVar);
+                        EndHook(worker, syncVar, syncVar.OriginalType, oldValue);
                     }
-                    else if (syncVar.FireOnServer && !syncVar.HasHook)
+                    else if (syncVar.InvokeHookOnServer && !syncVar.HasHook)
                     {
-                        Debug.LogWarning(
-                            $"Parameter {syncVar.FireOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.FireOnServer} back to false or remove for default false.");
+                        throw new HookMethodException($"Parameter {syncVar.InvokeHookOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.InvokeHookOnServer} back to false or remove for default false.", helper.Method);
                     }
                 }
             });
@@ -523,18 +522,17 @@ namespace Mirage.Weaver
                     WriteFromField(worker, helper.WriterParameter, syncVar);
                 });
 
-                if (syncVar.FireOnServer && syncVar.HasHook)
+                if (syncVar.InvokeHookOnServer && syncVar.HasHook)
                 {
                     VariableDefinition oldValue = helper.Method.AddLocal(syncVar.OriginalType);
 
                     // call the hook
                     // Generates: OnValueChanged(oldValue, this.syncVar)
-                    WriteCallHookMethodUsingField(worker, syncVar.Hook, oldValue, syncVar);
+                    EndHook(worker, syncVar, syncVar.OriginalType, oldValue);
                 }
-                else if (syncVar.FireOnServer && !syncVar.HasHook)
+                else if (syncVar.InvokeHookOnServer && !syncVar.HasHook)
                 {
-                    Debug.LogWarning(
-                        $"Parameter {syncVar.FireOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.FireOnServer} back to false or remove for default false.");
+                    throw new HookMethodException($"Parameter {syncVar.InvokeHookOnServer} is set to true but no hook was implemented. Please implement hook or set {syncVar.InvokeHookOnServer} back to false or remove for default false.", helper.Method);
                 }
             }
 

--- a/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
@@ -37,6 +37,7 @@ namespace Mirage.Weaver.SyncVars
         public bool HasHook { get; private set; }
         public SyncVarHook Hook { get; private set; }
         public bool InitialOnly { get; private set; }
+        public bool FireOnServer { get; private set; }
 
         /// <summary>
         /// Changing the type of the field to the wrapper type, if one exists
@@ -92,6 +93,8 @@ namespace Mirage.Weaver.SyncVars
 
             InitialOnly = GetInitialOnly(FieldDefinition);
 
+            FireOnServer = GetFireOnServer(FieldDefinition);
+
             ValueSerializer = ValueSerializerFinder.GetSerializer(this, writers, readers);
         }
 
@@ -99,6 +102,12 @@ namespace Mirage.Weaver.SyncVars
         {
             CustomAttribute attr = fieldDefinition.GetCustomAttribute<SyncVarAttribute>();
             return attr.GetField(nameof(SyncVarAttribute.initialOnly), false);
+        }
+
+        static bool GetFireOnServer(FieldDefinition fieldDefinition)
+        {
+            CustomAttribute attr = fieldDefinition.GetCustomAttribute<SyncVarAttribute>();
+            return attr.GetField(nameof(SyncVarAttribute.fireOnServer), false);
         }
     }
 }

--- a/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
@@ -96,6 +96,9 @@ namespace Mirage.Weaver.SyncVars
             InvokeHookOnServer = GetFireOnServer(FieldDefinition);
 
             ValueSerializer = ValueSerializerFinder.GetSerializer(this, writers, readers);
+
+            if (!HasHook && InvokeHookOnServer)
+                throw new HookMethodException("'invokeHookOnServer' is set to true but no hook was implemented. Please implement hook or set 'invokeHookOnServer' back to false or remove for default false.", FieldDefinition);
         }
 
         static bool GetInitialOnly(FieldDefinition fieldDefinition)

--- a/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVars/FoundSyncVar.cs
@@ -37,7 +37,7 @@ namespace Mirage.Weaver.SyncVars
         public bool HasHook { get; private set; }
         public SyncVarHook Hook { get; private set; }
         public bool InitialOnly { get; private set; }
-        public bool FireOnServer { get; private set; }
+        public bool InvokeHookOnServer { get; private set; }
 
         /// <summary>
         /// Changing the type of the field to the wrapper type, if one exists
@@ -93,7 +93,7 @@ namespace Mirage.Weaver.SyncVars
 
             InitialOnly = GetInitialOnly(FieldDefinition);
 
-            FireOnServer = GetFireOnServer(FieldDefinition);
+            InvokeHookOnServer = GetFireOnServer(FieldDefinition);
 
             ValueSerializer = ValueSerializerFinder.GetSerializer(this, writers, readers);
         }
@@ -107,7 +107,7 @@ namespace Mirage.Weaver.SyncVars
         static bool GetFireOnServer(FieldDefinition fieldDefinition)
         {
             CustomAttribute attr = fieldDefinition.GetCustomAttribute<SyncVarAttribute>();
-            return attr.GetField(nameof(SyncVarAttribute.fireOnServer), false);
+            return attr.GetField(nameof(SyncVarAttribute.invokeHookOnServer), false);
         }
     }
 }

--- a/Assets/Mirage/Weaver/Processors/SyncVars/HookMethodFinder.cs
+++ b/Assets/Mirage/Weaver/Processors/SyncVars/HookMethodFinder.cs
@@ -32,7 +32,7 @@ namespace Mirage.Weaver.SyncVars
         static SyncVarHook FindHookMethod(FieldDefinition syncVar, string hookFunctionName, TypeReference originalType)
         {
             // check event first
-            EventDefinition @event = syncVar.DeclaringType.Events.Where(x => x.Name == hookFunctionName).FirstOrDefault();
+            EventDefinition @event = syncVar.DeclaringType.Events.FirstOrDefault(x => x.Name == hookFunctionName);
             if (@event != null)
             {
                 return ValidateEvent(syncVar, originalType, @event);

--- a/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace Mirage.Tests.Runtime.ClientServer
+{
+    public class BehaviourWithSyncVarOnServerEvent : NetworkBehaviour
+    {
+        [SyncVar(hook = nameof(OnHealthChanged), invokeHookOnServer = true)]
+        public int health;
+
+        public event Action<int, int> OnHealthChanged;
+    }
+
+    public class BehaviourWithSyncVarOnServerMethod : NetworkBehaviour
+    {
+        [SyncVar(hook = nameof(OnHealthChanged), invokeHookOnServer = true)]
+        public int health;
+
+        public int called = 0;
+
+        public void OnHealthChanged(int oldValue, int newValue)
+        {
+            if(!IsServer) return;
+
+            called++;
+        }
+    }
+
+    public class SyncVarFireHookEventOnServerTests : ClientServerSetup<BehaviourWithSyncVarOnServerEvent>
+    {
+        [UnityTest]
+        public IEnumerator SyncVarHookEventIsCalledOnServer()
+        {
+            const int SValue = 10;
+            const int CValue = 0;
+            int oldValue = default;
+            int newValue = default;
+            int called = 0;
+
+            serverComponent.OnHealthChanged += (a, b) =>
+            {
+                oldValue = a;
+                newValue = b;
+                called++;
+            };
+
+            serverComponent.health = CValue;
+
+            yield return null;
+            yield return null;
+
+            Assert.That(called, Is.EqualTo(1));
+            Assert.That(oldValue, Is.EqualTo(CValue));
+            Assert.That(newValue, Is.EqualTo(SValue));
+
+        }
+    }
+
+    public class SyncVarFireHookMethodOnServerTests : ClientServerSetup<BehaviourWithSyncVarOnServerMethod>
+    {
+        [UnityTest]
+        public IEnumerator SyncVarHookEventIsCalledOnServer()
+        {
+            const int SValue = 10;
+            int oldValue = serverComponent.health;
+            int newValue = default;
+
+            serverComponent.health = SValue;
+
+            yield return null;
+            yield return null;
+
+            newValue = serverComponent.health;
+
+            Assert.That(serverComponent.called, Is.EqualTo(1));
+            Assert.That(oldValue, Is.Not.EqualTo(serverComponent.health));
+            Assert.That(newValue, Is.EqualTo(serverComponent.health));
+        }
+    }
+}

--- a/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs
@@ -47,7 +47,7 @@ namespace Mirage.Tests.Runtime.ClientServer
                 called++;
             };
 
-            serverComponent.health = CValue;
+            serverComponent.health = SValue;
 
             yield return new WaitUntil(() => called > 0);
 

--- a/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Mirage.Tests.Runtime.ClientServer
@@ -48,8 +49,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             serverComponent.health = CValue;
 
-            yield return null;
-            yield return null;
+            yield return new WaitUntil(() => called > 0);
 
             Assert.That(called, Is.EqualTo(1));
             Assert.That(oldValue, Is.EqualTo(CValue));
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.ClientServer
     public class SyncVarFireHookMethodOnServerTests : ClientServerSetup<BehaviourWithSyncVarOnServerMethod>
     {
         [UnityTest]
-        public IEnumerator SyncVarHookEventIsCalledOnServer()
+        public IEnumerator SyncVarHookMethodIsCalledOnServer()
         {
             const int SValue = 10;
             int oldValue = serverComponent.health;
@@ -69,8 +69,7 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             serverComponent.health = SValue;
 
-            yield return null;
-            yield return null;
+            yield return new WaitUntil(() => oldValue == newValue);
 
             newValue = serverComponent.health;
 

--- a/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs.meta
+++ b/Assets/Tests/Runtime/ClientServer/SyncVarFireHookOnServerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b562af4a40dfdbf4e88e6fb1f35059bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Weaver/SyncVarHookTests.cs
+++ b/Assets/Tests/Weaver/SyncVarHookTests.cs
@@ -116,7 +116,7 @@ namespace Mirage.Tests.Weaver
         public void SyncVarHookServerError()
         {
             HasError($"'invokeHookOnServer' is set to true but no hook was implemented. Please implement hook or set 'invokeHookOnServer' back to false or remove for default false.",
-                "System.Int32 SyncVarHookTests.SyncVarHookServer.SyncVarHookServer::health");
+                "System.Int32 SyncVarHookTests.SyncVarHookServerError.SyncVarHookServerError::health");
         }
     }
 }

--- a/Assets/Tests/Weaver/SyncVarHookTests.cs
+++ b/Assets/Tests/Weaver/SyncVarHookTests.cs
@@ -105,5 +105,18 @@ namespace Mirage.Tests.Weaver
             HasError($"Hook Event for 'health' needs to be type 'System.Action<,>' but was 'System.Action`2<System.Int32,System.Single>' instead",
                 "System.Action`2<System.Int32,System.Single> SyncVarHookTests.ErrorWhenEventArgsAreWrong.ErrorWhenEventArgsAreWrong::OnChangeHealth");
         }
+
+        [Test]
+        public void SyncVarHookServer()
+        {
+            IsSuccess();
+        }
+
+        [Test]
+        public void SyncVarHookServerError()
+        {
+            HasError($"'invokeHookOnServer' is set to true but no hook was implemented. Please implement hook or set 'invokeHookOnServer' back to false or remove for default false.",
+                "System.Int32 SyncVarHookTests.SyncVarHookServer.SyncVarHookServer::health");
+        }
     }
 }

--- a/Assets/Tests/Weaver/SyncVarHookTests~/SyncVarHookServer.cs
+++ b/Assets/Tests/Weaver/SyncVarHookTests~/SyncVarHookServer.cs
@@ -1,0 +1,15 @@
+using Mirage;
+
+namespace SyncVarHookTests.SyncVarHookServer
+{
+    class SyncVarHookServer : NetworkBehaviour
+    {
+        [SyncVar(hook = nameof(onChangeHealth), invokeHookOnServer = true)]
+        int health;
+
+        void onChangeHealth(int oldValue, int newValue)
+        {
+
+        }
+    }
+}

--- a/Assets/Tests/Weaver/SyncVarHookTests~/SyncVarHookServerError.cs
+++ b/Assets/Tests/Weaver/SyncVarHookTests~/SyncVarHookServerError.cs
@@ -1,0 +1,10 @@
+using Mirage;
+
+namespace SyncVarHookTests.SyncVarHookServerError
+{
+    class SyncVarHookServerError : NetworkBehaviour
+    {
+        [SyncVar(invokeHookOnServer = true)]
+        int health;
+    }
+}

--- a/doc/Articles/Guides/Sync/SyncVars.md
+++ b/doc/Articles/Guides/Sync/SyncVars.md
@@ -66,7 +66,7 @@ You can attach the Cat component to your cat prefab, and it will synchronize bot
 > Both `Cat` and `Pet` should be in the same assembly. If they are in separate assemblies, make sure not to change `name` from inside `Cat` directly, add a method to `Pet` instead. 
 
 ## SyncVar hook
-The `hook` property of SyncVar can be used to specify a function to be called when the SyncVar changes value on the client.
+The `hook` property of SyncVar can be used to specify a function to be called when the SyncVar changes value on the client and server.
 
 **Trivia:**
 - The hook callback must have two parameters of the same type as the SyncVar property. One for the old value, one for the new value.
@@ -74,7 +74,7 @@ The `hook` property of SyncVar can be used to specify a function to be called wh
 - The hook only fires for changed values, and changing a value in the inspector will not trigger an update.
 - Hooks can be virtual methods and overriden in a derived class.
 
-### Example
+### Example Client Only
 Below is a simple example of assigning a random color to each player when they're spawned on the server.  All clients will see all players in the correct colors, even if they join later.
 
 ```cs
@@ -84,6 +84,54 @@ using Mirage;
 public class Player : NetworkBehaviour
 {
     [SyncVar(hook = nameof(UpdateColor))]
+    Color playerColor = Color.black;
+
+    Renderer renderer;
+
+    // Unity makes a clone of the Material every time renderer.material is used.
+    // Cache it here and Destroy it in OnDestroy to prevent a memory leak.
+    Material cachedMaterial;
+
+    void Awake()
+    {
+        renderer = GetComponent<Renderer>();
+        NetIdentity.OnStartServer.AddListener(OnStartServer);
+    }
+
+    void OnStartServer()
+    {
+        playerColor = Random.ColorHSV(0f, 1f, 1f, 1f, 0.5f, 1f);
+    }
+
+    void UpdateColor(Color oldColor, Color newColor)
+    {
+        // this is executed on this player for each client
+        if (cachedMaterial == null)
+        {
+            cachedMaterial = renderer.material;
+        }
+
+        cachedMaterial.color = newColor;
+    }
+
+    void OnDestroy()
+    {
+        Destroy(cachedMaterial);
+    }
+}
+```
+
+### Example Client & Server
+Below is a simple example of assigning a random color to each player when they're spawned on the server. All clients will see all players in the correct colors, even if they join later.
+Server will also fire the event.
+
+```cs
+using UnityEngine;
+using Mirage;
+
+public class Player : NetworkBehaviour
+{
+    [SyncVar(hook = nameof(UpdateColor), fireOnServer = true)]
     Color playerColor = Color.black;
 
     Renderer renderer;


### PR DESCRIPTION
Can now fire hooks also on server. Requires new attribute parameter to be set. Default is false to now confuse or mess up projects. Example below...

```cs
using UnityEngine;
using Mirage;

public class Player : NetworkBehaviour
{
    [SyncVar(hook = nameof(UpdateColor), fireOnServer = true)]
    Color playerColor = Color.black;

    Renderer renderer;

    // Unity makes a clone of the Material every time renderer.material is used.
    // Cache it here and Destroy it in OnDestroy to prevent a memory leak.
    Material cachedMaterial;

    void Awake()
    {
        renderer = GetComponent<Renderer>();
        NetIdentity.OnStartServer.AddListener(OnStartServer);
    }

    void OnStartServer()
    {
        playerColor = Random.ColorHSV(0f, 1f, 1f, 1f, 0.5f, 1f);
    }

    void UpdateColor(Color oldColor, Color newColor)
    {
        // this is executed on this player for each client
        if (cachedMaterial == null)
        {
            cachedMaterial = renderer.material;
        }

        cachedMaterial.color = newColor;
    }

    void OnDestroy()
    {
        Destroy(cachedMaterial);
    }
}
```