### PR TITLE
feat(SocketLayer)!: adding conection key based on mirage version

### DIFF
--- a/Assets/Mirage/Runtime/ClientStoppedReason.cs
+++ b/Assets/Mirage/Runtime/ClientStoppedReason.cs
@@ -14,6 +14,8 @@ namespace Mirage
     [Serializable]
     public enum ClientStoppedReason
     {
+        // IMPORTANT: When adding new values, check all numbers, they might not be in order!
+
         /// <summary>No reason given</summary>
         None = 0,
 
@@ -33,6 +35,8 @@ namespace Mirage
         ConnectingTimeout = 5,
         /// <summary>Disconnect called locally before server replies with connected</summary>
         ConnectingCancel = 6,
+        /// <summary>Key given with first message did not match the value on the server, See SocketLayer Config</summary>
+        KeyInvalid = 9,
 
         /// <summary>Disconnect called when server was stopped in host mode</summary>
         HostModeStopped = 7,
@@ -62,6 +66,7 @@ namespace Mirage
                 case RejectReason.None: return ClientStoppedReason.None;
                 case RejectReason.Timeout: return ClientStoppedReason.ConnectingTimeout;
                 case RejectReason.ServerFull: return ClientStoppedReason.ServerFull;
+                case RejectReason.KeyInvalid: return ClientStoppedReason.KeyInvalid;
                 case RejectReason.ClosedByPeer: return ClientStoppedReason.ConnectingCancel;
             }
         }

--- a/Assets/Mirage/Runtime/SocketLayer/Config.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Config.cs
@@ -37,6 +37,13 @@ namespace Mirage.SocketLayer
 
         #region shared
         /// <summary>
+        /// Key sent with connection message (defaults to Major version of assmebly)
+        /// <para>Used to validate that server and client are same application/version</para>
+        /// <para>NOTE: key will be ASCII encoded</para>
+        /// </summary>
+        public string key = null;
+
+        /// <summary>
         /// How long after disconnect before connection is fully removed from Peer
         /// </summary>
         public float DisconnectDuration = 1;

--- a/Assets/Mirage/Runtime/SocketLayer/Enums/RejectReason.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Enums/RejectReason.cs
@@ -24,5 +24,10 @@ namespace Mirage.SocketLayer
         /// Closed called locally before connect
         /// </summary>
         ClosedByPeer = 3,
+
+        /// <summary>
+        /// Key given with first message did not match the value on the server
+        /// </summary>
+        KeyInvalid = 4,
     }
 }

--- a/Assets/Tests/Runtime/ClientServer/NetworkClientDisconnectTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkClientDisconnectTest.cs
@@ -151,6 +151,7 @@ namespace Mirage.Tests.Runtime.ClientServer.DisconnectTests
             Assert.That(called, Is.EqualTo(1));
         }
     }
+
     public class NetworkClientConnectFailedTest : ClientServerSetup<MockComponent>
     {
         protected override bool AutoConnectClient => false;
@@ -203,6 +204,32 @@ namespace Mirage.Tests.Runtime.ClientServer.DisconnectTests
 
             // stop connecting
             client.Disconnect();
+
+            // wait 2 frames so that messages can go from client->server->client
+            yield return null;
+            yield return null;
+
+            Assert.That(called, Is.EqualTo(1));
+        }
+    }
+
+    public class NetworkClientConnectFailedBadKeyTest : ClientServerSetup<MockComponent>
+    {
+        protected override Config ServerConfig => new Config { key = "Server Key" };
+        protected override Config ClientConfig => new Config { key = "Client Key" };
+        protected override bool AutoConnectClient => false;
+
+        [UnityTest]
+        public IEnumerator DisconnectEventWhenFull()
+        {
+            client.Connect("localhost");
+
+            int called = 0;
+            client.Disconnected.AddListener((reason) =>
+            {
+                called++;
+                Assert.That(reason, Is.EqualTo(ClientStoppedReason.KeyInvalid));
+            });
 
             // wait 2 frames so that messages can go from client->server->client
             yield return null;

--- a/Assets/Tests/SocketLayer/ConnectKeyValidatorTest.cs
+++ b/Assets/Tests/SocketLayer/ConnectKeyValidatorTest.cs
@@ -3,11 +3,63 @@ using NUnit.Framework;
 namespace Mirage.SocketLayer.Tests
 {
     [Category("SocketLayer")]
+    [TestFixture("hello")]
+    [TestFixture("Mirage V123")]
     public class ConnectKeyValidatorTest
     {
-        [Test] public void KeyIsSameEachCall() { Assert.Ignore("not implemented"); }
-        [Test] public void ValidateReturnsTrueIfKeyIsCorrect() { Assert.Ignore("not implemented"); }
-        [Test] public void ValidateReturnsFalseIfKeyIsCorrect() { Assert.Ignore("not implemented"); }
-        [Test] public void CopySetsKeyIn2ndElementOfBuffer() { Assert.Ignore("not implemented"); }
+        ConnectKeyValidator validator;
+
+        public ConnectKeyValidatorTest(string key)
+        {
+            validator = new ConnectKeyValidator(key);
+        }
+
+        [Test]
+        public void KeyIsSameEachCall()
+        {
+            byte[] buffer1 = new byte[50];
+            byte[] buffer2 = new byte[50];
+            validator.CopyTo(buffer1);
+            validator.CopyTo(buffer2);
+
+            Assert.That(buffer1, Is.EquivalentTo(buffer2), "buffers should have same values");
+        }
+
+        [Test]
+        public void ValidateReturnsTrueIfKeyIsCorrect()
+        {
+            byte[] buffer = new byte[50];
+            validator.CopyTo(buffer);
+
+            bool valid = validator.Validate(buffer);
+            Assert.IsTrue(valid);
+        }
+
+        [Test]
+        public void ValidateReturnsFalseIfKeyIsCorrect()
+        {
+            byte[] buffer = new byte[50];
+            validator.CopyTo(buffer);
+            // corrupt 1 byte
+            buffer[4] = 0;
+
+            bool valid = validator.Validate(buffer);
+            Assert.IsFalse(valid);
+        }
+
+        [Test]
+        [TestCase(1, 2)]
+        [TestCase(10, 220)]
+        public void DoesNotOverWriteFirst2Indexes(byte index1, byte index2)
+        {
+            // use tests cases so we check that it doesn't change atleast 2 sets of values
+            byte[] buffer = new byte[50];
+            buffer[0] = index1;
+            buffer[1] = index2;
+            validator.CopyTo(buffer);
+
+            Assert.That(buffer[0], Is.EqualTo(index1));
+            Assert.That(buffer[1], Is.EqualTo(index2));
+        }
     }
 }

--- a/Assets/Tests/SocketLayer/PeerTestBase.cs
+++ b/Assets/Tests/SocketLayer/PeerTestBase.cs
@@ -13,12 +13,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
     public class PeerTestBase
     {
         public const int maxConnections = 5;
-        protected static readonly byte[] connectRequest = new byte[3]
-        {
-            (byte)PacketType.Command,
-            (byte)Commands.ConnectRequest,
-            new ConnectKeyValidator().GetKey(),
-        };
+        protected byte[] connectRequest;
 
         PeerInstance instance;
         protected Action<IConnection> connectAction;
@@ -45,6 +40,17 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             peer.OnConnected += connectAction;
             peer.OnConnectionFailed += connectFailedAction;
             peer.OnDisconnected += disconnectAction;
+
+            CreateConnectPacket();
+        }
+
+        private void CreateConnectPacket()
+        {
+            var keyValidator = new ConnectKeyValidator(instance.config.key);
+            connectRequest = new byte[2 + keyValidator.KeyLength];
+            connectRequest[0] = (byte)PacketType.Command;
+            connectRequest[1] = (byte)Commands.ConnectRequest;
+            keyValidator.CopyTo(connectRequest);
         }
     }
 


### PR DESCRIPTION
This will ensure that client connecting is on the same major version as the client.

This key can be overriden by setting the value in Config

BREAKING CHANGE: Mismatched server/client versions will no longer be able to connect to each other