### PR TITLE
refactor: replacing MessagePacker.GetMessageType with property

### DIFF
--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using Mirage.Logging;
 using Mirage.Serialization;
 using UnityEngine;
@@ -95,14 +94,13 @@ namespace Mirage
             }
             else
             {
-                try
+                if (MessagePacker.MessageTypes.TryGetValue(msgType, out Type type))
                 {
-                    Type type = MessagePacker.GetMessageType(msgType);
-                    throw new InvalidDataException($"Unexpected message {type} received from {player}. Did you register a handler for it?");
+                    logger.Log($"Unexpected message {type} received from {player}. Did you register a handler for it?");
                 }
-                catch (KeyNotFoundException)
+                else
                 {
-                    throw new InvalidDataException($"Unexpected message ID {msgType} received from {player}. May be due to no existing RegisterHandler for this message.");
+                    logger.Log($"Unexpected message ID {msgType} received from {player}. May be due to no existing RegisterHandler for this message.");
                 }
             }
         }
@@ -129,10 +127,6 @@ namespace Mirage
                 {
                     int msgType = MessagePacker.UnpackId(networkReader);
                     InvokeHandler(player, msgType, networkReader);
-                }
-                catch (InvalidDataException ex)
-                {
-                    logger.Log(ex.ToString());
                 }
                 catch (Exception e)
                 {

--- a/Assets/Mirage/Runtime/Serialization/MessagePacker.cs
+++ b/Assets/Mirage/Runtime/Serialization/MessagePacker.cs
@@ -17,14 +17,22 @@ namespace Mirage.Serialization
     public static class MessagePacker
     {
         /// <summary>
-        /// Map of Message Id => Type
-        /// When we receive a message, we can lookup here to find out what type
-        /// it was.  This is populated by the weaver.
+        /// Backing field for <see cref="MessageTypes"/>
         /// </summary>
         private static readonly Dictionary<int, Type> messageTypes = new Dictionary<int, Type>();
 
-        public static Type GetMessageType(int id) => messageTypes[id];
+        /// <summary>
+        /// Map of Message Id => Type
+        /// When we receive a message, we can lookup here to find out what type it was.
+        /// This is populated by the weaver.
+        /// </summary>
+        public static IReadOnlyDictionary<int, Type> MessageTypes => messageTypes;
 
+        /// <summary>
+        /// Registers a message with its ID, Useful for debugging if a message handler is missing
+        /// <para>Used by weaver</para>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
         public static void RegisterMessage<T>()
         {
             int id = GetId<T>();

--- a/Assets/Tests/Runtime/MessagePackerTest.cs
+++ b/Assets/Tests/Runtime/MessagePackerTest.cs
@@ -115,7 +115,7 @@ namespace Mirage.Tests.Runtime.Serialization
 
             int id = MessagePacker.GetId<SomeRandomMessage>();
 
-            Type type = MessagePacker.GetMessageType(id);
+            Type type = MessagePacker.MessageTypes[id];
 
             Assert.That(type, Is.EqualTo(typeof(SomeRandomMessage)));
         }
@@ -138,7 +138,7 @@ namespace Mirage.Tests.Runtime.Serialization
         public void FindSystemMessage()
         {
             int id = MessagePacker.GetId<SceneMessage>();
-            Type type = MessagePacker.GetMessageType(id);
+            Type type = MessagePacker.MessageTypes[id];
             Assert.That(type, Is.EqualTo(typeof(SceneMessage)));
         }
 
@@ -151,7 +151,7 @@ namespace Mirage.Tests.Runtime.Serialization
             int id = MessagePacker.GetId(typeof(SomeRandomMessageNotRegistered));
             Assert.Throws<KeyNotFoundException>(() =>
             {
-                _ = MessagePacker.GetMessageType(id);
+                _ = MessagePacker.MessageTypes[id];
             });
         }
     }


### PR DESCRIPTION
Adding a IReadOnlyDictionary property instead of get function. This allows methods like TryGetValue to also be used

BREAKING CHANGE: MessagePacker.GetMessageType replaced with property