### PR TITLE
fix: throw InvalidOperationException if network client attempts to send messages while disconnected

### DIFF
--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -310,7 +310,6 @@ namespace Mirage
         public void Send<T>(T message, INotifyCallBack notifyCallBack)
         {
             // For more information, see notes in Send<T> ...
-
             // Throw a IOE if NetworkClient's connection is null.
             if (Player == null)
                 throw new InvalidOperationException("Cannot send the data. Send was called while the NetworkClient connection was null. " +

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -286,10 +286,8 @@ namespace Mirage
             // This is caused by Send() being fired after the Player object is disposed or reset
             // to null. Instead, throw a InvalidOperationException if that is the case.
 
-            // Throw a IOE if NetworkClient's connection is null.
             if (Player == null)
-                throw new InvalidOperationException("Cannot send the data. Send was called while the NetworkClient connection was null. " +
-                    "The connection may have been disconnected or terminated.");
+                ThrowIfSendingWhileNotConnected();
 
             // Otherwise, send it off.
             Player.Send(message, channelId);
@@ -298,10 +296,8 @@ namespace Mirage
         public void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable)
         {
             // For more information, see notes in Send<T> ...
-            // Throw a IOE if NetworkClient's connection is null.
             if (Player == null)
-                throw new InvalidOperationException("Cannot send the data. Send was called while the NetworkClient connection was null. " +
-                    "The connection may have been disconnected or terminated.");
+                ThrowIfSendingWhileNotConnected();
 
             // Otherwise, send it off.
             Player.Send(segment, channelId);
@@ -310,10 +306,8 @@ namespace Mirage
         public void Send<T>(T message, INotifyCallBack notifyCallBack)
         {
             // For more information, see notes in Send<T> ...
-            // Throw a IOE if NetworkClient's connection is null.
             if (Player == null)
-                throw new InvalidOperationException("Cannot send the data. Send was called while the NetworkClient connection was null. " +
-                    "The connection may have been disconnected or terminated.");
+                ThrowIfSendingWhileNotConnected();
 
             // Otherwise, send it off.
             Player.Send(message, notifyCallBack);
@@ -385,6 +379,12 @@ namespace Mirage
                 _peer.Close();
                 _peer = null;
             }
+        }
+
+        private void ThrowIfSendingWhileNotConnected()
+        {
+            throw new InvalidOperationException("Attempting to send data while not connected. This is not allowed. " +
+                "NetworkClient Player connection reference is null, in which the the connection may have been disconnected/terminated before the Send function was called.");
         }
 
         internal class DataHandler : IDataHandler

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -384,7 +384,7 @@ namespace Mirage
         private void ThrowIfSendingWhileNotConnected()
         {
             throw new InvalidOperationException("Attempting to send data while not connected. This is not allowed. " +
-                "NetworkClient Player connection reference is null, in which the the connection may have been disconnected/terminated before the Send function was called.");
+                "NetworkClient Player connection reference is null, in which the connection may have been disconnected/terminated before the Send function was called.");
         }
 
         internal class DataHandler : IDataHandler

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -282,16 +282,41 @@ namespace Mirage
         /// <returns>True if message was sent.</returns>
         public void Send<T>(T message, int channelId = Channel.Reliable)
         {
+            // Coburn, 2022-12-19: Fix NetworkClient.Send triggering NullReferenceException
+            // This is caused by Send() being fired after the Player object is disposed or reset
+            // to null. Instead, throw a InvalidOperationException if that is the case.
+
+            // Throw a IOE if NetworkClient's connection is null.
+            if (Player == null)
+                throw new InvalidOperationException("Cannot send the data. Send was called while the NetworkClient connection was null. " +
+                    "The connection may have been disconnected or terminated.");
+
+            // Otherwise, send it off.
             Player.Send(message, channelId);
         }
 
         public void Send(ArraySegment<byte> segment, int channelId = Channel.Reliable)
         {
+            // For more information, see notes in Send<T> ...
+            // Throw a IOE if NetworkClient's connection is null.
+            if (Player == null)
+                throw new InvalidOperationException("Cannot send the data. Send was called while the NetworkClient connection was null. " +
+                    "The connection may have been disconnected or terminated.");
+
+            // Otherwise, send it off.
             Player.Send(segment, channelId);
         }
 
         public void Send<T>(T message, INotifyCallBack notifyCallBack)
         {
+            // For more information, see notes in Send<T> ...
+
+            // Throw a IOE if NetworkClient's connection is null.
+            if (Player == null)
+                throw new InvalidOperationException("Cannot send the data. Send was called while the NetworkClient connection was null. " +
+                    "The connection may have been disconnected or terminated.");
+
+            // Otherwise, send it off.
             Player.Send(message, notifyCallBack);
         }
 

--- a/Assets/Tests/Runtime/NetworkClient.meta
+++ b/Assets/Tests/Runtime/NetworkClient.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58c572c9713e0414ba870ba16053c590
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/NetworkClient/NetworkClientSendIfDisconnectedTest.cs
+++ b/Assets/Tests/Runtime/NetworkClient/NetworkClientSendIfDisconnectedTest.cs
@@ -19,6 +19,12 @@ namespace Mirage.Tests.Runtime
             // Initialize...
             clientGO = new GameObject("Mirage Network Client Object", typeof(NetworkClient));
             clientNetClient = clientGO.GetComponent<NetworkClient>();
+
+            // Ensure that these are correct for this test.
+            // - The NetworkClient reference is not null.
+            // - The NetworkClient Player reference must be null.
+            Debug.Assert(clientNetClient != null);
+            Debug.Assert(clientNetClient.Player == null);           
         }
 
         [TearDown]
@@ -28,34 +34,12 @@ namespace Mirage.Tests.Runtime
         }
 
         [Test]
-        // Ensure that the created client game object and it's component(s) isn't null.
-        public void EnsureNetworkClientIsNotNull()
-        {
-            Assert.IsNotNull(clientGO);
-            Assert.IsNotNull(clientNetClient);
-        }
-
-        [Test]
-        // Ensure that the client object's Player reference is null.
-        public void EnsureNetworkClientPlayerIsNull()
-        {
-            Assert.IsNull(clientNetClient.Player);
-        }
-
-        [Test]
         // Make sure we throw IOE to prevent Send attempts.
         public void EnsureNetworkClientDoesntSendWhenDisconnected()
         {
             // Send out data.
             // This should always invoke a InvalidOperationException.
-            try
-            {
-                clientNetClient.Send(new byte[] { 0x13, 0x37, 0x69 });
-            }
-            catch (Exception ex)
-            {
-                Assert.That(ex is InvalidOperationException);
-            }
+            Assert.Throws<InvalidOperationException>(() => clientNetClient.Send(new byte[] { 0x13, 0x37, 0x69 }));
         }
     }
 }

--- a/Assets/Tests/Runtime/NetworkClient/NetworkClientSendIfDisconnectedTest.cs
+++ b/Assets/Tests/Runtime/NetworkClient/NetworkClientSendIfDisconnectedTest.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Mirage.Tests.Runtime
+{
+    public class NetworkClientSendIfDisconnectedTest
+    {
+        public GameObject clientGO;
+        public NetworkClient clientNetClient;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Initialize...
+            clientGO = new GameObject("Mirage Network Client Object", typeof(NetworkClient));
+            clientNetClient = clientGO.GetComponent<NetworkClient>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(clientGO);
+        }
+
+        [Test]
+        // Ensure that the created client game object and it's component(s) isn't null.
+        public void EnsureNetworkClientIsNotNull()
+        {
+            Assert.IsNotNull(clientGO);
+            Assert.IsNotNull(clientNetClient);
+        }
+
+        [Test]
+        // Ensure that the client object's Player reference is null.
+        public void EnsureNetworkClientPlayerIsNull()
+        {
+            Assert.IsNull(clientNetClient.Player);
+        }
+
+        [Test]
+        // Make sure we throw IOE to prevent Send attempts.
+        public void EnsureNetworkClientDoesntSendWhenDisconnected()
+        {
+            // Send out data.
+            // This should always invoke a InvalidOperationException.
+            try
+            {
+                clientNetClient.Send(new byte[] { 0x13, 0x37, 0x69 });
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex is InvalidOperationException);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Runtime/NetworkClient/NetworkClientSendIfDisconnectedTest.cs.meta
+++ b/Assets/Tests/Runtime/NetworkClient/NetworkClientSendIfDisconnectedTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a8e9c488fdc5dd499e89677b7a5e974
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes a NullReferenceException being fired since the NetworkClient's Player reference is null when trying to use the `Send(...)` function while disconnected. Discovered by myself while implementing some backend stuff in Mirage Standalone. 

Instead, throw a InvalidOperationException and explain to the user that sending things when disconnected is bad.