### PR TITLE
fix: fixing warning created from id generator

### DIFF
--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -348,6 +348,27 @@ namespace Mirage
             }
         }
 
+#if UNITY_EDITOR
+        /// <summary>
+        /// Gets PrefabHash avoiding runtime checks
+        /// <para>used by NetworkIdentityIdGenerator</para>
+        /// </summary>
+        internal int Editor_PrefabHash
+        {
+            get => _prefabHash;
+            set => _prefabHash = value;
+        }
+
+        /// <summary>
+        /// Gets SceneId avoiding runtime checks
+        /// <para>used by NetworkIdentityIdGenerator</para>
+        /// </summary>
+        internal ulong Editor_SceneId
+        {
+            get => _sceneId;
+            set => _sceneId = value;
+        }
+#endif
 
 
         [Header("Events")]


### PR DESCRIPTION
using SerializedObject was causing warning whe the editor first opened
using Undo should fix this