### PR TITLE
perf(Serialization)!: using unmanged pointer for read write

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -400,7 +400,7 @@ namespace Mirage
 
             // deserialize components if any payload
             // (Count is 0 if there were no components)
-            if (msg.payload.Count > 0)
+            if (msg.payload.Length > 0)
             {
                 using (var payloadReader = NetworkReaderPool.GetReader(msg.payload, Client.World))
                 {

--- a/Assets/Mirage/Runtime/INetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/INetworkPlayer.cs
@@ -1,4 +1,5 @@
 using System;
+using Mirage.Serialization;
 using Mirage.SocketLayer;
 
 namespace Mirage
@@ -9,7 +10,7 @@ namespace Mirage
     public interface IMessageSender
     {
         void Send<T>(T message, int channelId = Channel.Reliable);
-        void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable);
+        void Send(Segment segment, int channelId = Channel.Reliable);
         void Send<T>(T message, INotifyCallBack notifyCallBack);
     }
 

--- a/Assets/Mirage/Runtime/MessageHandler.cs
+++ b/Assets/Mirage/Runtime/MessageHandler.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Mirage
 {
-    public class MessageHandler : IMessageReceiver
+    public unsafe class MessageHandler : IMessageReceiver
     {
         private static readonly ILogger logger = LogFactory.GetLogger(typeof(MessageHandler));
 
@@ -108,11 +108,13 @@ namespace Mirage
             }
         }
 
+
+        // todo make Peer use unmanged buffers too
         public void HandleMessage(INetworkPlayer player, ArraySegment<byte> packet)
         {
-            using (var networkReader = NetworkReaderPool.GetReader(packet, _objectLocator))
+            var buffer = SegmentHelper.Convert(packet);
+            using (var networkReader = NetworkReaderPool.GetReader(buffer, _objectLocator))
             {
-
                 // protect against attackers trying to send invalid data packets
                 // exception could be throw if:
                 // - invalid headers

--- a/Assets/Mirage/Runtime/Messages.cs
+++ b/Assets/Mirage/Runtime/Messages.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using Mirage.Serialization;
 using UnityEngine;
 
 namespace Mirage
@@ -44,7 +44,7 @@ namespace Mirage
 
         // the parameters for the Cmd function
         // -> ArraySegment to avoid unnecessary allocations
-        public ArraySegment<byte> payload;
+        public Segment payload;
     }
 
     [NetworkMessage]
@@ -59,14 +59,14 @@ namespace Mirage
         public int replyId;
         // the parameters for the Cmd function
         // -> ArraySegment to avoid unnecessary allocations
-        public ArraySegment<byte> payload;
+        public Segment payload;
     }
 
     [NetworkMessage]
     public struct ServerRpcReply
     {
         public int replyId;
-        public ArraySegment<byte> payload;
+        public Segment payload;
     }
 
     [NetworkMessage]
@@ -77,7 +77,7 @@ namespace Mirage
         public int functionIndex;
         // the parameters for the Cmd function
         // -> ArraySegment to avoid unnecessary allocations
-        public ArraySegment<byte> payload;
+        public Segment payload;
     }
     #endregion
 
@@ -122,7 +122,7 @@ namespace Mirage
         /// The serialized component data
         /// <remark>ArraySegment to avoid unnecessary allocations</remark>
         /// </summary>
-        public ArraySegment<byte> payload;
+        public Segment payload;
     }
 
     [NetworkMessage]
@@ -155,7 +155,7 @@ namespace Mirage
         public uint netId;
         // the serialized component data
         // -> ArraySegment to avoid unnecessary allocations
-        public ArraySegment<byte> payload;
+        public Segment payload;
     }
 
     // A client sends this message to the server

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -280,7 +280,7 @@ namespace Mirage
             Player.Send(message, channelId);
         }
 
-        public void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable)
+        public void Send(Segment segment, int channelId = Channel.Reliable)
         {
             Player.Send(segment, channelId);
         }

--- a/Assets/Mirage/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirage/Runtime/NetworkIdentity.cs
@@ -1066,7 +1066,7 @@ namespace Mirage
                     //  below too)
                     if (ownerWritten > 0)
                     {
-                        varsMessage.payload = ownerWriter.ToArraySegment();
+                        varsMessage.payload = ownerWriter.ToSegment();
                         if (Owner != null && Owner.SceneIsReady)
                             Owner.Send(varsMessage);
                     }
@@ -1075,7 +1075,7 @@ namespace Mirage
                     // (only if we serialized anything for observers)
                     if (observersWritten > 0)
                     {
-                        varsMessage.payload = observersWriter.ToArraySegment();
+                        varsMessage.payload = observersWriter.ToSegment();
                         SendToRemoteObservers(varsMessage, false);
                     }
 

--- a/Assets/Mirage/Runtime/NetworkPlayer.cs
+++ b/Assets/Mirage/Runtime/NetworkPlayer.cs
@@ -153,11 +153,12 @@ namespace Mirage
             {
                 MessagePacker.Pack(message, writer);
 
-                var segment = writer.ToArraySegment();
-                NetworkDiagnostics.OnSend(message, segment.Count, 1);
+                var segment = writer.ToSegment();
+                NetworkDiagnostics.OnSend(message, segment.Length, 1);
                 Send(segment, channelId);
             }
         }
+
 
         /// <summary>
         /// Sends a block of data
@@ -165,17 +166,19 @@ namespace Mirage
         /// </summary>
         /// <param name="segment"></param>
         /// <param name="channelId"></param>
-        public void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable)
+        public void Send(Segment segment, int channelId = Channel.Reliable)
         {
             if (_isDisconnected) { return; }
 
+            var buffer = SegmentHelper.Convert(segment);
+
             if (channelId == Channel.Reliable)
             {
-                _connection.SendReliable(segment);
+                _connection.SendReliable(buffer);
             }
             else
             {
-                _connection.SendUnreliable(segment);
+                _connection.SendUnreliable(buffer);
             }
         }
 
@@ -194,9 +197,10 @@ namespace Mirage
             {
                 MessagePacker.Pack(message, writer);
 
-                var segment = writer.ToArraySegment();
-                NetworkDiagnostics.OnSend(message, segment.Count, 1);
-                _connection.SendNotify(segment, token);
+                var segment = writer.ToSegment();
+                NetworkDiagnostics.OnSend(message, segment.Length, 1);
+                var buffer = SegmentHelper.Convert(segment);
+                _connection.SendNotify(buffer, token);
             }
         }
 

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -436,7 +436,7 @@ namespace Mirage
             {
                 // pack message into byte[] once
                 MessagePacker.Pack(msg, writer);
-                var segment = writer.ToArraySegment();
+                var segment = writer.ToSegment();
                 var count = 0;
 
                 // using SendToMany (with IEnumerable) will cause Enumerator to be boxed and create GC/alloc
@@ -450,7 +450,7 @@ namespace Mirage
                 }
                 enumerator.Dispose();
 
-                NetworkDiagnostics.OnSend(msg, segment.Count, count);
+                NetworkDiagnostics.OnSend(msg, segment.Length, count);
             }
         }
 
@@ -468,7 +468,7 @@ namespace Mirage
             {
                 // pack message into byte[] once
                 MessagePacker.Pack(msg, writer);
-                var segment = writer.ToArraySegment();
+                var segment = writer.ToSegment();
                 var count = 0;
 
                 foreach (var player in players)
@@ -477,7 +477,7 @@ namespace Mirage
                     count++;
                 }
 
-                NetworkDiagnostics.OnSend(msg, segment.Count, count);
+                NetworkDiagnostics.OnSend(msg, segment.Length, count);
             }
         }
 
@@ -496,7 +496,7 @@ namespace Mirage
             {
                 // pack message into byte[] once
                 MessagePacker.Pack(msg, writer);
-                var segment = writer.ToArraySegment();
+                var segment = writer.ToSegment();
                 var count = players.Count;
 
                 for (var i = 0; i < count; i++)
@@ -504,7 +504,7 @@ namespace Mirage
                     players[i].Send(segment, channelId);
                 }
 
-                NetworkDiagnostics.OnSend(msg, segment.Count, count);
+                NetworkDiagnostics.OnSend(msg, segment.Length, count);
             }
         }
 

--- a/Assets/Mirage/Runtime/RemoteCalls/ClientRpcSender.cs
+++ b/Assets/Mirage/Runtime/RemoteCalls/ClientRpcSender.cs
@@ -45,7 +45,7 @@ namespace Mirage.RemoteCalls
                 netId = behaviour.NetId,
                 componentIndex = behaviour.ComponentIndex,
                 functionIndex = index,
-                payload = writer.ToArraySegment()
+                payload = writer.ToSegment()
             };
             return message;
         }

--- a/Assets/Mirage/Runtime/RemoteCalls/RemoteCallHelper.cs
+++ b/Assets/Mirage/Runtime/RemoteCalls/RemoteCallHelper.cs
@@ -46,7 +46,7 @@ namespace Mirage.RemoteCalls
                     var serverRpcReply = new ServerRpcReply
                     {
                         replyId = replyId,
-                        payload = writer.ToArraySegment()
+                        payload = writer.ToSegment()
                     };
 
                     senderPlayer.Send(serverRpcReply);

--- a/Assets/Mirage/Runtime/RemoteCalls/ServerRpcSender.cs
+++ b/Assets/Mirage/Runtime/RemoteCalls/ServerRpcSender.cs
@@ -18,7 +18,7 @@ namespace Mirage.RemoteCalls
                 netId = behaviour.NetId,
                 componentIndex = behaviour.ComponentIndex,
                 functionIndex = index,
-                payload = writer.ToArraySegment()
+                payload = writer.ToSegment()
             };
 
             behaviour.Client.Send(message, channelId);
@@ -32,7 +32,7 @@ namespace Mirage.RemoteCalls
                 netId = behaviour.NetId,
                 componentIndex = behaviour.ComponentIndex,
                 functionIndex = index,
-                payload = writer.ToArraySegment()
+                payload = writer.ToSegment()
             };
 
             (var task, var id) = behaviour.ClientObjectManager.CreateReplyTask<T>();

--- a/Assets/Mirage/Runtime/Serialization/CollectionExtensions.cs
+++ b/Assets/Mirage/Runtime/Serialization/CollectionExtensions.cs
@@ -87,6 +87,24 @@ namespace Mirage.Serialization
             }
         }
 
+        public static unsafe void WriteSegmentAndSize(this NetworkWriter writer, Segment segment)
+        {
+            if (segment.Ptr == null)
+            {
+                WriteCountPlusOne(writer, null);
+                return;
+            }
+
+            WriteCountPlusOne(writer, segment.Length);
+            writer.WriteSegment(segment);
+        }
+        public static Segment ReaderSegmentAndSize(this NetworkReader reader)
+        {
+            return ReadCountPlusOne(reader, out var count)
+                ? reader.ReadSegment(count)
+                : default;
+        }
+
 
         /// <returns>array or null</returns>
         public static byte[] ReadBytesAndSize(this NetworkReader reader)
@@ -98,6 +116,7 @@ namespace Mirage.Serialization
                 : null;
         }
 
+        [System.Obsolete("Use Segment instead", true)]
         public static ArraySegment<byte> ReadBytesAndSizeSegment(this NetworkReader reader)
         {
             // dont need to ValidateSize here because we dont allocate for segment

--- a/Assets/Mirage/Runtime/Serialization/MessagePacker.cs
+++ b/Assets/Mirage/Runtime/Serialization/MessagePacker.cs
@@ -77,6 +77,7 @@ namespace Mirage.Serialization
         // helper function to pack message into a simple byte[] (which allocates)
         // => useful for tests
         // => useful for local client message enqueue
+        [System.Obsolete("Use Segment instead", true)]
         public static byte[] Pack<T>(T message)
         {
             using (var writer = NetworkWriterPool.GetWriter())
@@ -103,6 +104,7 @@ namespace Mirage.Serialization
         /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
         /// <returns></returns>
         /// <exception cref="FormatException"></exception>
+        [System.Obsolete("Use Segment instead", true)]
         public static T Unpack<T>(byte[] data, IObjectLocator objectLocator)
         {
             using (var networkReader = NetworkReaderPool.GetReader(data, objectLocator))

--- a/Assets/Mirage/Runtime/Serialization/NetworkReaderPool.cs
+++ b/Assets/Mirage/Runtime/Serialization/NetworkReaderPool.cs
@@ -31,6 +31,21 @@ namespace Mirage.Serialization
         /// <param name="packet"></param>
         /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
         /// <returns></returns>
+        public static PooledNetworkReader GetReader(Segment packet, IObjectLocator objectLocator)
+        {
+            var reader = pool.Take();
+            reader.ObjectLocator = objectLocator;
+            reader.Reset(packet);
+            return reader;
+        }
+
+        /// <summary>
+        /// Gets reader from pool. sets internal array and objectLocator values
+        /// </summary>
+        /// <param name="packet"></param>
+        /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
+        /// <returns></returns>
+        [System.Obsolete("Use Segment instead", true)]
         public static PooledNetworkReader GetReader(ArraySegment<byte> packet, IObjectLocator objectLocator)
         {
             var reader = pool.Take();
@@ -44,6 +59,7 @@ namespace Mirage.Serialization
         /// <param name="packet"></param>
         /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
         /// <returns></returns>
+        [System.Obsolete("Use Segment instead", true)]
         public static PooledNetworkReader GetReader(byte[] array, IObjectLocator objectLocator)
         {
             var reader = pool.Take();
@@ -57,6 +73,7 @@ namespace Mirage.Serialization
         /// <param name="packet"></param>
         /// <param name="objectLocator">Can be null, but must be set in order to read NetworkIdentity Values</param>
         /// <returns></returns>
+        [System.Obsolete("Use Segment instead", true)]
         public static PooledNetworkReader GetReader(byte[] array, int offset, int length, IObjectLocator objectLocator)
         {
             var reader = pool.Take();

--- a/Assets/Mirage/Runtime/Serialization/StringExtensions.cs
+++ b/Assets/Mirage/Runtime/Serialization/StringExtensions.cs
@@ -45,7 +45,7 @@ namespace Mirage.Serialization
 
         /// <returns>string or null</returns>
         /// <exception cref="ArgumentException">Throws if invalid utf8 string is received</exception>
-        public static string ReadString(this NetworkReader reader)
+        public unsafe static string ReadString(this NetworkReader reader)
         {
             // read number of bytes
             var size = reader.ReadUInt16();
@@ -61,10 +61,10 @@ namespace Mirage.Serialization
                 throw new EndOfStreamException($"ReadString too long: {realSize}. Limit is: {MaxStringLength}");
             }
 
-            var data = reader.ReadBytesSegment(realSize);
+            var data = reader.ReadSegment(realSize);
 
             // convert directly from buffer to string via encoding
-            return encoding.GetString(data.Array, data.Offset, data.Count);
+            return encoding.GetString((byte*)data.Ptr, data.Length);
         }
     }
 }

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -436,7 +436,7 @@ namespace Mirage
             OnServerRpc(player, msg.netId, msg.componentIndex, msg.functionIndex, msg.payload, default);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void OnServerRpc(INetworkPlayer player, uint netId, int componentIndex, int functionIndex, ArraySegment<byte> payload, int replyId)
+        private void OnServerRpc(INetworkPlayer player, uint netId, int componentIndex, int functionIndex, Segment payload, int replyId)
         {
             if (!Server.World.TryGetIdentity(netId, out var identity))
             {
@@ -602,7 +602,7 @@ namespace Mirage
             });
         }
 
-        private static ArraySegment<byte> CreateSpawnMessagePayload(bool isOwner, NetworkIdentity identity, PooledNetworkWriter ownerWriter, PooledNetworkWriter observersWriter)
+        private static Segment CreateSpawnMessagePayload(bool isOwner, NetworkIdentity identity, PooledNetworkWriter ownerWriter, PooledNetworkWriter observersWriter)
         {
             // Only call OnSerializeAllSafely if there are NetworkBehaviours
             if (identity.NetworkBehaviours.Length == 0)
@@ -616,9 +616,9 @@ namespace Mirage
 
             // use owner segment if 'conn' owns this identity, otherwise
             // use observers segment
-            var payload = isOwner ?
-                ownerWriter.ToArraySegment() :
-                observersWriter.ToArraySegment();
+            var payload = isOwner
+                ? ownerWriter.ToSegment()
+                : observersWriter.ToSegment();
 
             return payload;
         }


### PR DESCRIPTION
Replacing managed buffers inside networkwriter and networkreader with pointers instead

BREAKING CHANGE: ToArray and ToArraySegment methods are now Obsolete and should be replaced with ToSegment