### PR TITLE
refactor(CharacterSpawner): nicer names on spawned characters (prefab name + endpoint) [skip ci]

### DIFF
--- a/Assets/Mirage/Runtime/CharacterSpawner.cs
+++ b/Assets/Mirage/Runtime/CharacterSpawner.cs
@@ -143,6 +143,9 @@ namespace Mirage
                 ? Instantiate(PlayerPrefab, startPos.position, startPos.rotation)
                 : Instantiate(PlayerPrefab);
 
+            // When spawning a player game object, Unity defaults to something like "MyPlayerObject(clone)"
+            // which sucks... So let's override it and make it easier to debug. Credit to Mirror for the nice touch.
+            player.name = $"{playerPrefab.name} {player.Connection.Endpoint}";
             ServerObjectManager.AddCharacter(player, character.gameObject);
         }
 

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -330,7 +330,7 @@ namespace Mirage
             // Set the connection on the NetworkIdentity on the server, NetworkIdentity.SetLocalPlayer is not called on the server (it is on clients)
             identity.SetClientOwner(player);
 
-            // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
+            // special case, we are in host mode, set hasAuthority to true so that all overrides see it
             if (player == Server.LocalPlayer)
             {
                 identity.HasAuthority = true;


### PR DESCRIPTION
This PR is mainly a slight cosmetic change inspired by Mirror. It replaces the spawned player name with the object name and the endpoint (Mirror uses a connection id, but since Mirage doesn't have that, we use the Endpoint instead). For example:

```
BEFORE:
Heroine(Clone)

AFTER:
Heroine [::ffff:192.168.88.200:38008]
```

This should help debugging.