### PR TITLE
fix: errors and warnings on 2023.1 alpha

### DIFF
--- a/Assets/Mirage/Runtime/Logging/EditorLogSettingsLoader.cs
+++ b/Assets/Mirage/Runtime/Logging/EditorLogSettingsLoader.cs
@@ -29,7 +29,11 @@ namespace Mirage.Logging
             if (cache != null)
                 return cache;
 
+#if UNITY_2021_1_OR_NEWER
+            cache = Object.FindFirstObjectByType<LogSettingsSO>();
+#else
             cache = Object.FindObjectOfType<LogSettingsSO>();
+#endif
             if (cache != null)
                 return cache;
 

--- a/Assets/Mirage/Runtime/Logging/EditorLogSettingsLoader.cs
+++ b/Assets/Mirage/Runtime/Logging/EditorLogSettingsLoader.cs
@@ -29,7 +29,7 @@ namespace Mirage.Logging
             if (cache != null)
                 return cache;
 
-#if UNITY_2021_1_OR_NEWER
+#if UNITY_2023_1_OR_NEWER
             cache = Object.FindFirstObjectByType<LogSettingsSO>();
 #else
             cache = Object.FindObjectOfType<LogSettingsSO>();

--- a/Assets/Mirage/package.json
+++ b/Assets/Mirage/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.cysharp.unitask": "2.0.36"
+        "com.cysharp.unitask": "2.3.3"
     },
     "samples": [
         {


### PR DESCRIPTION
A fresh install of Mirage on the 2023.1 alpha caused a few issues:
- Compilation issues due to ambiguous matches between UniTask's GetAwaiter and Unity's new Awaitable GetAwaiter
- Depcreation warning as Object.FindObjectOfType is now deprecated

I fixed these using the following methods:
- Update the UniTask dependency to 2.3.3 (the ambiguous match was fixed in [UniTask 2.3.2](https://github.com/Cysharp/UniTask/releases/tag/2.3.2)
- Added #if define in EditorLogSettingsLoader to use the new `Object.FindFirstObjectOfType`

I have not updated any tests to remove any warnings when in 2023.1, but I could if desired. 