### PR TITLE
feat(NetworkSceneManager)!: return scene instead of strings from events

### DIFF
--- a/Assets/Mirage/Runtime/CharacterSpawner.cs
+++ b/Assets/Mirage/Runtime/CharacterSpawner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Mirage.Logging;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
 
 namespace Mirage
@@ -100,9 +101,9 @@ namespace Mirage
         /// Called on the client when a normal scene change happens.
         /// <para>The default implementation of this function sets the client as ready and adds a player. Override the function to dictate what happens when the client connects.</para>
         /// </summary>
-        /// <param name="scenePath"></param>
+        /// <param name="scene"></param>
         /// <param name="sceneOperation">The type of scene load that happened.</param>
-        public virtual void OnClientFinishedSceneChange(string scenePath, SceneOperation sceneOperation)
+        public virtual void OnClientFinishedSceneChange(Scene scene, SceneOperation sceneOperation)
         {
             if (AutoSpawn && sceneOperation == SceneOperation.Normal)
                 RequestServerSpawnPlayer();

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -6,6 +6,7 @@ using Mirage.Logging;
 using Mirage.RemoteCalls;
 using Mirage.Serialization;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
 
 namespace Mirage
@@ -26,11 +27,11 @@ namespace Mirage
         internal readonly Dictionary<int, SpawnHandlerDelegate> spawnHandlers = new Dictionary<int, SpawnHandlerDelegate>();
         internal readonly Dictionary<int, UnSpawnDelegate> unspawnHandlers = new Dictionary<int, UnSpawnDelegate>();
 
-        [Header("Prefabs")]
         /// <summary>
         /// List of prefabs that will be registered with the spawning system.
         /// <para>For each of these prefabs, ClientManager.RegisterPrefab() will be automatically invoke.</para>
         /// </summary>
+        [Header("Prefabs")]
         public List<NetworkIdentity> spawnPrefabs = new List<NetworkIdentity>();
 
         /// <summary>
@@ -114,7 +115,7 @@ namespace Mirage
             syncVarReceiver = null;
         }
 
-        void OnFinishedSceneChange(string scenePath, SceneOperation sceneOperation)
+        void OnFinishedSceneChange(Scene scene, SceneOperation sceneOperation)
         {
             Client.World.RemoveDestroyedObjects();
 

--- a/Assets/Mirage/Runtime/INetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/INetworkSceneManager.cs
@@ -13,11 +13,17 @@ namespace Mirage
     }
 
     /// <summary>
-    /// Event fires from <see cref="INetworkSceneManager">INetworkSceneManager</see> when a scene change happens on either Server or Client.
+    /// Event fires from <see cref="INetworkSceneManager">INetworkSceneManager</see> when a scene change finishes on either Server or Client.
     /// <para>Scene - Loaded scene</para>
     /// <para>SceneOperation - Scene change type (Normal, Additive Load, Additive Unload).</para>
     /// </summary>
     [Serializable] public class SceneChangeFinishedEvent : UnityEvent<Scene, SceneOperation> { }
+
+    /// <summary>
+    /// Event fires from <see cref="INetworkSceneManager">INetworkSceneManager</see> when a scene change begins on either Server or Client.
+    /// <para>Scene - Name or path of the scene that's about to be loaded</para>
+    /// <para>SceneOperation - Scene change type (Normal, Additive Load, Additive Unload).</para>
+    /// </summary>
     [Serializable] public class SceneChangeStartedEvent : UnityEvent<string, SceneOperation> { }
 
     [Serializable] public class PlayerSceneChangeEvent : UnityEvent<INetworkPlayer> { }

--- a/Assets/Mirage/Runtime/INetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/INetworkSceneManager.cs
@@ -14,10 +14,11 @@ namespace Mirage
 
     /// <summary>
     /// Event fires from <see cref="INetworkSceneManager">INetworkSceneManager</see> when a scene change happens on either Server or Client.
-    /// <para>string - New ScenePath</para>
+    /// <para>Scene - Loaded scene</para>
     /// <para>SceneOperation - Scene change type (Normal, Additive Load, Additive Unload).</para>
     /// </summary>
-    [Serializable] public class SceneChangeEvent : UnityEvent<string, SceneOperation> { }
+    [Serializable] public class SceneChangeFinishedEvent : UnityEvent<Scene, SceneOperation> { }
+    [Serializable] public class SceneChangeStartedEvent : UnityEvent<string, SceneOperation> { }
 
     [Serializable] public class PlayerSceneChangeEvent : UnityEvent<INetworkPlayer> { }
 
@@ -26,22 +27,22 @@ namespace Mirage
         /// <summary>
         /// Event fires when the Client starts changing scene.
         /// </summary>
-        SceneChangeEvent OnClientStartedSceneChange { get; }
+        SceneChangeStartedEvent OnClientStartedSceneChange { get; }
 
         /// <summary>
         /// Event fires after the Client has completed its scene change.
         /// </summary>
-        SceneChangeEvent OnClientFinishedSceneChange { get; }
+        SceneChangeFinishedEvent OnClientFinishedSceneChange { get; }
 
         /// <summary>
         /// Event fires before Server changes scene.
         /// </summary>
-        SceneChangeEvent OnServerStartedSceneChange { get; }
+        SceneChangeStartedEvent OnServerStartedSceneChange { get; }
 
         /// <summary>
         /// Event fires after Server has completed scene change.
         /// </summary>
-        SceneChangeEvent OnServerFinishedSceneChange { get; }
+        SceneChangeFinishedEvent OnServerFinishedSceneChange { get; }
 
         /// <summary>
         /// Event fires On the server, after Client sends <see cref="SceneReadyMessage"/> to the server

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -5,6 +5,7 @@ using Mirage.Logging;
 using Mirage.RemoteCalls;
 using Mirage.Serialization;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
 
 namespace Mirage
@@ -92,7 +93,7 @@ namespace Mirage
             nextNetworkId = 1;
         }
 
-        void OnFinishedSceneChange(string scenePath, SceneOperation sceneOperation)
+        void OnFinishedSceneChange(Scene scene, SceneOperation sceneOperation)
         {
             Server.World.RemoveDestroyedObjects();
 

--- a/Assets/Mirage/Samples~/ChangeScene/Prefabs/ServerOnlySceneObject Variant.prefab
+++ b/Assets/Mirage/Samples~/ChangeScene/Prefabs/ServerOnlySceneObject Variant.prefab
@@ -7,81 +7,95 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
-      propertyPath: m_Color.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_Color.r
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: sceneId
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: serverOnly
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
-      propertyPath: _prefabHash
-      value: -192834059
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
+      propertyPath: m_AssetId
+      value:
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344372, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+    - target: {fileID: 1818873914431344372, guid: 685b07ee95b6b6b4db30b2440e670157,
+        type: 3}
       propertyPath: m_Name
-      value: ServerOnlySceneObject Variant
+      value: ServerOnlySceneObject
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}

--- a/Assets/Mirage/Samples~/ChangeScene/Prefabs/ServerOnlySceneObject Variant.prefab
+++ b/Assets/Mirage/Samples~/ChangeScene/Prefabs/ServerOnlySceneObject Variant.prefab
@@ -7,95 +7,81 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344369, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344370, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: sceneId
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
-      propertyPath: serverOnly
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 1818873914431344372, guid: 685b07ee95b6b6b4db30b2440e670157,
-        type: 3}
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: serverOnly
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+      propertyPath: _prefabHash
+      value: -192834059
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818873914431344372, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
       propertyPath: m_Name
-      value: ServerOnlySceneObject
+      value: ServerOnlySceneObject Variant
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}

--- a/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerNonHostTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkSceneManagerNonHostTests.cs
@@ -53,11 +53,11 @@ namespace Mirage.Tests.Runtime.ClientServer
         [Test]
         public void FinishLoadSceneTest()
         {
-            UnityAction<string, SceneOperation> func2 = Substitute.For<UnityAction<string, SceneOperation>>();
+            UnityAction<Scene, SceneOperation> func2 = Substitute.For<UnityAction<Scene, SceneOperation>>();
             clientSceneManager.OnClientFinishedSceneChange.AddListener(func2);
-            clientSceneManager.CompleteLoadingScene("Assets/Mirror/Tests/Runtime/testScene.unity", SceneOperation.Normal);
+            clientSceneManager.CompleteLoadingScene(default, SceneOperation.Normal);
 
-            func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
+            func2.Received(1).Invoke(Arg.Any<Scene>(), Arg.Any<SceneOperation>());
         }
 
         [UnityTest]
@@ -141,10 +141,10 @@ namespace Mirage.Tests.Runtime.ClientServer
         [Test]
         public void ServerSceneChangedTest()
         {
-            UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
+            UnityAction<Scene, SceneOperation> func1 = Substitute.For<UnityAction<Scene, SceneOperation>>();
             serverSceneManager.OnServerFinishedSceneChange.AddListener(func1);
-            serverSceneManager.OnServerFinishedSceneChange.Invoke("test", SceneOperation.Normal);
-            func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
+            serverSceneManager.OnServerFinishedSceneChange.Invoke(default, SceneOperation.Normal);
+            func1.Received(1).Invoke(Arg.Any<Scene>(), Arg.Any<SceneOperation>());
         }
 
         [Test]
@@ -154,10 +154,10 @@ namespace Mirage.Tests.Runtime.ClientServer
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
             {
-                clientSceneManager.OnClientSceneLoadFinished(null, SceneOperation.Normal);
+                clientSceneManager.OnClientSceneLoadFinished(default, SceneOperation.Normal);
             });
 
-            string message = new ArgumentNullException("scenePath", "Some how a null scene path has been entered.").Message;
+            string message = new ArgumentNullException(default, "Some how a null scene path has been entered.").Message;
             Assert.That(exception, Has.Message.EqualTo(message));
         }
 
@@ -173,7 +173,7 @@ namespace Mirage.Tests.Runtime.ClientServer
         });
 
         bool noAdditiveScenesFound;
-        void CheckForPendingAdditiveSceneList(string scenePath, SceneOperation sceneOperation)
+        void CheckForPendingAdditiveSceneList(Scene scene, SceneOperation sceneOperation)
         {
             if (clientSceneManager.ClientPendingAdditiveSceneLoadingList.Count == 0)
             {

--- a/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/Host/NetworkSceneManagerTests.cs
@@ -17,13 +17,13 @@ namespace Mirage.Tests.Runtime.Host
     {
         AssetBundle bundle;
 
-        UnityAction<string, SceneOperation> sceneEventFunction;
+        UnityAction<Scene, SceneOperation> sceneEventFunction;
 
         public override void ExtraSetup()
         {
             bundle = AssetBundle.LoadFromFile("Assets/Tests/Runtime/TestScene/testscene");
 
-            sceneEventFunction = Substitute.For<UnityAction<string, SceneOperation>>();
+            sceneEventFunction = Substitute.For<UnityAction<Scene, SceneOperation>>();
             sceneManager.OnServerFinishedSceneChange.AddListener(sceneEventFunction);
         }
 
@@ -35,22 +35,22 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void FinishLoadSceneHostTest()
         {
-            UnityAction<string, SceneOperation> func2 = Substitute.For<UnityAction<string, SceneOperation>>();
-            UnityAction<string, SceneOperation> func3 = Substitute.For<UnityAction<string, SceneOperation>>();
+            UnityAction<Scene, SceneOperation> func2 = Substitute.For<UnityAction<Scene, SceneOperation>>();
+            UnityAction<Scene, SceneOperation> func3 = Substitute.For<UnityAction<Scene, SceneOperation>>();
 
             sceneManager.OnServerFinishedSceneChange.AddListener(func2);
             sceneManager.OnClientFinishedSceneChange.AddListener(func3);
 
-            sceneManager.CompleteLoadingScene("test", SceneOperation.Normal);
+            sceneManager.CompleteLoadingScene(default, SceneOperation.Normal);
 
-            func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
-            func3.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
+            func2.Received(1).Invoke(Arg.Any<Scene>(), Arg.Any<SceneOperation>());
+            func3.Received(1).Invoke(Arg.Any<Scene>(), Arg.Any<SceneOperation>());
         }
 
         [UnityTest]
         public IEnumerator FinishLoadServerOnlyTest() => UniTask.ToCoroutine(async () =>
         {
-            UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
+            UnityAction<Scene, SceneOperation> func1 = Substitute.For<UnityAction<Scene, SceneOperation>>();
 
             client.Disconnect();
 
@@ -58,9 +58,9 @@ namespace Mirage.Tests.Runtime.Host
 
             sceneManager.OnServerFinishedSceneChange.AddListener(func1);
 
-            sceneManager.CompleteLoadingScene("test", SceneOperation.Normal);
+            sceneManager.CompleteLoadingScene(default, SceneOperation.Normal);
 
-            func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
+            func1.Received(1).Invoke(Arg.Any<Scene>(), Arg.Any<SceneOperation>());
         });
 
         [UnityTest]
@@ -86,7 +86,7 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void ServerChangedFiredOnceTest()
         {
-            sceneEventFunction.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
+            sceneEventFunction.Received(1).Invoke(Arg.Any<Scene>(), Arg.Any<SceneOperation>());
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace Mirage.Tests.Runtime.Host
             UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
             sceneManager.OnClientStartedSceneChange.AddListener(func1);
 
-            sceneManager.OnClientStartedSceneChange.Invoke("", SceneOperation.Normal);
+            sceneManager.OnClientStartedSceneChange.Invoke(default, SceneOperation.Normal);
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
@@ -138,18 +138,18 @@ namespace Mirage.Tests.Runtime.Host
         [Test]
         public void ClientSceneChangedTest()
         {
-            UnityAction<string, SceneOperation> func1 = Substitute.For<UnityAction<string, SceneOperation>>();
+            UnityAction<Scene, SceneOperation> func1 = Substitute.For<UnityAction<Scene, SceneOperation>>();
             sceneManager.OnClientFinishedSceneChange.AddListener(func1);
-            sceneManager.OnClientFinishedSceneChange.Invoke("test", SceneOperation.Normal);
-            func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
+            sceneManager.OnClientFinishedSceneChange.Invoke(default, SceneOperation.Normal);
+            func1.Received(1).Invoke(Arg.Any<Scene>(), Arg.Any<SceneOperation>());
         }
 
         [Test]
         public void ClientSceneReadyAfterChangedTest()
         {
             bool _readyAfterSceneChanged = false;
-            sceneManager.OnClientFinishedSceneChange.AddListener((string name, SceneOperation operation) => _readyAfterSceneChanged = client.Player.SceneIsReady);
-            sceneManager.OnClientFinishedSceneChange.Invoke("test", SceneOperation.Normal);
+            sceneManager.OnClientFinishedSceneChange.AddListener((Scene scene, SceneOperation operation) => _readyAfterSceneChanged = client.Player.SceneIsReady);
+            sceneManager.OnClientFinishedSceneChange.Invoke(default, SceneOperation.Normal);
 
             Assert.That(_readyAfterSceneChanged, Is.True);
         }


### PR DESCRIPTION
started events still take string, but finished events now return the loaded scene

resolves: #1026 

BREAKING CHANGE: 
- Scene finished loading events now return scene
- SceneChangeEvent class renamed to SceneChangeStartedEvent and SceneChangeFinishedEvent