### PR TITLE
fix: networkserver shouldn't create socket if we're not listening (addresses ticket #1054)

### DIFF
--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -186,7 +186,7 @@ namespace Mirage
             ThrowIfSocketIsMissing();
 
             Application.quitting += Stop;
-            if (logger.LogEnabled()) logger.Log($"NetworkServer Created, Mirage version: {Version.Current}");
+            if (logger.LogEnabled()) logger.Log($"NetworkServer created, Mirage version: {Version.Current}");
 
             logger.Assert(Players.Count == 0, "Player should have been reset since previous session");
             logger.Assert(connections.Count == 0, "Connections should have been reset since previous session");

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -213,7 +213,9 @@ namespace Mirage
 
             NetworkWriterPool.Configure(config.MaxPacketSize);
 
-            // Only create peer if listening
+            // Are we listening for incoming connections?
+            // If yes, set up a socket for incoming connections (we're a multiplayer game).
+            // If not, that's okay. Some games use a non-listening server for their single player game mode (Battlefield, Call of Duty...)
             if (Listening)
             {
                 // Create a server specific socket.
@@ -223,13 +225,14 @@ namespace Mirage
                 peer = new Peer(socket, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
                 peer.OnConnected += Peer_OnConnected;
                 peer.OnDisconnected += Peer_OnDisconnected;
-
+                // Bind it to the endpoint.
                 peer.Bind(SocketFactory.GetBindEndPoint());
 
                 if (logger.LogEnabled()) logger.Log("Server started, listening for connections");
             }
             else
             {
+                // Nicely mention that we're going live, but not listening for connections.
                 if (logger.LogEnabled()) logger.Log("Server started, but not listening for connections: Attempts to connect to this instance will fail!");
             }
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -198,7 +198,6 @@ namespace Mirage
             MessageHandler = new MessageHandler(World, DisconnectOnException);
             MessageHandler.RegisterHandler<NetworkPingMessage>(World.Time.OnServerPing);
 
-            ISocket socket = SocketFactory.CreateServerSocket();
             var dataHandler = new DataHandler(MessageHandler, connections);
             Metrics = EnablePeerMetrics ? new Metrics(MetricsSize) : null;
 
@@ -217,14 +216,22 @@ namespace Mirage
             // Only create peer if listening
             if (Listening)
             {
+                // Create a server specific socket.
+                ISocket socket = SocketFactory.CreateServerSocket();
+
+                // Tell the peer to use that newly created socket.
                 peer = new Peer(socket, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
                 peer.OnConnected += Peer_OnConnected;
                 peer.OnDisconnected += Peer_OnDisconnected;
 
                 peer.Bind(SocketFactory.GetBindEndPoint());
-            }
 
-            if (logger.LogEnabled()) logger.Log("Server started listening");
+                if (logger.LogEnabled()) logger.Log("Server started, listening for connections");
+            }
+            else
+            {
+                if (logger.LogEnabled()) logger.Log("Server started, but not listening for connections: Attempts to connect to this instance will fail!");
+            }
 
             InitializeAuthEvents();
             Active = true;


### PR DESCRIPTION
This PR fixes a minor issue where a server socket is created without regard to the listening status.

NetworkServer will also spit out a correct log entry now, that reflects what mode it is running. For example, if it's not listening it will now say "Server created, not listening for connections" instead of just saying "server started listening" which is wrong. 

Before:
- Create socket
- Internal stuff
- Are we listening? If yes, set up the peer
- Output a log message saying the server started listening... _(even if it isn't listening!)_

After:
- Internal stuff
- Are we listening? If yes, create the socket, set up peer, output a log entry saying it's now listening for connections
- Not listening? Output a message saying server created but not listening for connections

I have also added some extra comments to help explain the listening area of the code. IMO its better to explain what the code is doing.