### PR TITLE
fix: adding ability to start the Client & Server from interfaces

### DIFF
--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -40,6 +40,8 @@ namespace Mirage
 
         MessageHandler MessageHandler { get; }
 
+        void Connect(string address = null, ushort? port = null);
+
         void Disconnect();
     }
 }

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -1,5 +1,4 @@
 using Mirage.Events;
-using Mirage.SocketLayer;
 
 namespace Mirage
 {
@@ -42,8 +41,6 @@ namespace Mirage
         MessageHandler MessageHandler { get; }
 
         void Connect(string address = null, ushort? port = null);
-
-        void ConnectHost(INetworkServer server, IDataHandler serverDataHandler);
 
         void Disconnect();
     }

--- a/Assets/Mirage/Runtime/INetworkClient.cs
+++ b/Assets/Mirage/Runtime/INetworkClient.cs
@@ -1,4 +1,5 @@
 using Mirage.Events;
+using Mirage.SocketLayer;
 
 namespace Mirage
 {
@@ -41,6 +42,8 @@ namespace Mirage
         MessageHandler MessageHandler { get; }
 
         void Connect(string address = null, ushort? port = null);
+
+        void ConnectHost(INetworkServer server, IDataHandler serverDataHandler);
 
         void Disconnect();
     }

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -67,6 +67,8 @@ namespace Mirage
 
         IReadOnlyCollection<INetworkPlayer> Players { get; }
 
+        void StartServer();
+
         void Stop();
 
         void AddConnection(INetworkPlayer player);

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Mirage.Events;
-using Mirage.SocketLayer;
 
 namespace Mirage
 {
@@ -68,17 +67,13 @@ namespace Mirage
 
         IReadOnlyCollection<INetworkPlayer> Players { get; }
 
-        void StartServer(INetworkClient localClient = null);
+        void StartServer();
 
         void Stop();
 
         void AddConnection(INetworkPlayer player);
 
         void RemoveConnection(INetworkPlayer player);
-
-        void AddLocalConnection(INetworkClient client, IConnection connection);
-
-        void InvokeLocalConnected();
 
         void SendToAll<T>(T msg, int channelId = Channel.Reliable);
     }

--- a/Assets/Mirage/Runtime/INetworkServer.cs
+++ b/Assets/Mirage/Runtime/INetworkServer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Mirage.Events;
+using Mirage.SocketLayer;
 
 namespace Mirage
 {
@@ -67,13 +68,17 @@ namespace Mirage
 
         IReadOnlyCollection<INetworkPlayer> Players { get; }
 
-        void StartServer();
+        void StartServer(INetworkClient localClient = null);
 
         void Stop();
 
         void AddConnection(INetworkPlayer player);
 
         void RemoveConnection(INetworkPlayer player);
+
+        void AddLocalConnection(INetworkClient client, IConnection connection);
+
+        void InvokeLocalConnected();
 
         void SendToAll<T>(T msg, int channelId = Channel.Reliable);
     }

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -184,7 +184,7 @@ namespace Mirage
             _disconnected?.Invoke(ClientStoppedReason.HostModeStopped);
         }
 
-        internal void ConnectHost(NetworkServer server, IDataHandler serverDataHandler)
+        public void ConnectHost(INetworkServer server, IDataHandler serverDataHandler)
         {
             ThrowIfActive();
 

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -184,7 +184,7 @@ namespace Mirage
             _disconnected?.Invoke(ClientStoppedReason.HostModeStopped);
         }
 
-        public void ConnectHost(INetworkServer server, IDataHandler serverDataHandler)
+        internal void ConnectHost(NetworkServer server, IDataHandler serverDataHandler)
         {
             ThrowIfActive();
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -180,7 +180,7 @@ namespace Mirage
         /// <param name="config">Config for <see cref="Peer"/></param>
         /// <param name="localClient">if not null then start the server and client in hostmode</param>
         // Has to be called "StartServer" to stop unity complaining about "Start" method
-        public void StartServer(INetworkClient localClient = null)
+        public void StartServer(NetworkClient localClient = null)
         {
             ThrowIfActive();
             ThrowIfSocketIsMissing();
@@ -247,9 +247,14 @@ namespace Mirage
                 // this allows server methods like NetworkServer.Spawn to be called in there
                 _onStartHost?.Invoke();
 
-                LocalClient.ConnectHost(this, dataHandler);
+                localClient.ConnectHost(this, dataHandler);
                 if (logger.LogEnabled()) logger.Log("NetworkServer StartHost");
             }
+        }
+
+        void INetworkServer.StartServer()
+        {
+            StartServer();
         }
 
         void ThrowIfActive()
@@ -381,7 +386,7 @@ namespace Mirage
         /// Create Player on Server for hostmode and adds it to collections
         /// <para>Does not invoke <see cref="Connected"/> event, use <see cref="InvokeLocalConnected"/> instead at the correct time</para>
         /// </summary>
-        public void AddLocalConnection(INetworkClient client, IConnection connection)
+        internal void AddLocalConnection(INetworkClient client, IConnection connection)
         {
             if (LocalPlayer != null)
             {
@@ -402,7 +407,7 @@ namespace Mirage
         /// Invokes the Connected event using the local player
         /// <para>this should be done after the clients version has been invoked</para>
         /// </summary>
-        public void InvokeLocalConnected()
+        internal void InvokeLocalConnected()
         {
             if (LocalPlayer == null)
             {

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -180,7 +180,7 @@ namespace Mirage
         /// <param name="config">Config for <see cref="Peer"/></param>
         /// <param name="localClient">if not null then start the server and client in hostmode</param>
         // Has to be called "StartServer" to stop unity complaining about "Start" method
-        public void StartServer(NetworkClient localClient = null)
+        public void StartServer(INetworkClient localClient = null)
         {
             ThrowIfActive();
             ThrowIfSocketIsMissing();
@@ -247,14 +247,9 @@ namespace Mirage
                 // this allows server methods like NetworkServer.Spawn to be called in there
                 _onStartHost?.Invoke();
 
-                localClient.ConnectHost(this, dataHandler);
+                LocalClient.ConnectHost(this, dataHandler);
                 if (logger.LogEnabled()) logger.Log("NetworkServer StartHost");
             }
-        }
-
-        void INetworkServer.StartServer()
-        {
-            StartServer();
         }
 
         void ThrowIfActive()
@@ -386,7 +381,7 @@ namespace Mirage
         /// Create Player on Server for hostmode and adds it to collections
         /// <para>Does not invoke <see cref="Connected"/> event, use <see cref="InvokeLocalConnected"/> instead at the correct time</para>
         /// </summary>
-        internal void AddLocalConnection(INetworkClient client, IConnection connection)
+        public void AddLocalConnection(INetworkClient client, IConnection connection)
         {
             if (LocalPlayer != null)
             {
@@ -407,7 +402,7 @@ namespace Mirage
         /// Invokes the Connected event using the local player
         /// <para>this should be done after the clients version has been invoked</para>
         /// </summary>
-        internal void InvokeLocalConnected()
+        public void InvokeLocalConnected()
         {
             if (LocalPlayer == null)
             {

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -252,6 +252,11 @@ namespace Mirage
             }
         }
 
+        void INetworkServer.StartServer()
+        {
+            StartServer();
+        }
+
         void ThrowIfActive()
         {
             if (Active) throw new InvalidOperationException("Server is already active");


### PR DESCRIPTION
This PR stems from [this](https://discord.com/channels/809535064551456888/891063500846297161/977708825207517184) conversation. It adds the ability to start the server from the `INetworkServer` and connect from the `INetworkClient`.

Starting the host is also possible from the interfaces, however it required making several methods `public` instead of `internal` to allow for the interfaces to decouple the `NetworkServer` and `NetworkClient`. Let me know if this is ok.