### PR TITLE
refactor(SocketLayer)!: moving MaxPacketSize to SocketFactory

### DIFF
--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -116,15 +116,16 @@ namespace Mirage
             if (logger.LogEnabled()) logger.Log($"Client connecting to endpoint: {endPoint}");
 
             ISocket socket = SocketFactory.CreateClientSocket();
+            int maxPacketSize = SocketFactory.MaxPacketSize;
             MessageHandler = new MessageHandler(World, DisconnectOnException);
             var dataHandler = new DataHandler(MessageHandler);
             Metrics = EnablePeerMetrics ? new Metrics(MetricsSize) : null;
 
             Config config = PeerConfig ?? new Config();
 
-            NetworkWriterPool.Configure(config.MaxPacketSize);
+            NetworkWriterPool.Configure(maxPacketSize);
 
-            peer = new Peer(socket, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
+            peer = new Peer(socket, maxPacketSize, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
             peer.OnConnected += Peer_OnConnected;
             peer.OnConnectionFailed += Peer_OnConnectionFailed;
             peer.OnDisconnected += Peer_OnDisconnected;

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -211,7 +211,8 @@ namespace Mirage
                 };
             }
 
-            NetworkWriterPool.Configure(config.MaxPacketSize);
+            int maxPacketSize = SocketFactory.MaxPacketSize;
+            NetworkWriterPool.Configure(maxPacketSize);
 
             // Are we listening for incoming connections?
             // If yes, set up a socket for incoming connections (we're a multiplayer game).
@@ -222,7 +223,7 @@ namespace Mirage
                 ISocket socket = SocketFactory.CreateServerSocket();
 
                 // Tell the peer to use that newly created socket.
-                peer = new Peer(socket, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
+                peer = new Peer(socket, maxPacketSize, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
                 peer.OnConnected += Peer_OnConnected;
                 peer.OnDisconnected += Peer_OnDisconnected;
                 // Bind it to the endpoint.

--- a/Assets/Mirage/Runtime/Serialization/NetworkWriterPool.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkWriterPool.cs
@@ -18,8 +18,8 @@ namespace Mirage.Serialization
         static NetworkWriterPool()
         {
             // auto configure so that pool can be used without having to manually call it
-            var config = new Config();
-            Configure(config.MaxPacketSize);
+            // 1300 is greater than udp's MTU value
+            Configure(1300);
         }
 
         /// <summary>

--- a/Assets/Mirage/Runtime/SocketLayer/AckSystem.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/AckSystem.cs
@@ -77,7 +77,7 @@ namespace Mirage.SocketLayer
         /// <param name="connection"></param>
         /// <param name="ackTimeout">how long after last send before sending empty ack</param>
         /// <param name="time"></param>
-        public AckSystem(IRawConnection connection, Config config, ITime time, Pool<ByteBuffer> bufferPool, Metrics metrics = null)
+        public AckSystem(IRawConnection connection, Config config, int maxPacketSize, ITime time, Pool<ByteBuffer> bufferPool, Metrics metrics = null)
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
 
@@ -90,7 +90,7 @@ namespace Mirage.SocketLayer
             ackTimeout = config.TimeBeforeEmptyAck;
             emptyAckLimit = config.EmptyAckLimit;
             receivesBeforeEmpty = config.ReceivesBeforeEmptyAck;
-            maxPacketSize = config.MaxPacketSize;
+            this.maxPacketSize = maxPacketSize;
             maxPacketsInSendBufferPerConnection = config.MaxReliablePacketsInSendBufferPerConnection;
 
             maxFragments = config.MaxReliableFragments;

--- a/Assets/Mirage/Runtime/SocketLayer/Config.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Config.cs
@@ -49,24 +49,6 @@ namespace Mirage.SocketLayer
         public float DisconnectDuration = 1;
 
         /// <summary>
-        /// IPv6 + UDP Header
-        /// </summary>
-        const int HEADER_SIZE = 40 + 8;
-
-        /// <summary>
-        /// MTU is expected to be atleast this number
-        /// </summary>
-        const int MIN_MTU = 1280;
-
-        /// <summary>
-        /// Max size of array that will be sent to or can be received from <see cref="ISocket"/>
-        /// <para>This will also be the size of all buffers used by <see cref="Peer"/></para>
-        /// <para>This is not max message size because this size includes packets header added by <see cref="Peer"/></para>
-        /// </summary>
-        // todo move these settings to socket
-        public int MaxPacketSize = MIN_MTU - HEADER_SIZE;
-
-        /// <summary>
         /// How many buffers to create at start
         /// </summary>
         public int BufferPoolStartSize = 100;
@@ -111,7 +93,7 @@ namespace Mirage.SocketLayer
 
         /// <summary>
         /// How many fragments large reliable message can be split into
-        /// <para>if set to 0 then messages over <see cref="MaxPacketSize"/> will not be allowed to be sent</para>
+        /// <para>if set to 0 then messages over <see cref="SocketFactory.MaxPacketSize"/> will not be allowed to be sent</para>
         /// <para>max value is 255</para>
         /// </summary>
         public int MaxReliableFragments = 5;

--- a/Assets/Mirage/Runtime/SocketLayer/Connection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection.cs
@@ -109,7 +109,7 @@ namespace Mirage.SocketLayer
 
         IEndPoint IConnection.EndPoint => EndPoint;
 
-        internal Connection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, Time time, Pool<ByteBuffer> bufferPool, ILogger logger, Metrics metrics)
+        internal Connection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, int maxPacketSize, Time time, Pool<ByteBuffer> bufferPool, ILogger logger, Metrics metrics)
         {
             this.peer = peer;
             this.logger = logger;
@@ -124,7 +124,7 @@ namespace Mirage.SocketLayer
             disconnectedTracker = new DisconnectedTracker(config, time);
 
             this.metrics = metrics;
-            ackSystem = new AckSystem(this, config, time, bufferPool, metrics);
+            ackSystem = new AckSystem(this, config, maxPacketSize, time, bufferPool, metrics);
         }
 
         public override string ToString()

--- a/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
@@ -31,6 +31,10 @@ namespace Mirage.SocketLayer
     /// </remarks>
     public abstract class SocketFactory : MonoBehaviour
     {
+        /// <summary>Max size for packets sent to or received from Socket
+        /// <para>Called once when Sockets are created</para></summary>
+        public abstract int MaxPacketSize { get; }
+
         /// <summary>Creates a <see cref="ISocket"/> to be used by <see cref="Peer"/> on the server</summary>
         /// <exception cref="NotSupportedException">Throw when Server is not supported on current platform</exception>
         public abstract ISocket CreateServerSocket();

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -20,6 +20,8 @@ namespace Mirage.Sockets.Udp
         [Header("NanoSocket options")]
         public int BufferSize = 256 * 1024;
 
+        public override int MaxPacketSize => UdpMTU.MaxPacketSize;
+
         bool useNanoSocket => SocketLib == SocketLib.Native || (SocketLib == SocketLib.Automatic && IsDesktop);
 
         string IHasAddress.Address
@@ -177,5 +179,26 @@ namespace Mirage.Sockets.Udp
             EndPoint copy = inner.Create(inner.Serialize());
             return new EndPointWrapper(copy);
         }
+    }
+
+    public class UdpMTU
+    {
+        /// <summary>
+        /// IPv6 + UDP Header
+        /// </summary>
+        const int HEADER_SIZE = 40 + 8;
+
+        /// <summary>
+        /// MTU is expected to be atleast this number
+        /// </summary>
+        const int MIN_MTU = 1280;
+
+        /// <summary>
+        /// Max size of array that will be sent to or can be received from <see cref="ISocket"/>
+        /// <para>This will also be the size of all buffers used by <see cref="Peer"/></para>
+        /// <para>This is not max message size because this size includes packets header added by <see cref="Peer"/></para>
+        /// </summary>
+        // todo move these settings to socket
+        public static int MaxPacketSize => MIN_MTU - HEADER_SIZE;
     }
 }

--- a/Assets/Tests/Common/TestSocketFactory.cs
+++ b/Assets/Tests/Common/TestSocketFactory.cs
@@ -141,6 +141,7 @@ namespace Mirage.Tests
 
         int clientNameIndex;
         int serverNameIndex;
+        public override int MaxPacketSize => 1300;
         public override ISocket CreateClientSocket()
         {
             return new TestSocket($"Client {clientNameIndex++}");

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest.cs
@@ -20,8 +20,9 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
     /// </summary>
     public class AckSystemTestBase
     {
+        public const int MAX_PACKET_SIZE = 1300;
         protected readonly Random rand = new Random();
-        protected Pool<ByteBuffer> bufferPool = new Pool<ByteBuffer>(ByteBuffer.CreateNew, 1300, 100, 1000);
+        protected Pool<ByteBuffer> bufferPool = new Pool<ByteBuffer>(ByteBuffer.CreateNew, MAX_PACKET_SIZE, 100, 1000);
 
         protected byte[] createRandomData(int id)
         {

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_BufferSize.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_BufferSize.cs
@@ -19,7 +19,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             {
                 connection = new SubIRawConnection()
             };
-            instance.ackSystem = new AckSystem(instance.connection, config, time, bufferPool);
+            instance.ackSystem = new AckSystem(instance.connection, config, MAX_PACKET_SIZE, time, bufferPool);
 
             for (int i = 0; i < 50; i++)
             {
@@ -50,7 +50,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             {
                 connection = new SubIRawConnection()
             };
-            instance.ackSystem = new AckSystem(instance.connection, config, time, bufferPool);
+            instance.ackSystem = new AckSystem(instance.connection, config, MAX_PACKET_SIZE, time, bufferPool);
 
             for (int i = 0; i < 255; i++)
             {

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Fragmentation_Receive.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Fragmentation_Receive.cs
@@ -18,21 +18,21 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
         public void SetUp()
         {
             config = new Config();
-            int mtu = config.MaxPacketSize;
+            int mtu = MAX_PACKET_SIZE;
             int bigSize = (int)(mtu * 1.5f);
 
             message = CreateBigData(1, bigSize);
 
             var sender = new AckTestInstance();
             sender.connection = new SubIRawConnection();
-            sender.ackSystem = new AckSystem(sender.connection, config, new Time(), bufferPool);
+            sender.ackSystem = new AckSystem(sender.connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
             sender.ackSystem.SendReliable(message);
             packet1 = sender.packet(0);
             packet2 = sender.packet(1);
 
 
             var connection = new SubIRawConnection();
-            ackSystem = new AckSystem(connection, config, new Time(), bufferPool);
+            ackSystem = new AckSystem(connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
         }
 
         byte[] CreateBigData(int id, int size)
@@ -80,7 +80,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
 
             ackSystem.ReceiveReliable(packet2, packet2.Length, true);
 
-            int bytesIn1 = config.MaxPacketSize - AckSystem.MIN_RELIABLE_FRAGMENT_HEADER_SIZE;
+            int bytesIn1 = MAX_PACKET_SIZE - AckSystem.MIN_RELIABLE_FRAGMENT_HEADER_SIZE;
             int bytesIn2 = message.Length - bytesIn1;
 
             Assert.IsTrue(ackSystem.NextReliablePacket(out AckSystem.ReliableReceived first));

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Fragmentation_Send.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Fragmentation_Send.cs
@@ -15,14 +15,14 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
         public void SetUp()
         {
             var config = new Config();
-            int mtu = config.MaxPacketSize;
+            int mtu = MAX_PACKET_SIZE;
             int bigSize = (int)(mtu * 1.5f);
 
             byte[] message = CreateBigData(1, bigSize);
 
             instance = new AckTestInstance();
             instance.connection = new SubIRawConnection();
-            instance.ackSystem = new AckSystem(instance.connection, config, new Time(), bufferPool);
+            instance.ackSystem = new AckSystem(instance.connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
 
             // create and send n messages
             instance.messages = new List<byte[]>();

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_1stSend.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_1stSend.cs
@@ -29,7 +29,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             maxSequence = (ushort)((1 << config.SequenceSize) - 1);
 
             connection = new SubIRawConnection();
-            ackSystem = new AckSystem(connection, config, new Time(), bufferPool);
+            ackSystem = new AckSystem(connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
 
             message = createRandomData(1);
             ackSystem.SendNotify(message);

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_DroppedSends.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_DroppedSends.cs
@@ -39,12 +39,12 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
 
             instance1 = new AckTestInstance();
             instance1.connection = new SubIRawConnection();
-            instance1.ackSystem = new AckSystem(instance1.connection, config, new Time(), bufferPool);
+            instance1.ackSystem = new AckSystem(instance1.connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
 
 
             instance2 = new AckTestInstance();
             instance2.connection = new SubIRawConnection();
-            instance2.ackSystem = new AckSystem(instance2.connection, config, new Time(), bufferPool);
+            instance2.ackSystem = new AckSystem(instance2.connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
 
             // create and send n messages
             instance1.messages = new List<byte[]>();

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_ManySends.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_ManySends.cs
@@ -22,7 +22,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
 
             instance = new AckTestInstance();
             instance.connection = new SubIRawConnection();
-            instance.ackSystem = new AckSystem(instance.connection, new Config(), new Time(), bufferPool);
+            instance.ackSystem = new AckSystem(instance.connection, new Config(), MAX_PACKET_SIZE, new Time(), bufferPool);
 
             // create and send n messages
             instance.messages = new List<byte[]>();

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_NoDroppedSends.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Notify_NoDroppedSends.cs
@@ -28,13 +28,13 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
 
             instance1 = new AckTestInstance();
             instance1.connection = new SubIRawConnection();
-            instance1.ackSystem = new AckSystem(instance1.connection, config, new Time(), bufferPool);
+            instance1.ackSystem = new AckSystem(instance1.connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
             received1 = new List<ArraySegment<byte>>();
 
 
             instance2 = new AckTestInstance();
             instance2.connection = new SubIRawConnection();
-            instance2.ackSystem = new AckSystem(instance2.connection, config, new Time(), bufferPool);
+            instance2.ackSystem = new AckSystem(instance2.connection, config, MAX_PACKET_SIZE, new Time(), bufferPool);
             received2 = new List<ArraySegment<byte>>();
 
             // create and send n messages

--- a/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Reliable.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/AckSystemTest_Reliable.cs
@@ -138,12 +138,12 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
 
             instance1 = new AckTestInstance();
             instance1.connection = new SubIRawConnection();
-            instance1.ackSystem = new AckSystem(instance1.connection, config, time, bufferPool);
+            instance1.ackSystem = new AckSystem(instance1.connection, config, MAX_PACKET_SIZE, time, bufferPool);
 
 
             instance2 = new AckTestInstance();
             instance2.connection = new SubIRawConnection();
-            instance2.ackSystem = new AckSystem(instance2.connection, config, time, bufferPool);
+            instance2.ackSystem = new AckSystem(instance2.connection, config, MAX_PACKET_SIZE, time, bufferPool);
 
             badSocket = new BadSocket(instance1, instance2);
 

--- a/Assets/Tests/SocketLayer/ByteUtilsTest.cs
+++ b/Assets/Tests/SocketLayer/ByteUtilsTest.cs
@@ -88,7 +88,7 @@ namespace Mirage.SocketLayer.Tests
         }
 
         [Test]
-        [Explicit("c# only lets you bit shift by max of 63, It only takes first 6 bits, so will drop any extra bits and try to shift anyway")]
+        [Ignore("c# only lets you bit shift by max of 63, It only takes first 6 bits, so will drop any extra bits and try to shift anyway")]
         public void UlongShift()
         {
             ulong value = 0xfUL;
@@ -100,7 +100,7 @@ namespace Mirage.SocketLayer.Tests
 
         [Test]
         [Description("this test should fail")]
-        [Explicit("c# only lets you bit shift by max of 63. It only takes first 6 bits, so will drop any extra bits and try to shift anyway")]
+        [Ignore("c# only lets you bit shift by max of 63. It only takes first 6 bits, so will drop any extra bits and try to shift anyway")]
         public void UlongShift_ShouldFail()
         {
             ulong value = 0xfUL;

--- a/Assets/Tests/SocketLayer/PeerTest.cs
+++ b/Assets/Tests/SocketLayer/PeerTest.cs
@@ -15,7 +15,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
             {
-                _ = new Peer(null, Substitute.For<IDataHandler>(), new Config(), Substitute.For<ILogger>());
+                _ = new Peer(null, 1000, Substitute.For<IDataHandler>(), new Config(), Substitute.For<ILogger>());
             });
             var expected = new ArgumentNullException("socket");
             Assert.That(exception, Has.Message.EqualTo(expected.Message));
@@ -25,7 +25,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
             {
-                _ = new Peer(Substitute.For<ISocket>(), null, new Config(), Substitute.For<ILogger>());
+                _ = new Peer(Substitute.For<ISocket>(), 1000, null, new Config(), Substitute.For<ILogger>());
             });
             var expected = new ArgumentNullException("dataHandler");
             Assert.That(exception, Has.Message.EqualTo(expected.Message));
@@ -35,7 +35,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         {
             Assert.DoesNotThrow(() =>
             {
-                _ = new Peer(Substitute.For<ISocket>(), Substitute.For<IDataHandler>(), null, Substitute.For<ILogger>());
+                _ = new Peer(Substitute.For<ISocket>(), 1000, Substitute.For<IDataHandler>(), null, Substitute.For<ILogger>());
             });
         }
         [Test]
@@ -43,8 +43,19 @@ namespace Mirage.SocketLayer.Tests.PeerTests
         {
             Assert.DoesNotThrow(() =>
             {
-                _ = new Peer(Substitute.For<ISocket>(), Substitute.For<IDataHandler>(), new Config(), null);
+                _ = new Peer(Substitute.For<ISocket>(), 1000, Substitute.For<IDataHandler>(), new Config(), null);
             });
+        }
+
+        [Test]
+        public void ThrowIfPacketSizeIsTooSmall()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            {
+                _ = new Peer(Substitute.For<ISocket>(), 0, Substitute.For<IDataHandler>(), new Config(), Substitute.For<ILogger>());
+            });
+            var expected = new ArgumentException($"Max packet size too small for AckSystem header", "maxPacketSize");
+            Assert.That(exception, Has.Message.EqualTo(expected.Message));
         }
 
         [Test]
@@ -100,7 +111,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
                 peer.UpdateTest();
             });
 
-            Assert.That(exception, Has.Message.EqualTo($"Socket returned length above MTU. MaxPacketSize:{config.MaxPacketSize} length:{aboveMTU}"));
+            Assert.That(exception, Has.Message.EqualTo($"Socket returned length above MTU. MaxPacketSize:{MAX_PACKET_SIZE} length:{aboveMTU}"));
         }
 
         [Test]

--- a/Assets/Tests/SocketLayer/PeerTestBase.cs
+++ b/Assets/Tests/SocketLayer/PeerTestBase.cs
@@ -13,6 +13,8 @@ namespace Mirage.SocketLayer.Tests.PeerTests
     public class PeerTestBase
     {
         public const int maxConnections = 5;
+        public const int MAX_PACKET_SIZE = 1300;
+
         protected byte[] connectRequest;
 
         PeerInstance instance;
@@ -78,7 +80,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
                 ConnectAttemptInterval = 0.2f,
             };
             logger = LogFactory.GetLogger<PeerInstance>();
-            peer = new Peer(this.socket, dataHandler, this.config, logger);
+            peer = new Peer(this.socket, PeerTestBase.MAX_PACKET_SIZE, dataHandler, this.config, logger);
         }
     }
 

--- a/Assets/Tests/SocketLayer/PeerTestSendReceive.cs
+++ b/Assets/Tests/SocketLayer/PeerTestSendReceive.cs
@@ -37,7 +37,7 @@ namespace Mirage.SocketLayer.Tests.PeerTests
             serverConnections = new List<IConnection>();
 
             var config = new Config { MaxConnections = ClientCount };
-            maxFragmentMessageSize = config.MaxReliableFragments * (config.MaxPacketSize - AckSystem.MIN_RELIABLE_FRAGMENT_HEADER_SIZE);
+            maxFragmentMessageSize = config.MaxReliableFragments * (PeerTestBase.MAX_PACKET_SIZE - AckSystem.MIN_RELIABLE_FRAGMENT_HEADER_SIZE);
             NotifyWaitTime = config.TimeBeforeEmptyAck * 2;
 
 


### PR DESCRIPTION
Allows max packet size to be set by sockets rather than the general peer config.

BREAKING CHANGE: socket factories not have to override abstract MaxPacketSize property