### PR TITLE
fix: fixing calls to interface for target RPCs

### DIFF
--- a/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ClientRpcProcessor.cs
@@ -71,7 +71,7 @@ namespace Mirage.Weaver
                 // the client should just get the connection to the server and pass that in
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
                 worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.Client));
-                worker.Append(worker.Create(OpCodes.Call, (NetworkClient nb) => nb.Player));
+                worker.Append(worker.Create(OpCodes.Callvirt, (INetworkClient nb) => nb.Player));
             }
 
             ReadArguments(md, worker, readerParameter, senderParameter: null, hasNetworkConnection, paramSerializers);
@@ -236,14 +236,14 @@ namespace Mirage.Weaver
                     // local connection to the server
                     worker.Append(worker.Create(OpCodes.Ldarg_0));
                     worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.Client));
-                    worker.Append(worker.Create(OpCodes.Call, (NetworkClient nc) => nc.Player));
+                    worker.Append(worker.Create(OpCodes.Callvirt, (INetworkClient nc) => nc.Player));
                 }
                 else
                 {
                     worker.Append(worker.Create(OpCodes.Ldarg, i + 1));
                 }
             }
-            worker.Append(worker.Create(OpCodes.Call, rpc));
+            worker.Append(worker.Create(OpCodes.Callvirt, rpc));
         }
         bool Validate(MethodDefinition md, CustomAttribute clientRpcAttr)
         {

--- a/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
+++ b/Assets/Mirage/Weaver/Processors/ServerRpcProcessor.cs
@@ -293,14 +293,14 @@ namespace Mirage.Weaver
                 {
                     worker.Append(worker.Create(OpCodes.Ldarg_0));
                     worker.Append(worker.Create(OpCodes.Call, (NetworkBehaviour nb) => nb.Server));
-                    worker.Append(worker.Create(OpCodes.Call, (NetworkServer server) => server.LocalPlayer));
+                    worker.Append(worker.Create(OpCodes.Callvirt, (INetworkServer server) => server.LocalPlayer));
                 }
                 else
                 {
                     worker.Append(worker.Create(OpCodes.Ldarg, param));
                 }
             }
-            worker.Append(worker.Create(OpCodes.Call, rpc));
+            worker.Append(worker.Create(OpCodes.Callvirt, rpc));
 
             bool IsNetworkPlayer(ParameterDefinition param)
             {


### PR DESCRIPTION
fixing IL2CPP build when using targetRPCs.
Also note that Callvirt should be used calling interfaces.

note for future debugging: cpp output on failed build `Mirage/Temp/StagingArea/Data/il2cppOutput`

fixes:https://github.com/MirageNet/Mirage/issues/1020