### PR TITLE
refactor: forcing GetReader to be given objectLocator

### DIFF
--- a/Assets/Mirage/Components/NetworkAnimator.cs
+++ b/Assets/Mirage/Components/NetworkAnimator.cs
@@ -522,7 +522,7 @@ namespace Mirage
             if (logger.LogEnabled()) logger.Log("OnAnimationMessage for netId=" + NetId);
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters, null))
             {
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
                 RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, weight, parameters);
@@ -537,7 +537,7 @@ namespace Mirage
                 return;
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters, null))
             {
                 HandleAnimParamsMsg(networkReader);
                 RpcOnAnimationParametersClientMessage(parameters);
@@ -587,14 +587,14 @@ namespace Mirage
         [ClientRpc]
         void RpcOnAnimationClientMessage(int stateHash, float normalizedTime, int layerId, float weight, ArraySegment<byte> parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters, null))
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
         }
 
         [ClientRpc]
         void RpcOnAnimationParametersClientMessage(ArraySegment<byte> parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters, null))
                 HandleAnimParamsMsg(networkReader);
         }
 

--- a/Assets/Mirage/Components/NetworkTransformBase.cs
+++ b/Assets/Mirage/Components/NetworkTransformBase.cs
@@ -202,7 +202,7 @@ namespace Mirage
                 return;
 
             // deserialize payload
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(payload))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(payload, Server.World))
                 DeserializeFromReader(networkReader);
 
             // server-only mode does no interpolation to save computations,

--- a/Assets/Mirage/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirage/Editor/NetworkInformationPreview.cs
@@ -253,8 +253,15 @@ namespace Mirage
                 infos.Add(GetString("Network ID", identity.NetId.ToString()));
                 infos.Add(GetBoolean("Is Client", identity.IsClient));
                 infos.Add(GetBoolean("Is Server", identity.IsServer));
-                infos.Add(GetBoolean("Has Authority", identity.HasAuthority));
-                infos.Add(GetBoolean("Is Local Player", identity.IsLocalPlayer));
+                if (identity.IsClient)
+                {
+                    infos.Add(GetBoolean("Has Authority", identity.HasAuthority));
+                    infos.Add(GetBoolean("Is Local Player", identity.IsLocalPlayer));
+                }
+                if (identity.IsServer)
+                {
+                    infos.Add(GetString("Owner", identity.Owner != null ? identity.Owner.ToString() : "NULL"));
+                }
             }
             return infos;
         }

--- a/Assets/Mirage/Runtime/GameObjectSyncvar.cs
+++ b/Assets/Mirage/Runtime/GameObjectSyncvar.cs
@@ -54,14 +54,16 @@ namespace Mirage
 
         public static GameObjectSyncvar ReadGameObjectSyncVar(this NetworkReader reader)
         {
+            MirageNetworkReader mirageReader = reader.ToMirageReader();
+
             uint netId = reader.ReadPackedUInt32();
 
             NetworkIdentity identity = null;
-            bool hasValue = reader.ObjectLocator?.TryGetIdentity(netId, out identity) ?? false;
+            bool hasValue = mirageReader.ObjectLocator?.TryGetIdentity(netId, out identity) ?? false;
 
             return new GameObjectSyncvar
             {
-                objectLocator = reader.ObjectLocator,
+                objectLocator = mirageReader.ObjectLocator,
                 netId = netId,
                 gameObject = hasValue ? identity.gameObject : null
             };

--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -110,10 +110,8 @@ namespace Mirage
 
         public void HandleMessage(INetworkPlayer player, ArraySegment<byte> packet)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(packet))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(packet, objectLocator))
             {
-                // set ObjectLocator so that message can use NetworkIdentity
-                networkReader.ObjectLocator = objectLocator;
 
                 // protect against attackers trying to send invalid data packets
                 // exception could be throw if:

--- a/Assets/Mirage/Runtime/NetworkBehaviorSyncvar.cs
+++ b/Assets/Mirage/Runtime/NetworkBehaviorSyncvar.cs
@@ -61,15 +61,17 @@ namespace Mirage
 
         public static NetworkBehaviorSyncvar ReadNetworkBehaviourSyncVar(this NetworkReader reader)
         {
+            MirageNetworkReader mirageReader = reader.ToMirageReader();
+
             uint netId = reader.ReadPackedUInt32();
             int componentId = reader.ReadPackedInt32();
 
             NetworkIdentity identity = null;
-            bool hasValue = reader.ObjectLocator?.TryGetIdentity(netId, out identity) ?? false;
+            bool hasValue = mirageReader.ObjectLocator?.TryGetIdentity(netId, out identity) ?? false;
 
             return new NetworkBehaviorSyncvar
             {
-                objectLocator = reader.ObjectLocator,
+                objectLocator = mirageReader.ObjectLocator,
                 netId = netId,
                 componentId = componentId,
                 component = hasValue ? identity.NetworkBehaviours[componentId] : null

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -680,11 +680,11 @@ namespace Mirage
             // check if Barrier is at end of Deserialize, if it is then the Deserialize was likely a success
             byte barrierData = reader.ReadByte();
             if (barrierData != Barrier)
-            {                
+            {
                 throw new DeserializeFailedException($"Deserialization failure for component '{comp.GetType()}' on networked object '{name}' (NetId {NetId}, SceneId {SceneId:X})." +
                     $" Possible Reasons:\n" +
                     $"  * Do {comp.GetType()}'s OnSerialize and OnDeserialize calls write the same amount of data?\n" +
-                    $"  * Did something fail in {comp.GetType()}'s OnSerialize/OnDeserialize code?\n" + 
+                    $"  * Did something fail in {comp.GetType()}'s OnSerialize/OnDeserialize code?\n" +
                     $"  * Are the server and client instances built from the exact same project?\n" +
                     $"  * Maybe this OnDeserialize call was meant for another GameObject? The sceneIds can easily get out of sync if the Hierarchy was modified only on the client " +
                     $"OR the server. Try rebuilding both.\n\n");
@@ -693,8 +693,6 @@ namespace Mirage
 
         internal void OnDeserializeAll(NetworkReader reader, bool initialState)
         {
-            // needed so that we can deserialize gameobjects and NI
-            reader.ObjectLocator = Client != null ? Client.World : null;
             // deserialize all components that were received
             NetworkBehaviour[] components = NetworkBehaviours;
             // check if we can read at least 1 byte

--- a/Assets/Mirage/Runtime/NetworkIdentitySyncvar.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentitySyncvar.cs
@@ -54,14 +54,16 @@ namespace Mirage
 
         public static NetworkIdentitySyncvar ReadNetworkIdentitySyncVar(this NetworkReader reader)
         {
+            MirageNetworkReader mirageReader = reader.ToMirageReader();
+
             uint netId = reader.ReadPackedUInt32();
 
             NetworkIdentity identity = null;
-            reader.ObjectLocator?.TryGetIdentity(netId, out identity);
+            mirageReader.ObjectLocator?.TryGetIdentity(netId, out identity);
 
             return new NetworkIdentitySyncvar
             {
-                objectLocator = reader.ObjectLocator,
+                objectLocator = mirageReader.ObjectLocator,
                 netId = netId,
                 identity = identity
             };

--- a/Assets/Mirage/Runtime/Serialization/MessagePacker.cs
+++ b/Assets/Mirage/Runtime/Serialization/MessagePacker.cs
@@ -88,10 +88,24 @@ namespace Mirage.Serialization
             }
         }
 
-        // unpack a message we received
-        public static T Unpack<T>(byte[] data)
+        /// <summary>
+        /// unpack a message we received
+        /// <para>Use <see cref="Unpack{T}(byte[], IObjectLocator)"/> Instead to if you need to read NetworkIdentities</para>
+        /// </summary>
+        [System.Obsolete("Use Unpack(byte[], IObjectLocator) instead")]
+        public static T Unpack<T>(byte[] data) => Unpack<T>(data, null);
+
+        /// <summary>
+        /// unpack a message we received
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="data"></param>
+        /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
+        /// <returns></returns>
+        /// <exception cref="FormatException"></exception>
+        public static T Unpack<T>(byte[] data, IObjectLocator objectLocator)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(data))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(data, objectLocator))
             {
                 int msgType = GetId<T>();
 

--- a/Assets/Mirage/Runtime/Serialization/MirageTypesExtensions.cs
+++ b/Assets/Mirage/Runtime/Serialization/MirageTypesExtensions.cs
@@ -49,7 +49,7 @@ namespace Mirage.Serialization
             if (reader is MirageNetworkReader mirageReader)
                 return mirageReader;
             else
-                throw new InvalidOperationException("Must be MirageNetworkReader to use ReadNetworkIdentity");
+                throw new InvalidOperationException("Reader is not MirageNetworkReader");
         }
 
         public static NetworkIdentity ReadNetworkIdentity(this NetworkReader reader)

--- a/Assets/Mirage/Runtime/Serialization/MirageTypesExtensions.cs
+++ b/Assets/Mirage/Runtime/Serialization/MirageTypesExtensions.cs
@@ -40,15 +40,27 @@ namespace Mirage.Serialization
             writer.WriteNetworkIdentity(identity);
         }
 
-
+        /// <summary>
+        /// Casts reader to <see cref="MirageNetworkReader"/>, throw if cast is invalid
+        /// </summary>
+        /// <param name=""></param>
+        public static MirageNetworkReader ToMirageReader(this NetworkReader reader)
+        {
+            if (reader is MirageNetworkReader mirageReader)
+                return mirageReader;
+            else
+                throw new InvalidOperationException("Must be MirageNetworkReader to use ReadNetworkIdentity");
+        }
 
         public static NetworkIdentity ReadNetworkIdentity(this NetworkReader reader)
         {
+            MirageNetworkReader mirageReader = reader.ToMirageReader();
+
             uint netId = reader.ReadPackedUInt32();
             if (netId == 0)
                 return null;
 
-            return FindNetworkIdentity(reader.ObjectLocator, netId);
+            return FindNetworkIdentity(mirageReader.ObjectLocator, netId);
         }
 
         private static NetworkIdentity FindNetworkIdentity(IObjectLocator objectLocator, uint netId)
@@ -67,6 +79,8 @@ namespace Mirage.Serialization
 
         public static NetworkBehaviour ReadNetworkBehaviour(this NetworkReader reader)
         {
+            MirageNetworkReader mirageReader = reader.ToMirageReader();
+
             // we can't use ReadNetworkIdentity here, because we need to know if netid was 0 or not
             // if it is not 0 we need to read component index even if NI is null, or it'll fail to deserilize next part
             uint netId = reader.ReadPackedUInt32();
@@ -76,7 +90,7 @@ namespace Mirage.Serialization
             // always read index if netid is not 0
             byte componentIndex = reader.ReadByte();
 
-            NetworkIdentity identity = FindNetworkIdentity(reader.ObjectLocator, netId);
+            NetworkIdentity identity = FindNetworkIdentity(mirageReader.ObjectLocator, netId);
             if (identity is null)
                 return null;
 

--- a/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkReader.cs
@@ -77,13 +77,6 @@ namespace Mirage.Serialization
             get => (bitPosition + 0b111) >> 3;
         }
 
-        /// <summary>
-        /// some service object that can find objects by net id
-        /// </summary>
-        // todo try move this somewhere else
-        public IObjectLocator ObjectLocator { get; set; }
-
-
         public NetworkReader() { }
 
         ~NetworkReader()

--- a/Assets/Mirage/Runtime/Serialization/NetworkReaderPool.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkReaderPool.cs
@@ -25,30 +25,62 @@ namespace Mirage.Serialization
             }
         }
 
-        public static PooledNetworkReader GetReader(ArraySegment<byte> packet)
+        /// <summary>
+        /// Gets reader from pool. sets internal array and objectLocator values
+        /// </summary>
+        /// <param name="packet"></param>
+        /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
+        /// <returns></returns>
+        public static PooledNetworkReader GetReader(ArraySegment<byte> packet, IObjectLocator objectLocator)
         {
             PooledNetworkReader reader = pool.Take();
+            reader.ObjectLocator = objectLocator;
             reader.Reset(packet.Array, packet.Offset, packet.Count);
             return reader;
         }
-        public static PooledNetworkReader GetReader(byte[] array)
+        /// <summary>
+        /// Gets reader from pool. sets internal array and objectLocator values
+        /// </summary>
+        /// <param name="packet"></param>
+        /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
+        /// <returns></returns>
+        public static PooledNetworkReader GetReader(byte[] array, IObjectLocator objectLocator)
         {
             PooledNetworkReader reader = pool.Take();
+            reader.ObjectLocator = objectLocator;
             reader.Reset(array, 0, array.Length);
             return reader;
         }
-        public static PooledNetworkReader GetReader(byte[] array, int offset, int length)
+        /// <summary>
+        /// Gets reader from pool. sets internal array and objectLocator values
+        /// </summary>
+        /// <param name="packet"></param>
+        /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
+        /// <returns></returns>
+        public static PooledNetworkReader GetReader(byte[] array, int offset, int length, IObjectLocator objectLocator)
         {
             PooledNetworkReader reader = pool.Take();
+            reader.ObjectLocator = objectLocator;
             reader.Reset(array, offset, length);
             return reader;
         }
     }
 
     /// <summary>
+    /// NetworkReader but has a ObjectLocator field that can be used by Reader functions to fetch NetworkIdentity
+    /// </summary>
+    public class MirageNetworkReader : NetworkReader
+    {
+        /// <summary>
+        /// Used to find objects by net id
+        /// </summary>
+        public IObjectLocator ObjectLocator { get; set; }
+    }
+
+    /// <summary>
     /// NetworkReader to be used with <see cref="NetworkReaderPool">NetworkReaderPool</see>
     /// </summary>
-    public sealed class PooledNetworkReader : NetworkReader, IDisposable
+    public sealed class PooledNetworkReader : MirageNetworkReader, IDisposable
     {
         private readonly Pool<PooledNetworkReader> pool;
 

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -463,9 +463,8 @@ namespace Mirage
 
             if (logger.LogEnabled()) logger.Log($"OnServerRpcMessage for netId={netId} conn={player}");
 
-            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(payload))
+            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(payload, Server.World))
             {
-                reader.ObjectLocator = Server.World;
                 remoteCall.Invoke(reader, behaviour, player, replyId);
             }
         }

--- a/Assets/Mirage/Runtime/SyncVarReceiver.cs
+++ b/Assets/Mirage/Runtime/SyncVarReceiver.cs
@@ -45,7 +45,7 @@ namespace Mirage
 
             if (objectLocator.TryGetIdentity(msg.netId, out NetworkIdentity localObject))
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
+                using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload, objectLocator))
                     localObject.OnDeserializeAll(networkReader, false);
             }
             else

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_MyByteEnum_0_3.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_MyByteEnum_0_3.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.MyByteE
 
                 Assert.That(writer.BitPosition, Is.EqualTo(2));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(2));
@@ -160,7 +160,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.MyByteE
 
                 Assert.That(writer.BitPosition, Is.EqualTo(2));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(2));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_MyDirection_N1_1.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_MyDirection_N1_1.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.MyDirec
 
                 Assert.That(writer.BitPosition, Is.EqualTo(2));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(2));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.MyDirec
 
                 Assert.That(writer.BitPosition, Is.EqualTo(2));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(2));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N1000_0.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N1000_0.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N10_10.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N10_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(5));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(5));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(5));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(5));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N20000_20000.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N20000_20000.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N20
 
                 Assert.That(writer.BitPosition, Is.EqualTo(16));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(16));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N20
 
                 Assert.That(writer.BitPosition, Is.EqualTo(16));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(16));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2000_N1000.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2000_N1000.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N20
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N20
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2147483648_2147483647.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2147483648_2147483647.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N21
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(32));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N21
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(32));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2147483648_2147483647max.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2147483648_2147483647max.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N21
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(32));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N21
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(32));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2147483648_2147483647min.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_int_N2147483648_2147483647min.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N21
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(32));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.int_N21
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(32));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_short_N1000_1000.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_short_N1000_1000.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.short_N
 
                 Assert.That(writer.BitPosition, Is.EqualTo(11));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(11));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.short_N
 
                 Assert.That(writer.BitPosition, Is.EqualTo(11));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(11));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_short_N10_10.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_short_N10_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.short_N
 
                 Assert.That(writer.BitPosition, Is.EqualTo(5));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(5));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.short_N
 
                 Assert.That(writer.BitPosition, Is.EqualTo(5));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(5));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_short_N32768_32767.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_short_N32768_32767.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.short_N
 
                 Assert.That(writer.BitPosition, Is.EqualTo(16));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(16));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.short_N
 
                 Assert.That(writer.BitPosition, Is.EqualTo(16));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(16));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_uint_0_5000.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_uint_0_5000.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.uint_0_
 
                 Assert.That(writer.BitPosition, Is.EqualTo(13));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(13));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.uint_0_
 
                 Assert.That(writer.BitPosition, Is.EqualTo(13));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(13));

--- a/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_ushort_0_65535.cs
+++ b/Assets/Tests/Generated/BitCountFromRangeTests/BitCountFromRange_ushort_0_65535.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.ushort_
 
                 Assert.That(writer.BitPosition, Is.EqualTo(16));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(16));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.ushort_
 
                 Assert.That(writer.BitPosition, Is.EqualTo(16));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(16));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_MyByteEnum_4.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_MyByteEnum_4.cs
@@ -69,7 +69,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.MyByteEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(4));
@@ -161,7 +161,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.MyByteEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(4));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_MyEnum_4.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_MyEnum_4.cs
@@ -69,7 +69,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.MyEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(4));
@@ -161,7 +161,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.MyEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(4));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_int_10.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_int_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.int_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.int_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_int_17.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_int_17.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.int_17
 
                 Assert.That(writer.BitPosition, Is.EqualTo(17));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(17));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.int_17
 
                 Assert.That(writer.BitPosition, Is.EqualTo(17));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(17));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_int_32.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_int_32.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.int_32
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(32));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.int_32
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(32));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_short_12.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_short_12.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.short_12
 
                 Assert.That(writer.BitPosition, Is.EqualTo(12));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(12));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.short_12
 
                 Assert.That(writer.BitPosition, Is.EqualTo(12));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(12));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_short_4.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_short_4.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.short_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(4));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.short_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(4));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_ulong_24.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_ulong_24.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.ulong_24
 
                 Assert.That(writer.BitPosition, Is.EqualTo(24));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(24));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.ulong_24
 
                 Assert.That(writer.BitPosition, Is.EqualTo(24));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(24));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_ulong_5.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_ulong_5.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.ulong_5
 
                 Assert.That(writer.BitPosition, Is.EqualTo(5));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(5));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.ulong_5
 
                 Assert.That(writer.BitPosition, Is.EqualTo(5));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(5));

--- a/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_ulong_64.cs
+++ b/Assets/Tests/Generated/BitCountTests/BitCountBehaviour_ulong_64.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.ulong_64
 
                 Assert.That(writer.BitPosition, Is.EqualTo(64));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(64));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.ulong_64
 
                 Assert.That(writer.BitPosition, Is.EqualTo(64));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(64));

--- a/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_100_10.cs
+++ b/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_100_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._100_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._100_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_100_14.cs
+++ b/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_100_14.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._100_14
 
                 Assert.That(writer.BitPosition, Is.EqualTo(14));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(14));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._100_14
 
                 Assert.That(writer.BitPosition, Is.EqualTo(14));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(14));

--- a/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_10_10.cs
+++ b/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_10_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._10_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._10_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_1_8.cs
+++ b/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_1_8.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._1_8
 
                 Assert.That(writer.BitPosition, Is.EqualTo(8));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(8));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._1_8
 
                 Assert.That(writer.BitPosition, Is.EqualTo(8));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(8));

--- a/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_500_14.cs
+++ b/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_500_14.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._500_14
 
                 Assert.That(writer.BitPosition, Is.EqualTo(14));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(14));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._500_14
 
                 Assert.That(writer.BitPosition, Is.EqualTo(14));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(14));

--- a/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_500_17.cs
+++ b/Assets/Tests/Generated/FloatPackTests/FloatPackBehaviour_500_17.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._500_17
 
                 Assert.That(writer.BitPosition, Is.EqualTo(17));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(17));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests._500_17
 
                 Assert.That(writer.BitPosition, Is.EqualTo(17));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(17));

--- a/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_10_0.cs
+++ b/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_10_0.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._10_0
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(32));
@@ -164,7 +164,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._10_0
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(32));

--- a/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_10_45.cs
+++ b/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_10_45.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._10_45
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(32));
@@ -164,7 +164,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._10_45
 
                 Assert.That(writer.BitPosition, Is.EqualTo(32));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(32));

--- a/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_8_0.cs
+++ b/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_8_0.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._8_0
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(26));
@@ -164,7 +164,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._8_0
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(26));

--- a/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_8_45.cs
+++ b/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_8_45.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._8_45
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(26));
@@ -164,7 +164,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._8_45
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(26));

--- a/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_9_0.cs
+++ b/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_9_0.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._9_0
 
                 Assert.That(writer.BitPosition, Is.EqualTo(29));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(29));
@@ -164,7 +164,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._9_0
 
                 Assert.That(writer.BitPosition, Is.EqualTo(29));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(29));

--- a/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_9_45.cs
+++ b/Assets/Tests/Generated/QuaternionPackTests/QuaternionPackBehaviour_9_45.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._9_45
 
                 Assert.That(writer.BitPosition, Is.EqualTo(29));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(29));
@@ -164,7 +164,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests._9_45
 
                 Assert.That(writer.BitPosition, Is.EqualTo(29));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(29));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_MyEnumByte_4.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_MyEnumByte_4.cs
@@ -87,7 +87,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.MyEnumByte_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -188,7 +188,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.MyEnumByte_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_MyEnum_4.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_MyEnum_4.cs
@@ -87,7 +87,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.MyEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -188,7 +188,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.MyEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_int_6.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_int_6.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.int_6
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.int_6
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_int_7.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_int_7.cs
@@ -75,7 +75,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.int_7
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -176,7 +176,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.int_7
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_long_8.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_long_8.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.long_8
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.long_8
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_short_6.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_short_6.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.short_6
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.short_6
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_uint_6.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_uint_6.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.uint_6
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.uint_6
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_uint_7.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_uint_7.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.uint_7
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.uint_7
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_uint_8.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_uint_8.cs
@@ -77,7 +77,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.uint_8
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -178,7 +178,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.uint_8
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_ulong_9.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_ulong_9.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.ulong_9
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.ulong_9
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_ushort_7.cs
+++ b/Assets/Tests/Generated/VarIntBlocksTests/VarIntBlocksBehaviour_ushort_7.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.ushort_7
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.ushort_7
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_MyEnumByte_4_64.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_MyEnumByte_4_64.cs
@@ -87,7 +87,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.MyEnumByte_4_64
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -188,7 +188,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.MyEnumByte_4_64
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_MyEnum_4_64.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_MyEnum_4_64.cs
@@ -87,7 +87,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.MyEnum_4_64
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -188,7 +188,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.MyEnum_4_64
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_int_100_1000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_int_100_1000.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.int_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.int_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_int_100_10000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_int_100_10000.cs
@@ -75,7 +75,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.int_100_10000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -176,7 +176,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.int_100_10000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_long_100_1000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_long_100_1000.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.long_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.long_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_short_100_1000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_short_100_1000.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.short_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.short_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_uint_100_1000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_uint_100_1000.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.uint_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.uint_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_uint_255_64000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_uint_255_64000.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.uint_255_64000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.uint_255_64000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_uint_500_32000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_uint_500_32000.cs
@@ -77,7 +77,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.uint_500_32000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -178,7 +178,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.uint_500_32000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_ulong_100_1000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_ulong_100_1000.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.ulong_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.ulong_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_ushort_100_1000.cs
+++ b/Assets/Tests/Generated/VarIntTests/VarIntBehaviour_ushort_100_1000.cs
@@ -76,7 +76,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.ushort_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -177,7 +177,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.ushort_100_1000
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_27b2.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_27b2.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_27b2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(27));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(27));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_27b2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(27));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(27));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_27f.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_27f.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_27f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(27));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(27));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_27f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(27));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(27));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_27f2.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_27f2.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_27f2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(27));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(27));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_27f2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(27));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(27));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_30b.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_1000_30b.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_30b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(30));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(30));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._1000_30b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(30));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(30));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_18b2.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_18b2.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_18b2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(18));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(18));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_18b2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(18));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(18));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_18f.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_18f.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_18f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(18));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(18));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_18f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(18));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(18));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_18f2.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_18f2.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_18f2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(18));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(18));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_18f2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(18));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(18));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_20b.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_100_20b.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_20b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(20));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(20));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._100_20b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(20));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(20));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26b.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26b.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(26));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(26));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26b2.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26b2.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26b2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(26));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26b2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(26));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26f.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26f.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(26));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(26));

--- a/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26f2.cs
+++ b/Assets/Tests/Generated/Vector2PackTests/Vector2PackBehaviour_200_26f2.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26f2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(26));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests._200_26f2
 
                 Assert.That(writer.BitPosition, Is.EqualTo(26));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(26));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_42b3.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_42b3.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_42b3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(42));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(42));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_42b3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(42));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(42));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_42f.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_42f.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_42f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(42));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(42));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_42f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(42));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(42));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_42f3.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_42f3.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_42f3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(42));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(42));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_42f3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(42));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(42));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_45b.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_1000_45b.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_45b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(45));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(45));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._1000_45b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(45));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(45));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_28b3.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_28b3.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_28b3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(28));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(28));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_28b3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(28));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(28));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_28f.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_28f.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_28f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(28));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(28));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_28f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(28));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(28));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_28f3.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_28f3.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_28f3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(28));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(28));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_28f3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(28));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(28));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_30b.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_100_30b.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_30b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(30));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(30));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._100_30b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(30));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(30));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39b.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39b.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(39));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39b
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(39));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39b3.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39b3.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39b3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(39));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39b3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(39));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39f.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39f.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(39));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39f
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(39));

--- a/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39f3.cs
+++ b/Assets/Tests/Generated/Vector3PackTests/Vector3PackBehaviour_200_39f3.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39f3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(39));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests._200_39f3
 
                 Assert.That(writer.BitPosition, Is.EqualTo(39));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(39));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_MyEnum2_4_negative.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_MyEnum2_4_negative.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.MyEnum2_4_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(4));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.MyEnum2_4_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(4));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_MyEnum_4.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_MyEnum_4.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.MyEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(4));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.MyEnum_4
 
                 Assert.That(writer.BitPosition, Is.EqualTo(4));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(4));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_int_10.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_int_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.int_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.int_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_int_10_negative.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_int_10_negative.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.int_10_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.int_10_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_long_10.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_long_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.long_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.long_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_long_10_negative.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_long_10_negative.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.long_10_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.long_10_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_short_10.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_short_10.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.short_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.short_10
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_short_10_negative.cs
+++ b/Assets/Tests/Generated/ZigZagTests/ZigZagBehaviour_short_10_negative.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.short_10_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(10));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.short_10_negative
 
                 Assert.That(writer.BitPosition, Is.EqualTo(10));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(10));

--- a/Assets/Tests/Generators/.BitCountFromRangeTestTemplate.cs
+++ b/Assets/Tests/Generators/.BitCountFromRangeTestTemplate.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.%%NAME%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountFromRangeAttributeTests.%%NAME%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));

--- a/Assets/Tests/Generators/.BitCountTestTemplate.cs
+++ b/Assets/Tests/Generators/.BitCountTestTemplate.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.%%TYPE%%_%%BIT_C
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.BitCountAttributeTests.%%TYPE%%_%%BIT_C
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));

--- a/Assets/Tests/Generators/.FloatPackTestTemplate.cs
+++ b/Assets/Tests/Generators/.FloatPackTestTemplate.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.FloatPackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));

--- a/Assets/Tests/Generators/.QuaternionPackTestTemplate.cs
+++ b/Assets/Tests/Generators/.QuaternionPackTestTemplate.cs
@@ -72,7 +72,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
@@ -164,7 +164,7 @@ namespace Mirage.Tests.Runtime.Generated.QuaternionPackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));

--- a/Assets/Tests/Generators/.VarIntBlocksTestTemplate.cs
+++ b/Assets/Tests/Generators/.VarIntBlocksTestTemplate.cs
@@ -73,7 +73,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -174,7 +174,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntBlocksTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generators/.VarIntTestTemplate.cs
+++ b/Assets/Tests/Generators/.VarIntTestTemplate.cs
@@ -73,7 +73,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));
@@ -174,7 +174,7 @@ namespace Mirage.Tests.Runtime.Generated.VarIntTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(expectedBitCount));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(expectedBitCount));

--- a/Assets/Tests/Generators/.Vector2PackTestTemplate.cs
+++ b/Assets/Tests/Generators/.Vector2PackTestTemplate.cs
@@ -67,7 +67,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
@@ -159,7 +159,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector2PackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));

--- a/Assets/Tests/Generators/.Vector3PackTestTemplate.cs
+++ b/Assets/Tests/Generators/.Vector3PackTestTemplate.cs
@@ -68,7 +68,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
@@ -162,7 +162,7 @@ namespace Mirage.Tests.Runtime.Generated.Vector3PackAttributeTests.%%NAME%%
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));

--- a/Assets/Tests/Generators/.ZigzagTestTemplate.cs
+++ b/Assets/Tests/Generators/.ZigzagTestTemplate.cs
@@ -61,7 +61,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.%%TYPE%%_%%BIT_COU
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     clientComponent.DeserializeSyncVars(reader, true);
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
@@ -153,7 +153,7 @@ namespace Mirage.Tests.Runtime.Generated.ZigZagAttributeTests.%%TYPE%%_%%BIT_COU
 
                 Assert.That(writer.BitPosition, Is.EqualTo(%%BIT_COUNT%%));
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), null))
                 {
                     var outStruct = reader.Read<BitPackStruct>();
                     Assert.That(reader.BitPosition, Is.EqualTo(%%BIT_COUNT%%));

--- a/Assets/Tests/Runtime/Serialization/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Tests/Runtime/Serialization/NetworkBehaviourSerializeTest.cs
@@ -155,7 +155,7 @@ namespace Mirage.Tests.Runtime.Serialization.NetworkBehaviourSerialize
             {
                 source.OnSerialize(writer, initialState);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), target.World))
                 {
                     target.OnDeserialize(reader, initialState);
                 }

--- a/Assets/Tests/Runtime/Serialization/NetworkReaderTest.cs
+++ b/Assets/Tests/Runtime/Serialization/NetworkReaderTest.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using Mirage.Serialization;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Mirage.Tests.Runtime.Serialization
@@ -23,6 +25,51 @@ namespace Mirage.Tests.Runtime.Serialization
                     reader.ReadBytes(bytes, 0, bytes.Length + 1);
                 });
             }
+        }
+
+        [Test]
+        public void GettingReaderSetObjectLocator_WithBytes()
+        {
+            IObjectLocator locator = Substitute.For<IObjectLocator>();
+            byte[] bytes = { 0x00, 0x01 };
+            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(bytes, locator))
+            {
+                Assert.That(reader.ObjectLocator, Is.EqualTo(locator));
+            }
+        }
+
+        [Test]
+        public void GettingReaderSetObjectLocator_WithSegment()
+        {
+            IObjectLocator locator = Substitute.For<IObjectLocator>();
+            byte[] bytes = { 0x00, 0x01 };
+            var segment = new ArraySegment<byte>(bytes);
+            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(segment, locator))
+            {
+                Assert.That(reader.ObjectLocator, Is.EqualTo(locator));
+            }
+        }
+
+        [Test]
+        public void GettingReaderSetObjectLocator_WithBytesAndLength()
+        {
+            IObjectLocator locator = Substitute.For<IObjectLocator>();
+            byte[] bytes = { 0x00, 0x01 };
+            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(bytes, 0, 2, locator))
+            {
+                Assert.That(reader.ObjectLocator, Is.EqualTo(locator));
+            }
+        }
+
+        [Test]
+        public void ThrowsIfNotMirageReader()
+        {
+            var reader = new NetworkReader();
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = reader.ToMirageReader();
+            });
+            Assert.That(exception, Has.Message.EqualTo("Reader is not MirageNetworkReader"));
         }
     }
 }

--- a/Assets/Tests/Runtime/Serialization/NetworkReaderTest.cs
+++ b/Assets/Tests/Runtime/Serialization/NetworkReaderTest.cs
@@ -16,7 +16,7 @@ namespace Mirage.Tests.Runtime.Serialization
             // should throw an exception
             byte[] bytes = { 0x00, 0x01 };
 
-            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(bytes))
+            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(bytes, null))
             {
                 Assert.Throws<EndOfStreamException>(() =>
                 {

--- a/Assets/Tests/Runtime/Serialization/NetworkWriterTest.cs
+++ b/Assets/Tests/Runtime/Serialization/NetworkWriterTest.cs
@@ -12,7 +12,7 @@ namespace Mirage.Tests.Runtime.Serialization
     public class NetworkWriterTest
     {
         private readonly NetworkWriter writer = new NetworkWriter(1300);
-        private readonly NetworkReader reader = new NetworkReader();
+        private readonly MirageNetworkReader reader = new MirageNetworkReader();
 
         [SetUp]
         public void Setup()

--- a/Assets/Tests/Runtime/SyncVarHookOrderTest.cs
+++ b/Assets/Tests/Runtime/SyncVarHookOrderTest.cs
@@ -100,7 +100,7 @@ namespace Mirage.Tests.Runtime.Serialization
             {
                 serverComponent.SerializeSyncVars(writer, initial);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment(), clientComponent.World))
                 {
                     clientComponent.DeserializeSyncVars(reader, initial);
                 }

--- a/Assets/Tests/Runtime/SyncVarTest.cs
+++ b/Assets/Tests/Runtime/SyncVarTest.cs
@@ -22,7 +22,7 @@ namespace Mirage.Tests.Runtime.Serialization
     {
         readonly NetworkWriter ownerWriter = new NetworkWriter(1300);
         readonly NetworkWriter observersWriter = new NetworkWriter(1300);
-        readonly NetworkReader reader = new NetworkReader();
+        readonly MirageNetworkReader reader = new MirageNetworkReader();
 
         [TearDown]
         public void TearDown()
@@ -149,14 +149,16 @@ namespace Mirage.Tests.Runtime.Serialization
         }
 
         [Test]
-        public void SetNetworkIdentitySyncvar()
+        [Description("Syncvars are converted to properties behind the scenes, this tests makes sure you can set and get them")]
+        public void CanSetAndGetNetworkIdentitySyncvar()
         {
             var gameObject = new GameObject("player", typeof(NetworkIdentity), typeof(MockPlayer));
+            var other = new GameObject("other", typeof(NetworkIdentity));
             MockPlayer player = gameObject.GetComponent<MockPlayer>();
 
-            player.target = gameObject.GetComponent<NetworkIdentity>();
+            player.target = other.GetComponent<NetworkIdentity>();
 
-            Assert.That(player.target, Is.EqualTo(player.GetComponent<NetworkIdentity>()));
+            Assert.That(player.target, Is.EqualTo(other.GetComponent<NetworkIdentity>()));
         }
     }
 }


### PR DESCRIPTION
This avoids bugs where you Get a reader but dont set objectLocator. The objectLocator value only needs to be set if reading NetworkIdentity, otherwise can be null.

Because Reader pool is static, but objectLocator belong to a single instance it should be set each time, so that a Reader does not return a NetworkIdentity from another instance of mirage.

Also moving ObjectLocator out of the base class NetworkReader and into a new MirageNetworkReader class. MirageNetworkReader Is used by the pool so all reader inside mirage will be MirageNetworkReader. This change makes it easier to use NetworkReader outside of mirage as it no longer depends on Mirage.

BREAKING CHANGE: NetworkReaderPool.GetReader now has IObjectLocator argument (can be null). Use MirageNetworkReader instead of NetworkReader if you need to read NetworkIdentity