### PR TITLE
fix: enabling runInBackground so that connections dont timeout

### DIFF
--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -40,6 +40,9 @@ namespace Mirage
 
         public bool DisconnectOnException = true;
 
+        [Tooltip("If true will set Application.runInBackground")]
+        public bool RunInBackground = true;
+
         Peer peer;
 
         [Tooltip("Authentication component attached to this object")]
@@ -131,6 +134,9 @@ namespace Mirage
             peer.OnDisconnected += Peer_OnDisconnected;
 
             IConnection connection = peer.Connect(endPoint);
+
+            if (RunInBackground)
+                Application.runInBackground = RunInBackground;
 
             // setup all the handlers
             Player = new NetworkPlayer(connection);

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -42,6 +42,9 @@ namespace Mirage
 
         public bool DisconnectOnException = true;
 
+        [Tooltip("If true will set Application.runInBackground")]
+        public bool RunInBackground = true;
+
         [Tooltip("If disabled the server will not create a Network Peer to listen. This can be used to run server single player mode")]
         public bool Listening = true;
 
@@ -230,6 +233,9 @@ namespace Mirage
                 peer.Bind(SocketFactory.GetBindEndPoint());
 
                 if (logger.LogEnabled()) logger.Log($"Server started, listening for connections. Using socket {socket.GetType()}");
+
+                if (RunInBackground)
+                    Application.runInBackground = RunInBackground;
             }
             else
             {


### PR DESCRIPTION
peer runs on main thread, so will be paused if runInBackground is false. This causes connections to timeout.