### PR TITLE
perf: moving replyId to its own message

### DIFF
--- a/Assets/Mirage/Runtime/Messages.cs
+++ b/Assets/Mirage/Runtime/Messages.cs
@@ -42,10 +42,21 @@ namespace Mirage
         public int componentIndex;
         public int functionIndex;
 
+        // the parameters for the Cmd function
+        // -> ArraySegment to avoid unnecessary allocations
+        public ArraySegment<byte> payload;
+    }
+
+    [NetworkMessage]
+    public struct ServerRpcWithReplyMessage
+    {
+        public uint netId;
+        public int componentIndex;
+        public int functionIndex;
+
         // if the server Rpc can return values
         // this then a ServerRpcReply will be sent with this id
-        // use nullable for syncing so sent as 1 bit if null, but 0 for no id else where in the code
-        public int? replyId;
+        public int replyId;
         // the parameters for the Cmd function
         // -> ArraySegment to avoid unnecessary allocations
         public ArraySegment<byte> payload;

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Mirage.Logging;
 using Mirage.RemoteCalls;
 using Mirage.Serialization;
@@ -71,6 +72,7 @@ namespace Mirage
         internal void RegisterMessageHandlers()
         {
             Server.MessageHandler.RegisterHandler<ServerRpcMessage>(OnServerRpcMessage);
+            Server.MessageHandler.RegisterHandler<ServerRpcWithReplyMessage>(OnServerRpcWithReplyMessage);
         }
 
         void OnServerStarted()
@@ -424,21 +426,30 @@ namespace Mirage
         /// </summary>
         /// <param name="player"></param>
         /// <param name="msg"></param>
+        void OnServerRpcWithReplyMessage(INetworkPlayer player, ServerRpcWithReplyMessage msg)
+        {
+            OnServerRpc(player, msg.netId, msg.componentIndex, msg.functionIndex, msg.payload, msg.replyId);
+        }
         void OnServerRpcMessage(INetworkPlayer player, ServerRpcMessage msg)
         {
-            if (!Server.World.TryGetIdentity(msg.netId, out NetworkIdentity identity))
+            OnServerRpc(player, msg.netId, msg.componentIndex, msg.functionIndex, msg.payload, default);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void OnServerRpc(INetworkPlayer player, uint netId, int componentIndex, int functionIndex, ArraySegment<byte> payload, int replyId)
+        {
+            if (!Server.World.TryGetIdentity(netId, out NetworkIdentity identity))
             {
-                if (logger.WarnEnabled()) logger.LogWarning("Spawned object not found when handling ServerRpc message [netId=" + msg.netId + "]");
+                if (logger.WarnEnabled()) logger.LogWarning($"Spawned object not found when handling ServerRpc message [netId={netId}]");
                 return;
             }
 
-            NetworkBehaviour behaviour = identity.NetworkBehaviours[msg.componentIndex];
+            NetworkBehaviour behaviour = identity.NetworkBehaviours[componentIndex];
 
-            RemoteCall remoteCall = behaviour.remoteCallCollection.Get(msg.functionIndex);
+            RemoteCall remoteCall = behaviour.remoteCallCollection.Get(functionIndex);
 
             if (remoteCall.InvokeType != RpcInvokeType.ServerRpc)
             {
-                throw new MethodInvocationException($"Invalid ServerRpc for index {msg.functionIndex}");
+                throw new MethodInvocationException($"Invalid ServerRpc for index {functionIndex}");
             }
 
             // ServerRpcs can be for player objects, OR other objects with client-authority
@@ -446,16 +457,16 @@ namespace Mirage
             //    only allow the ServerRpc if clientAuthorityOwner
             if (remoteCall.RequireAuthority && identity.Owner != player)
             {
-                if (logger.WarnEnabled()) logger.LogWarning("ServerRpc for object without authority [netId=" + msg.netId + "]");
+                if (logger.WarnEnabled()) logger.LogWarning($"ServerRpc for object without authority [netId={netId}]");
                 return;
             }
 
-            if (logger.LogEnabled()) logger.Log("OnServerRpcMessage for netId=" + msg.netId + " conn=" + player);
+            if (logger.LogEnabled()) logger.Log($"OnServerRpcMessage for netId={netId} conn={player}");
 
-            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(msg.payload))
+            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(payload))
             {
                 reader.ObjectLocator = Server.World;
-                remoteCall.Invoke(reader, behaviour, player, msg.replyId.GetValueOrDefault());
+                remoteCall.Invoke(reader, behaviour, player, replyId);
             }
         }
 


### PR DESCRIPTION
nullable will cause 1 bit for null, but that will be rounded up to 1 bytes when sending message.

This adds a seperate message for replyId so that it does not take up any extra bandwidth when it is not included