### PR TITLE
perf: using plus 1 count for other collection types

### DIFF
--- a/Assets/Mirage/Runtime/Serialization/CollectionExtensions.cs
+++ b/Assets/Mirage/Runtime/Serialization/CollectionExtensions.cs
@@ -175,7 +175,7 @@ namespace Mirage.Serialization
 
         /// <summary>Reads 0 as null, and all over values as -1</summary>
         /// <param name="count">The real count of the </param>
-        /// <returns>if collection should be null or not</returns>
+        /// <returns>true if collection has value, false if collection is null</returns>
         internal static bool ReadCountPlusOne(NetworkReader reader, out int count)
         {
             // count = 0 means the array was null

--- a/Assets/Mirage/Runtime/Serialization/CollectionExtensions.cs
+++ b/Assets/Mirage/Runtime/Serialization/CollectionExtensions.cs
@@ -12,15 +12,13 @@ namespace Mirage.Serialization
         /// <param name="buffer">array or null</param>
         public static void WriteBytesAndSize(this NetworkWriter writer, byte[] buffer, int offset, int count)
         {
-            // null is supported
-            // write 0 for null array, increment normal size by 1 to save bandwith
-            // (using size=-1 for null would limit max size to 32kb instead of 64kb)
             if (buffer == null)
             {
-                writer.WritePackedUInt32(0u);
+                WriteCountPlusOne(writer, null);
                 return;
             }
-            writer.WritePackedUInt32(checked((uint)count) + 1u);
+
+            WriteCountPlusOne(writer, count);
             writer.WriteBytes(buffer, offset, count);
         }
 
@@ -30,8 +28,12 @@ namespace Mirage.Serialization
         /// <param name="buffer">array or null</param>
         public static void WriteBytesAndSize(this NetworkWriter writer, byte[] buffer)
         {
-            // buffer might be null, so we can't use .Length in that case
-            writer.WriteBytesAndSize(buffer, 0, buffer != null ? buffer.Length : 0);
+            WriteCountPlusOne(writer, buffer?.Length);
+
+            if (buffer == null)
+                return;
+
+            writer.WriteBytes(buffer, 0, buffer.Length);
         }
 
         public static void WriteBytesAndSizeSegment(this NetworkWriter writer, ArraySegment<byte> buffer)
@@ -39,60 +41,70 @@ namespace Mirage.Serialization
             writer.WriteBytesAndSize(buffer.Array, buffer.Offset, buffer.Count);
         }
 
-
         public static void WriteList<T>(this NetworkWriter writer, List<T> list)
         {
+            WriteCountPlusOne(writer, list?.Count);
+
             if (list is null)
-            {
-                writer.WritePackedInt32(-1);
                 return;
-            }
-            writer.WritePackedInt32(list.Count);
-            for (int i = 0; i < list.Count; i++)
+
+            int length = list.Count;
+            for (int i = 0; i < length; i++)
                 writer.Write(list[i]);
         }
 
         public static void WriteArray<T>(this NetworkWriter writer, T[] array)
         {
+            WriteCountPlusOne(writer, array?.Length);
+
             if (array is null)
-            {
-                writer.WritePackedInt32(-1);
                 return;
-            }
-            writer.WritePackedInt32(array.Length);
-            for (int i = 0; i < array.Length; i++)
+
+            int length = array.Length;
+            for (int i = 0; i < length; i++)
                 writer.Write(array[i]);
         }
 
         public static void WriteArraySegment<T>(this NetworkWriter writer, ArraySegment<T> segment)
         {
-            int length = segment.Count;
-            writer.WritePackedInt32(length);
-            for (int i = 0; i < length; i++)
+            T[] array = segment.Array;
+
+            if (array == null)
             {
-                writer.Write(segment.Array[segment.Offset + i]);
+                WriteCountPlusOne(writer, null);
+            }
+            else
+            {
+                // cache these properties in local variable because they wont change and calling properties has performance cost
+                int offset = segment.Offset;
+                int length = segment.Count;
+
+                WriteCountPlusOne(writer, length);
+                for (int i = 0; i < length; i++)
+                {
+                    writer.Write(array[offset + i]);
+                }
             }
         }
-
 
 
         /// <returns>array or null</returns>
         public static byte[] ReadBytesAndSize(this NetworkReader reader)
         {
-            // count = 0 means the array was null
-            // otherwise count -1 is the length of the array
-            uint count = reader.ReadPackedUInt32();
+            // dont need to ValidateSize here because ReadBytes does it
 
-            // Use checked() to force it to throw OverflowException if data is invalid
-            return count == 0 ? null : reader.ReadBytes(checked((int)(count - 1u)));
+            return ReadCountPlusOne(reader, out int count)
+                ? reader.ReadBytes(count)
+                : null;
         }
 
         public static ArraySegment<byte> ReadBytesAndSizeSegment(this NetworkReader reader)
         {
-            // count = 0 means the array was null
-            // otherwise count - 1 is the length of the array
-            uint count = reader.ReadPackedUInt32();
-            return count == 0 ? default : reader.ReadBytesSegment(checked((int)(count - 1u)));
+            // dont need to ValidateSize here because we dont allocate for segment
+
+            return ReadCountPlusOne(reader, out int count)
+                ? reader.ReadBytesSegment(count)
+                : default;
         }
 
         public static byte[] ReadBytes(this NetworkReader reader, int count)
@@ -107,10 +119,12 @@ namespace Mirage.Serialization
 
         public static List<T> ReadList<T>(this NetworkReader reader)
         {
-            int length = reader.ReadPackedInt32();
-            if (length < 0)
+            bool hasValue = ReadCountPlusOne(reader, out int length);
+            if (!hasValue)
                 return null;
+
             ValidateSize(reader, length);
+
             var result = new List<T>(length);
             for (int i = 0; i < length; i++)
             {
@@ -121,10 +135,12 @@ namespace Mirage.Serialization
 
         public static T[] ReadArray<T>(this NetworkReader reader)
         {
-            int length = reader.ReadPackedInt32();
-            if (length < 0)
+            bool hasValue = ReadCountPlusOne(reader, out int length);
+            if (!hasValue)
                 return null;
+
             ValidateSize(reader, length);
+
             var result = new T[length];
             for (int i = 0; i < length; i++)
             {
@@ -133,13 +149,51 @@ namespace Mirage.Serialization
             return result;
         }
 
+        public static ArraySegment<T> ReadArraySegment<T>(this NetworkReader reader)
+        {
+            T[] array = reader.ReadArray<T>();
+            return array != null ? new ArraySegment<T>(array) : default;
+        }
+
+
+        /// <summary>Writes null as 0, and all over values as +1</summary>
+        /// <param name="count">The real count or null if collection is is null</param>
+        internal static void WriteCountPlusOne(NetworkWriter writer, int? count)
+        {
+            // null is supported
+            // write 0 for null array, increment normal size by 1 to save bandwith
+            // (using size=-1 for null would limit max size to 32kb instead of 64kb)
+            if (count.HasValue)
+            {
+                writer.WritePackedUInt32(checked((uint)count) + 1u);
+            }
+            else
+            {
+                writer.WritePackedUInt32(0);
+            }
+        }
+
+        /// <summary>Reads 0 as null, and all over values as -1</summary>
+        /// <param name="count">The real count of the </param>
+        /// <returns>if collection should be null or not</returns>
+        internal static bool ReadCountPlusOne(NetworkReader reader, out int count)
+        {
+            // count = 0 means the array was null
+            // otherwise count -1 is the length of the array
+            uint value = reader.ReadPackedUInt32();
+            // Use checked() to force it to throw OverflowException if data is invalid/
+            // do -1 after checked, incase value is 0 (count will be -1, but ok because we will return false in that case)
+            count = checked((int)value) - 1;
+            return value != 0;
+        }
+
         /// <summary>
         /// Use to check max size in reader before allocating array/list
         /// <para>Assumes each element is only 1 bit, so max size allocated will be MTU*8 if attacks tries to attack</para>
         /// </summary>
         /// <param name="reader"></param>
         /// <param name="lengthInBits"></param>
-        static void ValidateSize(NetworkReader reader, int lengthInBits)
+        internal static void ValidateSize(NetworkReader reader, int lengthInBits)
         {
             // T might be only 1 bit long, so we have to check vs bit length
             // todo have weaver calculate minimum size for T, so we can use it here instead of 1 bit

--- a/Assets/Mirage/Weaver/Serialization/Writers.cs
+++ b/Assets/Mirage/Weaver/Serialization/Writers.cs
@@ -16,6 +16,7 @@ namespace Mirage.Weaver
         protected override string GeneratedLabel => "__MirageWirterGenerated";
         protected override Expression<Action> ArrayExpression => () => CollectionExtensions.WriteArray<byte>(default, default);
         protected override Expression<Action> ListExpression => () => CollectionExtensions.WriteList<byte>(default, default);
+        protected override Expression<Action> SegmentExpression => () => CollectionExtensions.WriteArraySegment<byte>(default, default);
         protected override Expression<Action> NullableExpression => () => SystemTypesExtensions.WriteNullable<byte>(default, default);
 
         protected override MethodReference GetGenericFunction()
@@ -152,11 +153,6 @@ namespace Mirage.Weaver
             }
         }
 
-        protected override MethodReference GenerateSegmentFunction(TypeReference typeReference, TypeReference elementType)
-        {
-            Expression<Action> segmentExpression = () => CollectionExtensions.WriteArraySegment<byte>(default, default);
-            return GenerateCollectionFunction(typeReference, elementType, segmentExpression);
-        }
         protected override MethodReference GenerateCollectionFunction(TypeReference typeReference, TypeReference elementType, Expression<Action> genericExpression)
         {
             // make sure element has a writer

--- a/Assets/Mirage/Weaver/SerializeFunctionBase.cs
+++ b/Assets/Mirage/Weaver/SerializeFunctionBase.cs
@@ -180,7 +180,7 @@ namespace Mirage.Weaver
                 var genericInstance = (GenericInstanceType)typeReference;
                 TypeReference elementType = genericInstance.GenericArguments[0];
 
-                return GenerateSegmentFunction(typeReference, elementType);
+                return GenerateCollectionFunction(typeReference, elementType, SegmentExpression);
             }
             if (typeReference.Is(typeof(List<>)))
             {
@@ -276,10 +276,10 @@ namespace Mirage.Weaver
 
         protected abstract MethodReference GenerateEnumFunction(TypeReference typeReference);
         protected abstract MethodReference GenerateCollectionFunction(TypeReference typeReference, TypeReference elementType, Expression<Action> genericExpression);
-        protected abstract MethodReference GenerateSegmentFunction(TypeReference typeReference, TypeReference elementType);
 
         protected abstract Expression<Action> ArrayExpression { get; }
         protected abstract Expression<Action> ListExpression { get; }
+        protected abstract Expression<Action> SegmentExpression { get; }
         protected abstract Expression<Action> NullableExpression { get; }
 
         protected abstract MethodReference GenerateClassOrStructFunction(TypeReference typeReference);

--- a/Assets/Tests/Runtime/Serialization/ArraySegmentWriterTest.cs
+++ b/Assets/Tests/Runtime/Serialization/ArraySegmentWriterTest.cs
@@ -80,6 +80,7 @@ namespace Mirage.Tests.Runtime.Serialization
 
                 ArraySegment<int> unpacked = MessagePacker.Unpack<ArraySegment<int>>(data);
 
+                Assert.IsNull(unpacked.Array);
                 Assert.That(unpacked.Offset, Is.EqualTo(0));
                 Assert.That(unpacked.Count, Is.EqualTo(0));
             }


### PR DESCRIPTION
For byte[], 0 is written for null and count+1 is written for count, we can re-use this for other collections

Splitting these methods into seperate fucntions so they can be used for all collections

Also changing are ArraySegment<T> is read, it now has its own extension methods that checks if the array is null or not before creating the segment