### PR TITLE
fix: fix bug when running sample scene

### DIFF
--- a/Assets/Mirage/Samples~/Chat/Scripts/ChatWindow.cs
+++ b/Assets/Mirage/Samples~/Chat/Scripts/ChatWindow.cs
@@ -23,6 +23,11 @@ namespace Mirage.Examples.Chat
         {
             Player.OnMessage += OnPlayerMessage;
         }
+        
+        public void OnDestroy()
+        {
+            Player.OnMessage -= OnPlayerMessage;
+        }
 
         void OnPlayerMessage(Player player, string message)
         {


### PR DESCRIPTION
When [`Player.RpcReceive`](https://github.com/MirageNet/Mirage/blob/master/Assets/Mirage/Samples%7E/Chat/Scripts/Player.cs#L22) is called, an `MissingReferenceException` is thrown and prevents sample from running properly.

The commit unsubscribes `ChatWindow` from `Player` events.