### PR TITLE
fix: miscellanous NanoSocket bits and pieces, add Mirage Standalone support

### DIFF
--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoEndPoint.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoEndPoint.cs
@@ -1,4 +1,3 @@
-#if UNITY_STANDALONE || UNITY_EDITOR
 using System;
 using Mirage.SocketLayer;
 using NanoSockets;
@@ -52,4 +51,3 @@ namespace Mirage.Sockets.Udp
         }
     }
 }
-#endif

--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoSocket.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoSocket.cs
@@ -1,4 +1,3 @@
-#if UNITY_STANDALONE || UNITY_EDITOR
 using System;
 using Mirage.SocketLayer;
 using NanoSockets;
@@ -90,4 +89,3 @@ namespace Mirage.Sockets.Udp
         }
     }
 }
-#endif

--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
@@ -21,7 +21,6 @@
  *  SOFTWARE.
  */
 
-#if UNITY_STANDALONE || UNITY_EDITOR
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -233,4 +232,3 @@ namespace NanoSockets
 #endif
     }
 }
-#endif

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -5,6 +5,8 @@
 #define NANO_SOCKET_ALLOWED
 #endif
 
+
+
 using Mirage.SocketLayer;
 using System;
 using System.Net;
@@ -23,10 +25,10 @@ namespace Mirage.Sockets.Udp
         public string Address = "localhost";
         public ushort Port = 7777;
 
-        [Tooltip("Allows you to set which Socket implementation you want to use.\nAutomatic will use native (NanoSockets) on supported platforms (Windows, Mac & Linux).")]
-        public SocketLib SocketLib;
+        [Tooltip("Which socket implementation do you wish to use?\nThe default (automatic) will attempt to use NanoSockets on supported platforms (Windows, Mac & Linux) and fallback to C# Sockets if unsupported.")]
+        public SocketLib SocketLib = SocketLib.Automatic;
 
-        [Header("NanoSocket options")]
+        [Header("NanoSocket-specific Options")]
         public int BufferSize = 256 * 1024;
 
         public override int MaxPacketSize => UdpMTU.MaxPacketSize;
@@ -38,6 +40,7 @@ namespace Mirage.Sockets.Udp
             get => Address;
             set => Address = value;
         }
+
         int IHasPort.Port
         {
             get => Port;
@@ -54,12 +57,14 @@ namespace Mirage.Sockets.Udp
 
         private void Awake()
         {
+            // Do not attempt to initialize NanoSockets if we're not using them.
             if (!useNanoSocket) return;
 
-            // NanoSocket is only available on Windows, Mac and Linux
-            // However on newer versions of Mac it causes the standalone builds
-            // to be unable to load the NanoSocket native library. So we just use
-            // C# Managed sockets instead.
+            // NanoSocket is only available on Windows, Mac and Linux... but...
+            // However on some versions of Mac it causes the standalone builds
+            // to be unable to load the NanoSocket native library. Maybe a issue with
+            // unsigned libraries or maybe Gatekeeper? So we just use C# managed sockets instead.
+            // TODO: Review this and actually see if it's a problem on Monterey.
 
             // give different warning for OSX
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -1,11 +1,9 @@
 // nanosockets breaks on some platforms (like iOS)
 // so only include it for standalone and editor
 // but not for mac because of code signing issue
-#if (UNITY_STANDALONE || UNITY_EDITOR) && !(UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
+#if !(UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
 #define NANO_SOCKET_ALLOWED
 #endif
-
-
 
 using Mirage.SocketLayer;
 using System;
@@ -68,16 +66,14 @@ namespace Mirage.Sockets.Udp
 
             // give different warning for OSX
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-            Debug.LogWarning("NanoSocket support on MacOS is tempermental due to codesigning issues.\nTo ensure functionality, C# sockets will be used instead. This message is harmless (don't panic!).");
-            SocketLib = SocketLib.Managed;
+            Debug.LogWarning("To ensure functionality, C# sockets will be used instead due to NanoSockets being tempermental. Don't panic: this message is harmless!");
+            this.SocketLib = SocketLib.Managed;
             return;
-
-            // "Standalone" here is referring to Win64 or Linux64, but not mac, because that should be covered by case above
 #elif NANO_SOCKET_ALLOWED
             // Attempt initialization of NanoSockets native library. If this fails, go back to native.
             InitializeNanoSockets();
 #else
-            Debug.LogWarning("NanoSocket does not support this platform (non-desktop platform detected). Switching to C# Managed sockets.");
+            Debug.LogWarning("NanoSocket doesn't support this platform, falling back to C# Managed Sockets.");
             this.SocketLib = SocketLib.Managed;
 #endif
         }
@@ -92,9 +88,9 @@ namespace Mirage.Sockets.Udp
 
                 initCount++;
             }
-            catch (DllNotFoundException)
+            catch (Exception ex)
             {
-                Debug.LogWarning("NanoSocket DLL not found or failed to load. Switching to C# Managed Sockets.");
+                Debug.LogWarning($"NanoSocket native library not found or failed to load; switching to C# Managed Sockets. Exception returned was:\n{ex}");
                 SocketLib = SocketLib.Managed;
             }
         }
@@ -107,10 +103,7 @@ namespace Mirage.Sockets.Udp
 #if NANO_SOCKET_ALLOWED
             initCount--;
 
-            if (initCount == 0)
-            {
-                UDP.Deinitialize();
-            }
+            if (initCount == 0) UDP.Deinitialize();
 #endif
         }
 

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -170,18 +170,27 @@ namespace Mirage.Sockets.Udp
 
         private void ThrowIfNotSupported()
         {
-            if (IsWebgl)
+            if (IsWebGL)
             {
                 throw new NotSupportedException("The WebGL platform does not support UDP Sockets. Please use WebSockets instead.");
             }
         }
 
-        private static bool IsWebgl => Application.platform == RuntimePlatform.WebGLPlayer;
-        private static bool IsDesktop =>
-            Application.platform == RuntimePlatform.LinuxPlayer
+        private static bool isThisADesktopTarget()
+        {
+#if UNITY_STANDALONE || UNITY_EDITOR
+            return Application.platform == RuntimePlatform.LinuxPlayer
             || Application.platform == RuntimePlatform.OSXPlayer
             || Application.platform == RuntimePlatform.WindowsPlayer
             || Application.isEditor;
+#else
+            // Added for basic support in Mirage Standalone.
+            return true;
+#endif
+        }
+
+        private static bool IsWebGL => Application.platform == RuntimePlatform.WebGLPlayer;
+        private static bool IsDesktop => isThisADesktopTarget();
     }
 
     public class EndPointWrapper : IEndPoint


### PR DESCRIPTION
This is a multi-commit PR that addresses a few things:

1. Renamed some variables (ie `isWebgl` is now `isWebGL`). This is more just for cosmetic appearance, and these were used internally and not outside of the Mirage Sockets' layer.
2. Introduced NanoSockets compatibility for Mirage Standalone. Had to remove `#if UNITY_EDITOR || UNITY_STANDALONE` defines in the NanoSockets source files or the Mirage Standalone project would complain.
3. Patched `isDesktop` to point to a boolean-returning function instead of a expression for Mirage Standalone compatibility.
4. Rewrote/Reworked some tooltip(s) and error message(s).

Tested briefly on Windows instance of the Unity Editor version 2020.3.38. Shouldn't break anything, I hope.