### PR TITLE
refactor(SockerLayer): removing unity logger from peer

### DIFF
--- a/Assets/Mirage/Runtime/SocketLayer/Connection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection.cs
@@ -73,23 +73,23 @@ namespace Mirage.SocketLayer
                 switch (value)
                 {
                     case ConnectionState.Connected:
-                        logger.Assert(_state == ConnectionState.Created || _state == ConnectionState.Connecting);
+                        logger?.Assert(_state == ConnectionState.Created || _state == ConnectionState.Connecting);
                         break;
 
                     case ConnectionState.Connecting:
-                        logger.Assert(_state == ConnectionState.Created);
+                        logger?.Assert(_state == ConnectionState.Created);
                         break;
 
                     case ConnectionState.Disconnected:
-                        logger.Assert(_state == ConnectionState.Connected);
+                        logger?.Assert(_state == ConnectionState.Connected);
                         break;
 
                     case ConnectionState.Destroyed:
-                        logger.Assert(_state == ConnectionState.Removing);
+                        logger?.Assert(_state == ConnectionState.Removing);
                         break;
                 }
 
-                if (logger.IsLogTypeAllowed(LogType.Log)) logger.Log($"{EndPoint} changed state from {_state} to {value}");
+                if (logger.Enabled(LogType.Log)) logger.Log($"{EndPoint} changed state from {_state} to {value}");
                 _state = value;
             }
         }
@@ -112,7 +112,7 @@ namespace Mirage.SocketLayer
         internal Connection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, Time time, Pool<ByteBuffer> bufferPool, ILogger logger, Metrics metrics)
         {
             this.peer = peer;
-            this.logger = logger ?? Debug.unityLogger;
+            this.logger = logger;
 
             EndPoint = endPoint ?? throw new ArgumentNullException(nameof(endPoint));
             this.dataHandler = dataHandler ?? throw new ArgumentNullException(nameof(dataHandler));
@@ -268,7 +268,7 @@ namespace Mirage.SocketLayer
         }
         internal void Disconnect(DisconnectReason reason, bool sendToOther = true)
         {
-            if (logger.filterLogType == LogType.Log) logger.Log($"Disconnect with reason: {reason}");
+            if (logger.Enabled(LogType.Log)) logger.Log($"Disconnect with reason: {reason}");
             switch (State)
             {
                 case ConnectionState.Connecting:
@@ -343,7 +343,7 @@ namespace Mirage.SocketLayer
 
             // copy first
             int copyLength = received.length - 1;
-            logger.Assert(copyLength == ackSystem.SizePerFragment, "First should be max size");
+            logger?.Assert(copyLength == ackSystem.SizePerFragment, "First should be max size");
             Buffer.BlockCopy(firstArray, 1, message, 0, copyLength);
             received.buffer.Release();
 
@@ -354,7 +354,7 @@ namespace Mirage.SocketLayer
                 AckSystem.ReliableReceived next = ackSystem.GetNextFragment();
                 byte[] nextArray = next.buffer.array;
 
-                logger.Assert(i == (fragmentLength - 1 - nextArray[0]), "fragment index should decrement each time");
+                logger?.Assert(i == (fragmentLength - 1 - nextArray[0]), "fragment index should decrement each time");
 
                 // +1 because first is copied above
                 copyLength = next.length - 1;

--- a/Assets/Mirage/Runtime/SocketLayer/LoggerExtensions.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/LoggerExtensions.cs
@@ -8,17 +8,22 @@ namespace Mirage.SocketLayer
         {
             if (!condition) logger.Log(LogType.Assert, "Failed Assertion");
         }
-        internal static void Assert<T>(this ILogger logger, bool condition, T msg )
+        internal static void Assert<T>(this ILogger logger, bool condition, T msg)
         {
             if (!condition) logger.Log(LogType.Assert, $"Failed Assertion: {msg}");
         }
         internal static void Error<T>(this ILogger logger, T msg = default)
         {
-             logger.Log(LogType.Error, msg);
+            logger.Log(LogType.Error, msg);
         }
         internal static void Warn<T>(this ILogger logger, T msg = default)
         {
             logger.Log(LogType.Warning, msg);
+        }
+
+        internal static bool Enabled(this ILogger logger, LogType logType)
+        {
+            return logger != null && logger.IsLogTypeAllowed(logType);
         }
     }
 }

--- a/Assets/Mirage/Runtime/SocketLayer/Peer.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Peer.cs
@@ -61,7 +61,7 @@ namespace Mirage.SocketLayer
 
         public Peer(ISocket socket, IDataHandler dataHandler, Config config = null, ILogger logger = null, Metrics metrics = null)
         {
-            this.logger = logger ?? Debug.unityLogger;
+            this.logger = logger;
             this.metrics = metrics;
             this.config = config ?? new Config();
 
@@ -109,7 +109,7 @@ namespace Mirage.SocketLayer
         {
             if (!active)
             {
-                if (logger.IsLogTypeAllowed(LogType.Warning)) logger.Log(LogType.Warning, "Peer is not active");
+                if (logger.Enabled(LogType.Warning)) logger.Log(LogType.Warning, "Peer is not active");
                 return;
             }
             active = false;
@@ -130,13 +130,13 @@ namespace Mirage.SocketLayer
         {
             // connecting connections can send connect messages so is allowed
             // todo check connected before message are sent from high level
-            logger.Assert(connection.State == ConnectionState.Connected || connection.State == ConnectionState.Connecting || connection.State == ConnectionState.Disconnected, connection.State);
+            logger?.Assert(connection.State == ConnectionState.Connected || connection.State == ConnectionState.Connecting || connection.State == ConnectionState.Disconnected, connection.State);
 
             socket.Send(connection.EndPoint, data, length);
             metrics?.OnSend(length);
             connection.SetSendTime();
 
-            if (logger.filterLogType == LogType.Log)
+            if (logger.Enabled(LogType.Log))
             {
                 if ((PacketType)data[0] == PacketType.Command)
                 {
@@ -169,7 +169,7 @@ namespace Mirage.SocketLayer
 
                 socket.Send(endPoint, buffer.array, length);
                 metrics?.OnSendUnconnected(length);
-                if (logger.filterLogType == LogType.Log)
+                if (logger.Enabled(LogType.Log))
                 {
                     logger.Log($"Send to {endPoint} type: Command, {command}");
                 }
@@ -275,14 +275,14 @@ namespace Mirage.SocketLayer
             // ingore message of invalid size
             if (!packet.IsValidSize())
             {
-                if (logger.filterLogType == LogType.Log)
+                if (logger.Enabled(LogType.Log))
                 {
                     logger.Log($"Receive from {connection} was too small");
                 }
                 return;
             }
 
-            if (logger.filterLogType == LogType.Log)
+            if (logger.Enabled(LogType.Log))
             {
                 if (packet.type == PacketType.Command)
                 {
@@ -303,7 +303,7 @@ namespace Mirage.SocketLayer
                     connection.SetReceiveTime();
 
                 }
-                else if (logger.filterLogType == LogType.Warning) logger.Log(LogType.Warning, $"Receive from {connection} type: {packet.type} while not connected");
+                else if (logger.Enabled(LogType.Warning)) logger.Log(LogType.Warning, $"Receive from {connection} type: {packet.type} while not connected");
 
                 // ignore other messages if not connected
                 return;
@@ -412,7 +412,7 @@ namespace Mirage.SocketLayer
         }
         private void AcceptNewConnection(IEndPoint endPoint)
         {
-            if (logger.IsLogTypeAllowed(LogType.Log)) logger.Log($"Accepting new connection from:{endPoint}");
+            if (logger.Enabled(LogType.Log)) logger.Log($"Accepting new connection from:{endPoint}");
 
             Connection connection = CreateNewConnection(endPoint);
 
@@ -448,7 +448,7 @@ namespace Mirage.SocketLayer
                     break;
 
                 case ConnectionState.Connecting:
-                    logger.Error($"Server connections should not be in {nameof(ConnectionState.Connecting)} state");
+                    logger?.Error($"Server connections should not be in {nameof(ConnectionState.Connecting)} state");
                     break;
             }
         }
@@ -465,7 +465,7 @@ namespace Mirage.SocketLayer
             switch (connection.State)
             {
                 case ConnectionState.Created:
-                    logger.Error($"Accepted Connections should not be in {nameof(ConnectionState.Created)} state");
+                    logger?.Error($"Accepted Connections should not be in {nameof(ConnectionState.Created)} state");
                     break;
 
                 case ConnectionState.Connected:
@@ -488,7 +488,7 @@ namespace Mirage.SocketLayer
                     break;
 
                 default:
-                    logger.Error($"Rejected Connections should not be in {nameof(ConnectionState.Created)} state");
+                    logger?.Error($"Rejected Connections should not be in {nameof(ConnectionState.Created)} state");
                     break;
             }
         }
@@ -513,7 +513,7 @@ namespace Mirage.SocketLayer
 
         internal void FailedToConnect(Connection connection, RejectReason reason)
         {
-            if (logger.IsLogTypeAllowed(LogType.Warning)) logger.Log(LogType.Warning, $"Connection Failed to connect: {reason}");
+            if (logger.Enabled(LogType.Warning)) logger.Log(LogType.Warning, $"Connection Failed to connect: {reason}");
 
             RemoveConnection(connection);
 
@@ -524,7 +524,7 @@ namespace Mirage.SocketLayer
         internal void RemoveConnection(Connection connection)
         {
             // shouldn't be trying to removed a destroyed connected
-            logger.Assert(connection.State != ConnectionState.Destroyed && connection.State != ConnectionState.Removing);
+            logger?.Assert(connection.State != ConnectionState.Destroyed && connection.State != ConnectionState.Removing);
 
             connection.State = ConnectionState.Removing;
             connectionsToRemove.Add(connection);
@@ -563,7 +563,7 @@ namespace Mirage.SocketLayer
                 // value should be removed from dictionary
                 if (!removed)
                 {
-                    logger.Error($"Failed to remove {connection} from connection set");
+                    logger?.Error($"Failed to remove {connection} from connection set");
                 }
             }
             connectionsToRemove.Clear();

--- a/Assets/Mirage/Runtime/SocketLayer/Pool.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Pool.cs
@@ -44,7 +44,7 @@ namespace Mirage.SocketLayer
                 Put(CreateNewBuffer());
             }
 
-            if (logger.IsLogTypeAllowed(LogType.Log)) logger.Log(LogType.Log, $"Configuring buffer, start Size {startPoolSize}, max size {maxPoolSize}");
+            if (logger.Enabled(LogType.Log)) logger.Log(LogType.Log, $"Configuring buffer, start Size {startPoolSize}, max size {maxPoolSize}");
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Mirage.SocketLayer
 
             this.bufferSize = bufferSize;
             this.maxPoolSize = maxPoolSize;
-            this.logger = logger ?? Debug.unityLogger;
+            this.logger = logger;
 
             pool = new T[maxPoolSize];
             for (int i = 0; i < startPoolSize; i++)
@@ -125,7 +125,7 @@ namespace Mirage.SocketLayer
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void CheckLimit(Pool<T> pool)
             {
-                if (pool.created >= pool.maxPoolSize && pool.logger.IsLogTypeAllowed(LogType.Warning))
+                if (pool.created >= pool.maxPoolSize && pool.logger.Enabled(LogType.Warning))
                 {
                     float now = GetTime();
 


### PR DESCRIPTION
Allowing peer logger to be null. if it is null then nothing will be logged