### PR TITLE
fix: fixed welcome window change log parsing

### DIFF
--- a/Assets/Mirage/Editor/WelcomeWindow/Resources/Changelog.uxml
+++ b/Assets/Mirage/Editor/WelcomeWindow/Resources/Changelog.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
-    <ui:VisualElement name="Header" style="flex-wrap: nowrap; white-space: nowrap;">
-        <ui:Label text="Version" display-tooltip-when-elided="true" name="ChangeLogVersion" style="font-size: 20px; -unity-font-style: bold; flex-wrap: nowrap;" />
+    <ui:VisualElement name="ChangeSet" style="flex-wrap: nowrap; white-space: nowrap;">
+        <ui:Label text="Version" display-tooltip-when-elided="true" name="ChangeLogVersion" />
         <ui:Label display-tooltip-when-elided="true" name="ChangeLogText" style="-unity-font-style: normal; font-size: 12px; flex-wrap: nowrap; white-space: normal;" />
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uss
+++ b/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uss
@@ -47,6 +47,19 @@
     white-space: normal;
 }
 
+#ChangeSet {
+    padding-left: 10px;
+    padding-right: 10px;
+    margin-bottom: 15px;
+}
+
+#ChangeLogVersion {
+    font-size: 20px;
+    -unity-font-style: bold;
+    flex-wrap: nowrap;
+    margin-bottom: 5px;
+}
+
 #Description {
     font-size: 14px;
     -unity-text-align: upper-left;


### PR DESCRIPTION
There were some parsing issues with the welcome window change log, so I made some tweaks.
On 2021.2 it now looks like this (with Rich Text support)
![image](https://user-images.githubusercontent.com/9001218/147756970-e19f8c23-74f3-4d1b-ac2a-2b6750229925.png)

On 2020.1.17 it looks like this now:
![image](https://user-images.githubusercontent.com/9001218/147757035-9acf5fbc-af47-4d21-811e-4648644a1c6b.png)
