### PR TITLE
fix: fix welcome window packages tab displaying actual modules

### DIFF
--- a/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
+++ b/Assets/Mirage/Editor/WelcomeWindow/Resources/WelcomeWindow.uxml
@@ -58,17 +58,8 @@
                     <ui:Label name="Description" text="Mirage is a modular networking library. It ships with the foundation that you can build upon by installing packages." style="flex-basis: auto; flex-grow: 0; flex-shrink: 0;" />
                     <ui:Label text="Available Packages" display-tooltip-when-elided="True" style="padding-left: 10px; -unity-font-style: bold;" />
                     <ui:VisualElement name="ModulesList" style="flex-grow: 1; padding-left: 10px; padding-right: 10px;">
-                        <ui:VisualElement name="Module" tooltip="Automatically find games within the same network.">
-                            <ui:Label text="LAN Discovery" name="Name" />
-                            <ui:Button text="Install" name="InstallButton" class="installButton" />
-                        </ui:VisualElement>
-                        <ui:VisualElement name="Module" tooltip="A transport that uses Facepunch&apos;s Steam SDK.">
-                            <ui:Label text="Steam (Facepunch)" name="Name" />
-                            <ui:Button text="Install" name="InstallButton" class="installButton" />
-                        </ui:VisualElement>
-                        <ui:VisualElement name="Module" tooltip="A transport that uses Steamworks.NET.">
-                            <ui:Label text="Steam (Steamworks.NET)" name="Name" />
-                            <ui:Button text="Install" name="InstallButton" class="installButton" />
+                        <ui:VisualElement>
+                            <ui:Label text="Loading...." name="Name" />
                         </ui:VisualElement>
                     </ui:VisualElement>
                     <ui:VisualElement name="Spacer" />

--- a/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
+++ b/Assets/Mirage/Editor/WelcomeWindow/WelcomeWindow.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using Mirage.Logging;
@@ -145,19 +144,6 @@ namespace Mirage
         //the code to handle display and button clicking
         private void OnEnable()
         {
-            // Might need to do this later on if we go to asset store.
-            // Packages read off of the scoped registry which if we use asset store release wont have this.
-            MethodInfo unityMethod = typeof(Client).GetMethod("AddScopedRegistry",
-                BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic, null,
-                new[] { typeof(string), typeof(string), typeof(string[]) }, null);
-
-            unityMethod.Invoke(this, new object[]
-                {
-                    "Mirage",
-                    "https://package.openupm.com",
-                    new[]{ "com.miragenet", "com.cysharp.unitask"}
-                });
-
             changeLogPath = AssetDatabase.GetAssetPath(MonoScript.FromScriptableObject(this)) + "/../../../CHANGELOG.md";
 
             //Load the UI
@@ -515,6 +501,7 @@ namespace Mirage
                             displayName = package.displayName,
                             gitUrl = package.name,
                             packageName = package.name,
+                            tooltip = package.description,
                             installed = packageInstalled
                         });
                     }
@@ -550,7 +537,7 @@ namespace Mirage
                     name = module.displayName
                 };
 
-                var label = new Label(module.displayName) { style = { width = new StyleLength(200) } };
+                var label = new Label(module.displayName) { style = { width = new StyleLength(200) }, tooltip = module.tooltip };
 
                 containerElement.Add(label);
                 containerElement.Add(moduleButton);
@@ -570,6 +557,7 @@ namespace Mirage
         public string displayName;
         public string packageName;
         public string gitUrl;
+        public string tooltip;
         public bool installed;
     }
 }


### PR DESCRIPTION
This actually now properly displays all modules that are built off of com.miragenet. This can install / uninstall from packages tab from welcome window.

Atm there is one hiccup some old packages still being displayed. I think we need to delete the repo for them but I don't have permission to delete them.

![image](https://user-images.githubusercontent.com/11801941/149642200-330ff2a9-cd68-4e8b-aeb0-1f928989894c.png)