### PR TITLE
fix: il2cpp linux runtime SIGABRT crash with nanosockets (unity 2021.3.15+ ?)

### DIFF
--- a/Assets/Mirage/Runtime/Sockets/Udp/Mirage.Sockets.Udp.asmdef
+++ b/Assets/Mirage/Runtime/Sockets/Udp/Mirage.Sockets.Udp.asmdef
@@ -1,11 +1,12 @@
 {
     "name": "Mirage.Sockets.Udp",
+    "rootNamespace": "",
     "references": [
         "GUID:c0b2064c294eb174c9f3f7da398eb677"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoEndPoint.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoEndPoint.cs
@@ -6,11 +6,10 @@ namespace Mirage.Sockets.Udp
 {
     public sealed class NanoEndPoint : IEndPoint, IEquatable<NanoEndPoint>
     {
-        public Address address;
+        public Address address = new Address();
 
         public NanoEndPoint(string host, ushort port)
         {
-            address = new Address();
             address.port = port;
             UDP.SetHostName(ref address, host);
         }

--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
@@ -99,21 +99,12 @@ namespace NanoSockets
             // commit suicide.
             // Solution: Allocate 64 bytes on the stack, tell NanoSockets to put the
             // IP into that, then read as string in the return function. Tested and
-            // confirmed working on Manjaro x64.
-
+            // confirmed working on Manjaro x64 (Unity 2021.3.15).
 
             // Attempt v2 (2022-12-09): Use unsafe pointer for the IP string.
             var ptr = stackalloc char[64];
             UDP.GetIP(ref this, (IntPtr)ptr, 64);
             return $"IP: {new string(ptr)} Port: {this.Port}";
-
-            // Original code is as follows.
-            /*
-            // function header: public override string ToString()
-            var ip = new StringBuilder(64);
-            NanoSockets.UDP.GetIP(ref this, ip, 64);
-            return string.Format("IP:{0} Port:{1}", ip, this.port);
-            */
         }
 
         public static Address CreateFromIpPort(string ip, ushort port)

--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
@@ -5,7 +5,6 @@
  *  NanoSockets modifications made by Mirage Team
  *  Copyright (c) 2022 Mirage Team and contributors.
  *  
- *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
  *  in the Software without restriction, including without limitation the rights
@@ -29,6 +28,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using Mirage.SocketLayer;
 
 namespace NanoSockets
 {
@@ -89,43 +89,27 @@ namespace NanoSockets
             return hash;
         }
 
-        public override string ToString()
+             
+        public unsafe override string ToString()
         {
             // FIX: Unity IL2CPP SIGABRT in 2021.3.15 on Linux builds
             // Problem: On Linux IL2CPP builds, it seems something with
             // IL2CPP and StringBuilder causes SIGABRT to be emitted due to
             // a bad free of a pointer: "free(): invalid pointer". Unity will then
             // commit suicide.
-            // Solution: This successfully works around it, unfortunately at
-            // a cost of 64 * 2 bytes of memory every time ToString() is called.
-            // Improvements welcome.
+            // Solution: Allocate 64 bytes on the stack, tell NanoSockets to put the
+            // IP into that, then read as string in the return function. Tested and
+            // confirmed working on Manjaro x64.
 
-            // Allocate 64 bytes of memory temporarily.
-            var ipPtr = Marshal.AllocHGlobal(64);
-            var ipAddress = string.Empty;
 
-            // Check if the GetIP call was possible
-            if (UDP.GetIP(ref this, ipPtr, 64) == 0)
-            {
-                // NanoSockets returned OK. Copy that to an ANSI string.
-                // Pretty sure we won't have UTF-8 in our IP addresses...
-                ipAddress = Marshal.PtrToStringAnsi(ipPtr, 64);
-
-                // Free the memory, otherwise memory leak = bad!
-                Marshal.FreeHGlobal(ipPtr);
-
-                return string.Format("{0}:{1}", ipAddress, port);
-            }
-            else
-            {
-                // Free the allocated memory, even though we didn't use it.
-                Marshal.FreeHGlobal(ipPtr);
-                // Return a UNKNOWN string just to make the function happy.
-                return "UNKNOWN";
-            }
+            // Attempt v2 (2022-12-09): Use unsafe pointer for the IP string.
+            var ptr = stackalloc char[64];
+            UDP.GetIP(ref this, (IntPtr)ptr, 64);
+            return $"IP: {new string(ptr)} Port: {this.Port}";
 
             // Original code is as follows.
             /*
+            // function header: public override string ToString()
             var ip = new StringBuilder(64);
             NanoSockets.UDP.GetIP(ref this, ip, 64);
             return string.Format("IP:{0} Port:{1}", ip, this.port);

--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoSockets/Scripts/NanoSockets.cs
@@ -1,6 +1,10 @@
 /*
  *  Lightweight UDP sockets abstraction for rapid implementation of message-oriented protocols
  *  Copyright (c) 2019 Stanislav Denisov
+ *  
+ *  NanoSockets modifications made by Mirage Team
+ *  Copyright (c) 2022 Mirage Team and contributors.
+ *  
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -212,7 +212,6 @@ namespace Mirage.Sockets.Udp
             || Application.isEditor;
 #endif
         }
-
     }
 
     public class EndPointWrapper : IEndPoint


### PR DESCRIPTION
This can probably be reverted in a later commit or PR if Unity looks into the StringBuilder SIGABRT crash and fixes their IL2CPP StringBuilder Marshalling. I've reported that bug to Unity, currently awaiting resolution. Confirmed bug with GDB debugger and help of imer and FakeByte.

What this PR features is the following:

- A fix to prevent IL2CPP SIGABRT crashes when calling NanoSocket's Address.ToString() function. Tested and confirmed working on Manjaro x86_64 with the Mirage Basic demo. It allocates memory however, improved version welcome!
- Adding our modification notice to the C# wrappers' header.
- Minor restructure out of pure what-if testing (don't make a new address inside a function iirc).