### PR TITLE
refactor: making networkidentity references readonly in inspector

### DIFF
--- a/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs
+++ b/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs
@@ -1,0 +1,21 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace Mirage
+{
+    [CustomPropertyDrawer(typeof(ReadOnlyInspectorAttribute))]
+    public class ReadOnlyDecoratorDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            GUI.enabled = false;
+            EditorGUI.PropertyField(position, property, label, true);
+            GUI.enabled = true;
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+    }
+}

--- a/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs.meta
+++ b/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c05c2e7b29e25248b9d21fec72ba9f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/CustomAttributes.cs
+++ b/Assets/Mirage/Runtime/CustomAttributes.cs
@@ -133,4 +133,10 @@ namespace Mirage
     /// </summary>
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class FoldoutEventAttribute : PropertyAttribute { }
+
+    /// <summary>
+    /// Draws UnityEvent as a foldout
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class ReadOnlyInspectorAttribute : PropertyAttribute { }
 }

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -193,6 +193,8 @@ namespace Mirage
         /// <summary>
         /// The ServerObjectManager is present only for server/host instances.
         /// </summary>
+        [ReadOnlyInspector]
+        [Tooltip("Reference to Server set after the object is spawned. Used when debugging to see which server this object belongs to.")]
         public ServerObjectManager ServerObjectManager;
 
         /// <summary>
@@ -203,6 +205,8 @@ namespace Mirage
         /// <summary>
         /// The ClientObjectManager is present only for client instances.
         /// </summary>
+        [ReadOnlyInspector]
+        [Tooltip("Reference to Client set after the object is spawned. Used when debugging to see which client this object belongs to.")]
         public ClientObjectManager ClientObjectManager;
 
         INetworkPlayer _owner;


### PR DESCRIPTION
avoids confusion with users thinking they need to be set by them

![image](https://user-images.githubusercontent.com/23101891/150194631-ef733f43-e96d-4237-a04e-b472d1de41ab.png)
