### PR TITLE
fix: throwing if SceneManager returns null

### DIFF
--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -667,6 +667,9 @@ namespace Mirage
                     ? SceneManager.LoadSceneAsync(scenePath, sceneLoadParameters.Value)
                     : SceneManager.LoadSceneAsync(scenePath);
 
+                if (SceneLoadingAsyncOperationInfo == null)
+                    throw new InvalidOperationException($"SceneManager failed to load scene with path: {scenePath}");
+
                 //If non host client. Wait for server to finish scene change
                 if (Client && Client.Active && !Client.IsLocalClient)
                 {


### PR DESCRIPTION
returning null means that unity failed to load the scene, in this case we should throw because we can't continue

resolves: https://github.com/MirageNet/Mirage/issues/1027