### PR TITLE
feat: ui toolkit network behaviour editor for unity 2022.2 and newer

### DIFF
--- a/Assets/Mirage/Editor/FoldoutEventDrawer.cs
+++ b/Assets/Mirage/Editor/FoldoutEventDrawer.cs
@@ -1,19 +1,11 @@
-#if UNITY_2022_2_OR_NEWER
-#define USE_UI_TOOLKIT
-#endif // UNITY_2022_2_OR_NEWER
-
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
-#if USE_UI_TOOLKIT
-using UnityEditor.UIElements;
-using UnityEngine.UIElements;
-#endif // USE_UI_TOOLKIT
 
 namespace Mirage
 {
     [CustomPropertyDrawer(typeof(FoldoutEventAttribute))]
-    public class FoldoutEventDrawer : PropertyDrawer
+    public partial class FoldoutEventDrawer : PropertyDrawer
     {
         private UnityEventDrawer _unityEventDrawer;
 
@@ -61,21 +53,5 @@ namespace Mirage
                 UnityEventDrawer.OnGUI(eventRec, property, label);
             }
         }
-
-#if USE_UI_TOOLKIT
-        public override VisualElement CreatePropertyGUI(SerializedProperty property)
-        {
-            var foldout = new Foldout()
-            {
-                text = property.displayName,
-            };
-
-            foldout.Add(UnityEventDrawer.CreatePropertyGUI(property));
-
-            foldout.BindProperty(property);
-
-            return foldout;
-        }
-#endif // USE_UI_TOOLKIT
     }
 }

--- a/Assets/Mirage/Editor/FoldoutEventDrawer.cs
+++ b/Assets/Mirage/Editor/FoldoutEventDrawer.cs
@@ -1,6 +1,14 @@
+#if UNITY_2022_2_OR_NEWER
+#define USE_UI_TOOLKIT
+#endif // UNITY_2022_2_OR_NEWER
+
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+#if USE_UI_TOOLKIT
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+#endif // USE_UI_TOOLKIT
 
 namespace Mirage
 {
@@ -53,5 +61,21 @@ namespace Mirage
                 UnityEventDrawer.OnGUI(eventRec, property, label);
             }
         }
+
+#if USE_UI_TOOLKIT
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var foldout = new Foldout()
+            {
+                text = property.displayName,
+            };
+
+            foldout.Add(UnityEventDrawer.CreatePropertyGUI(property));
+
+            foldout.BindProperty(property);
+
+            return foldout;
+        }
+#endif // USE_UI_TOOLKIT
     }
 }

--- a/Assets/Mirage/Editor/FoldoutEventDrawerUIToolkit.cs
+++ b/Assets/Mirage/Editor/FoldoutEventDrawerUIToolkit.cs
@@ -1,0 +1,22 @@
+#if UNITY_2022_2_OR_NEWER
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace Mirage
+{
+    public partial class FoldoutEventDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var foldout = new Foldout { text = property.displayName };
+
+            foldout.Add(UnityEventDrawer.CreatePropertyGUI(property));
+
+            foldout.BindProperty(property);
+
+            return foldout;
+        }
+    }
+}
+#endif

--- a/Assets/Mirage/Editor/FoldoutEventDrawerUIToolkit.cs.meta
+++ b/Assets/Mirage/Editor/FoldoutEventDrawerUIToolkit.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6bf8d2a11fce435eab8d74d2dd36190c
+timeCreated: 1672238247

--- a/Assets/Mirage/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirage/Editor/NetworkBehaviourInspector.cs
@@ -1,3 +1,7 @@
+#if UNITY_2022_2_OR_NEWER // Unity uses UI toolkit by default for inspectors in 2022.2 and up.
+#define USE_UI_TOOLKIT
+#endif
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -5,6 +9,11 @@ using Mirage.Collections;
 using Mirage.Logging;
 using UnityEditor;
 using UnityEngine;
+#if USE_UI_TOOLKIT
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+using System.Globalization;
+#endif // USE_UI_TOOLKIT
 using Object = UnityEngine.Object;
 
 namespace Mirage
@@ -34,6 +43,45 @@ namespace Mirage
             _drawer.DrawDefaultSyncLists();
             _drawer.DrawDefaultSyncSettings();
         }
+
+#if USE_UI_TOOLKIT
+        public override VisualElement CreateInspectorGUI()
+        {
+            var root = new VisualElement();
+
+            // Create the default inspector.
+            var iterator = serializedObject.GetIterator();
+            for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
+            {
+                var field = new PropertyField(iterator);
+                field.Bind(serializedObject);
+
+                // Disable the script field.
+                if (iterator.propertyPath == "m_Script")
+                {
+                    field.SetEnabled(false);
+                }
+
+                root.Add(field);
+            }
+
+            // Create the sync lists editor.
+            var syncLists = _drawer.CreateDefaultSyncLists();
+            if (syncLists != null)
+            {
+                root.Add(syncLists);
+            }
+
+            // Crete the sync settings editor.
+            var syncSettings = _drawer.CreateDefaultSyncSettings();
+            if (syncSettings != null)
+            {
+                root.Add(syncSettings);
+            }
+
+            return root;
+        }
+#endif // USE_UI_TOOLKIT
     }
 #endif
 
@@ -135,6 +183,48 @@ namespace Mirage
             // apply
             _serializedObject.ApplyModifiedProperties();
         }
+
+#if USE_UI_TOOLKIT
+        public VisualElement CreateDefaultSyncLists()
+        {
+            return _syncListDrawer?.Create();
+        }
+
+        public VisualElement CreateDefaultSyncSettings()
+        {
+            if (!_syncsAnything)
+            {
+                return null;
+            }
+
+            var root = new VisualElement();
+
+            root.Add(CreateHeader("Sync Settings"));
+
+            var syncMode = new PropertyField(_serializedObject.FindProperty("syncMode"));
+            syncMode.Bind(_serializedObject);
+            root.Add(syncMode);
+
+            var syncInterval = new PropertyField(_serializedObject.FindProperty("syncInterval"));
+            syncInterval.Bind(_serializedObject);
+            root.Add(syncInterval);
+
+            return root;
+        }
+
+        public static VisualElement CreateHeader(string text)
+        {
+            var root = new VisualElement();
+            root.AddToClassList("unity-decorator-drawers-container");
+
+            var label = new Label(text);
+            label.AddToClassList("unity-header-drawer__label");
+
+            root.Add(label);
+
+            return root;
+        }
+#endif // USE_UI_TOOLKIT
     }
 
     /// <summary>
@@ -196,17 +286,118 @@ namespace Mirage
             }
         }
 
+#if USE_UI_TOOLKIT
+        public VisualElement Create()
+        {
+            if (_syncListFields.Count == 0) { return null; }
+
+            var root = new VisualElement();
+
+            root.Add(NetworkBehaviourInspectorDrawer.CreateHeader("Sync Lists"));
+
+            foreach (var syncListField in _syncListFields)
+            {
+                root.Add(CreateSyncList(syncListField));
+            }
+
+            return root;
+        }
+
+        private VisualElement CreateSyncList(SyncListField syncListField)
+        {
+            syncListField.UpdateItems(_targetObject);
+
+            var list = new ListView(syncListField.items)
+            {
+                showBorder = true,
+                showFoldoutHeader = true,
+                headerTitle = syncListField.label,
+                showAddRemoveFooter = false,
+                showBoundCollectionSize = false,
+                showAlternatingRowBackgrounds = AlternatingRowBackground.All,
+                makeItem = MakeSyncListItem,
+                bindItem = (element, i) => BindSyncListItem(element, i, syncListField),
+                viewDataKey = "mirage-sync-list-" + syncListField.field.Name // Used for the expanded state
+            };
+
+            // Because we can't listen for any lists updates, just refresh the list completely every 1 second.
+            list.schedule.Execute(() =>
+            {
+                // No need to update the game is not playing.
+                if (Application.isPlaying)
+                {
+                    syncListField.UpdateItems(_targetObject);
+                    list.Rebuild();
+                }
+            }).Every(1000);
+
+            return list;
+        }
+
+        private static VisualElement MakeSyncListItem()
+        {
+            var root = new VisualElement();
+            root.AddToClassList("unity-base-field");
+            root.AddToClassList("unity-base-field__aligned");
+            root.AddToClassList("unity-base-field__inspector-field");
+
+            var elementLabel = new Label
+            {
+                name = "element-label"
+            };
+
+            elementLabel.AddToClassList("unity-base-field__label");
+            elementLabel.AddToClassList("unity-property-field__label");
+
+            var elementValue = new Label("Test")
+            {
+                name = "element-value"
+            };
+
+            root.Add(elementLabel);
+            root.Add(elementValue);
+
+            return root;
+        }
+
+        private static void BindSyncListItem(VisualElement element, int index, SyncListField field)
+        {
+            var elementLabel = element.Q<Label>("element-label");
+            var elementValue = element.Q<Label>("element-value");
+
+            elementLabel.text = $"Element {index.ToString(CultureInfo.InvariantCulture)}";
+
+            elementValue.text = field.items[index] != null ? field.items[index].ToString() : "NULL";
+        }
+#endif // USE_UI_TOOLKIT
+
         private class SyncListField
         {
             public bool visible;
             public readonly FieldInfo field;
             public readonly string label;
+            public readonly List<object> items;
 
             public SyncListField(FieldInfo field)
             {
                 this.field = field;
                 visible = false;
                 label = field.Name + "  [" + field.FieldType.Name + "]";
+                items = new List<object>();
+            }
+
+            public void UpdateItems(object target)
+            {
+                var fieldValue = field.GetValue(target);
+                if (fieldValue is IEnumerable syncList)
+                {
+                    items.Clear();
+
+                    foreach (var item in syncList)
+                    {
+                        items.Add(item);
+                    }
+                }
             }
         }
     }

--- a/Assets/Mirage/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirage/Editor/NetworkBehaviourInspector.cs
@@ -264,25 +264,31 @@ namespace Mirage
 
         private void DrawSyncList(SyncListField syncListField)
         {
-            syncListField.visible = EditorGUILayout.Foldout(syncListField.visible, syncListField.label);
+            syncListField.visible = EditorGUILayout.Foldout(syncListField.visible, syncListField.label, true);
             if (syncListField.visible)
             {
-                using (new EditorGUI.IndentLevelScope())
+                EditorGUILayout.BeginVertical("OL box");
+                int count = 0;
+                var fieldValue = syncListField.field.GetValue(_targetObject);
+                if (fieldValue is IEnumerable synclist)
                 {
-                    var fieldValue = syncListField.field.GetValue(_targetObject);
-                    if (fieldValue is IEnumerable synclist)
+                    var index = 0;
+                    foreach (var item in synclist)
                     {
-                        var index = 0;
-                        foreach (var item in synclist)
-                        {
-                            var itemValue = item != null ? item.ToString() : "NULL";
-                            var itemLabel = "Element " + index;
-                            EditorGUILayout.LabelField(itemLabel, itemValue);
+                        var itemValue = item != null ? item.ToString() : "NULL";
+                        var itemLabel = "Element " + index;
+                        EditorGUILayout.LabelField(itemLabel, itemValue);
 
-                            index++;
-                        }
+                        index++;
+                        count++;
                     }
                 }
+
+                if (count == 0)
+                {
+                    EditorGUILayout.LabelField("List is empty");
+                }
+                EditorGUILayout.EndVertical();
             }
         }
 

--- a/Assets/Mirage/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirage/Editor/NetworkBehaviourInspector.cs
@@ -1,7 +1,3 @@
-#if UNITY_2022_2_OR_NEWER // Unity uses UI toolkit by default for inspectors in 2022.2 and up.
-#define USE_UI_TOOLKIT
-#endif
-
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -9,11 +5,6 @@ using Mirage.Collections;
 using Mirage.Logging;
 using UnityEditor;
 using UnityEngine;
-#if USE_UI_TOOLKIT
-using UnityEditor.UIElements;
-using UnityEngine.UIElements;
-using System.Globalization;
-#endif // USE_UI_TOOLKIT
 using Object = UnityEngine.Object;
 
 namespace Mirage
@@ -21,7 +12,7 @@ namespace Mirage
 #if !EXCLUDE_NETWORK_BEHAVIOUR_INSPECTOR
     [CustomEditor(typeof(NetworkBehaviour), true)]
     [CanEditMultipleObjects]
-    public class NetworkBehaviourInspector : Editor
+    public partial class NetworkBehaviourInspector : Editor
     {
         private static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkBehaviourInspector));
         private NetworkBehaviourInspectorDrawer _drawer;
@@ -43,52 +34,13 @@ namespace Mirage
             _drawer.DrawDefaultSyncLists();
             _drawer.DrawDefaultSyncSettings();
         }
-
-#if USE_UI_TOOLKIT
-        public override VisualElement CreateInspectorGUI()
-        {
-            var root = new VisualElement();
-
-            // Create the default inspector.
-            var iterator = serializedObject.GetIterator();
-            for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
-            {
-                var field = new PropertyField(iterator);
-                field.Bind(serializedObject);
-
-                // Disable the script field.
-                if (iterator.propertyPath == "m_Script")
-                {
-                    field.SetEnabled(false);
-                }
-
-                root.Add(field);
-            }
-
-            // Create the sync lists editor.
-            var syncLists = _drawer.CreateDefaultSyncLists();
-            if (syncLists != null)
-            {
-                root.Add(syncLists);
-            }
-
-            // Crete the sync settings editor.
-            var syncSettings = _drawer.CreateDefaultSyncSettings();
-            if (syncSettings != null)
-            {
-                root.Add(syncSettings);
-            }
-
-            return root;
-        }
-#endif // USE_UI_TOOLKIT
     }
 #endif
 
     /// <summary>
     /// split from Editor class so that people can use this with custom inspectoer
     /// </summary>
-    public class NetworkBehaviourInspectorDrawer
+    public partial class NetworkBehaviourInspectorDrawer
     {
         /// <summary>
         /// List of all visible syncVars in target class
@@ -183,55 +135,13 @@ namespace Mirage
             // apply
             _serializedObject.ApplyModifiedProperties();
         }
-
-#if USE_UI_TOOLKIT
-        public VisualElement CreateDefaultSyncLists()
-        {
-            return _syncListDrawer?.Create();
-        }
-
-        public VisualElement CreateDefaultSyncSettings()
-        {
-            if (!_syncsAnything)
-            {
-                return null;
-            }
-
-            var root = new VisualElement();
-
-            root.Add(CreateHeader("Sync Settings"));
-
-            var syncMode = new PropertyField(_serializedObject.FindProperty("syncMode"));
-            syncMode.Bind(_serializedObject);
-            root.Add(syncMode);
-
-            var syncInterval = new PropertyField(_serializedObject.FindProperty("syncInterval"));
-            syncInterval.Bind(_serializedObject);
-            root.Add(syncInterval);
-
-            return root;
-        }
-
-        public static VisualElement CreateHeader(string text)
-        {
-            var root = new VisualElement();
-            root.AddToClassList("unity-decorator-drawers-container");
-
-            var label = new Label(text);
-            label.AddToClassList("unity-header-drawer__label");
-
-            root.Add(label);
-
-            return root;
-        }
-#endif // USE_UI_TOOLKIT
     }
 
     /// <summary>
     /// Draws sync lists in inspector
     /// <para>because synclists are not serailzied by unity they will not show up in the default inspector, so we need a custom draw to draw them</para>
     /// </summary>
-    public class SyncListDrawer
+    public partial class SyncListDrawer
     {
         private readonly Object _targetObject;
         private readonly List<SyncListField> _syncListFields;
@@ -291,91 +201,6 @@ namespace Mirage
                 EditorGUILayout.EndVertical();
             }
         }
-
-#if USE_UI_TOOLKIT
-        public VisualElement Create()
-        {
-            if (_syncListFields.Count == 0) { return null; }
-
-            var root = new VisualElement();
-
-            root.Add(NetworkBehaviourInspectorDrawer.CreateHeader("Sync Lists"));
-
-            foreach (var syncListField in _syncListFields)
-            {
-                root.Add(CreateSyncList(syncListField));
-            }
-
-            return root;
-        }
-
-        private VisualElement CreateSyncList(SyncListField syncListField)
-        {
-            syncListField.UpdateItems(_targetObject);
-
-            var list = new ListView(syncListField.items)
-            {
-                showBorder = true,
-                showFoldoutHeader = true,
-                headerTitle = syncListField.label,
-                showAddRemoveFooter = false,
-                showBoundCollectionSize = false,
-                showAlternatingRowBackgrounds = AlternatingRowBackground.All,
-                makeItem = MakeSyncListItem,
-                bindItem = (element, i) => BindSyncListItem(element, i, syncListField),
-                viewDataKey = "mirage-sync-list-" + syncListField.field.Name // Used for the expanded state
-            };
-
-            // Because we can't listen for any lists updates, just refresh the list completely every 1 second.
-            list.schedule.Execute(() =>
-            {
-                // No need to update the game is not playing.
-                if (Application.isPlaying)
-                {
-                    syncListField.UpdateItems(_targetObject);
-                    list.Rebuild();
-                }
-            }).Every(1000);
-
-            return list;
-        }
-
-        private static VisualElement MakeSyncListItem()
-        {
-            var root = new VisualElement();
-            root.AddToClassList("unity-base-field");
-            root.AddToClassList("unity-base-field__aligned");
-            root.AddToClassList("unity-base-field__inspector-field");
-
-            var elementLabel = new Label
-            {
-                name = "element-label"
-            };
-
-            elementLabel.AddToClassList("unity-base-field__label");
-            elementLabel.AddToClassList("unity-property-field__label");
-
-            var elementValue = new Label("Test")
-            {
-                name = "element-value"
-            };
-
-            root.Add(elementLabel);
-            root.Add(elementValue);
-
-            return root;
-        }
-
-        private static void BindSyncListItem(VisualElement element, int index, SyncListField field)
-        {
-            var elementLabel = element.Q<Label>("element-label");
-            var elementValue = element.Q<Label>("element-value");
-
-            elementLabel.text = $"Element {index.ToString(CultureInfo.InvariantCulture)}";
-
-            elementValue.text = field.items[index] != null ? field.items[index].ToString() : "NULL";
-        }
-#endif // USE_UI_TOOLKIT
 
         private class SyncListField
         {

--- a/Assets/Mirage/Editor/NetworkBehaviourInspectorUIToolkit.cs
+++ b/Assets/Mirage/Editor/NetworkBehaviourInspectorUIToolkit.cs
@@ -1,0 +1,181 @@
+#if UNITY_2022_2_OR_NEWER // Unity uses UI toolkit by default for inspectors in 2022.2 and up.
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+using System.Globalization;
+using UnityEngine;
+
+namespace Mirage
+{
+#if !EXCLUDE_NETWORK_BEHAVIOUR_INSPECTOR
+    public partial class NetworkBehaviourInspector
+    {
+        public override VisualElement CreateInspectorGUI()
+        {
+            var root = new VisualElement();
+
+            // Create the default inspector.
+            var iterator = serializedObject.GetIterator();
+            for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
+            {
+                var field = new PropertyField(iterator);
+                field.Bind(serializedObject);
+
+                // Disable the script field.
+                if (iterator.propertyPath == "m_Script")
+                {
+                    field.SetEnabled(false);
+                }
+
+                root.Add(field);
+            }
+
+            // Create the sync lists editor.
+            var syncLists = _drawer.CreateDefaultSyncLists();
+            if (syncLists != null)
+            {
+                root.Add(syncLists);
+            }
+
+            // Crete the sync settings editor.
+            var syncSettings = _drawer.CreateDefaultSyncSettings();
+            if (syncSettings != null)
+            {
+                root.Add(syncSettings);
+            }
+
+            return root;
+        }
+    }
+#endif // !EXCLUDE_NETWORK_BEHAVIOUR_INSPECTOR
+
+    public partial class NetworkBehaviourInspectorDrawer
+    {
+        public VisualElement CreateDefaultSyncLists()
+        {
+            return _syncListDrawer?.Create();
+        }
+
+        public VisualElement CreateDefaultSyncSettings()
+        {
+            if (!_syncsAnything)
+            {
+                return null;
+            }
+
+            var root = new VisualElement();
+
+            root.Add(CreateHeader("Sync Settings"));
+
+            var syncMode = new PropertyField(_serializedObject.FindProperty("syncMode"));
+            syncMode.Bind(_serializedObject);
+            root.Add(syncMode);
+
+            var syncInterval = new PropertyField(_serializedObject.FindProperty("syncInterval"));
+            syncInterval.Bind(_serializedObject);
+            root.Add(syncInterval);
+
+            return root;
+        }
+
+        public static VisualElement CreateHeader(string text)
+        {
+            var root = new VisualElement();
+            root.AddToClassList("unity-decorator-drawers-container");
+
+            var label = new Label(text);
+            label.AddToClassList("unity-header-drawer__label");
+
+            root.Add(label);
+
+            return root;
+        }
+    }
+
+    public partial class SyncListDrawer
+    {
+        public VisualElement Create()
+        {
+            if (_syncListFields.Count == 0) { return null; }
+
+            var root = new VisualElement();
+
+            root.Add(NetworkBehaviourInspectorDrawer.CreateHeader("Sync Lists"));
+
+            foreach (var syncListField in _syncListFields)
+            {
+                root.Add(CreateSyncList(syncListField));
+            }
+
+            return root;
+        }
+
+        private VisualElement CreateSyncList(SyncListField syncListField)
+        {
+            syncListField.UpdateItems(_targetObject);
+
+            var list = new ListView(syncListField.items)
+            {
+                showBorder = true,
+                showFoldoutHeader = true,
+                headerTitle = syncListField.label,
+                showAddRemoveFooter = false,
+                showBoundCollectionSize = false,
+                showAlternatingRowBackgrounds = AlternatingRowBackground.All,
+                makeItem = MakeSyncListItem,
+                bindItem = (element, i) => BindSyncListItem(element, i, syncListField),
+                viewDataKey = "mirage-sync-list-" + syncListField.field.Name // Used for the expanded state
+            };
+
+            // Because we can't listen for any lists updates, just refresh the list completely every 1 second.
+            list.schedule.Execute(() =>
+            {
+                // No need to update the game is not playing.
+                if (Application.isPlaying)
+                {
+                    syncListField.UpdateItems(_targetObject);
+
+                    list.Rebuild();
+                }
+            }).Every(1000);
+
+            return list;
+        }
+
+        private static VisualElement MakeSyncListItem()
+        {
+            var root = new VisualElement();
+            root.AddToClassList("unity-base-field");
+            root.AddToClassList("unity-base-field__aligned");
+            root.AddToClassList("unity-base-field__inspector-field");
+
+            var elementLabel = new Label
+            {
+                name = "element-label"
+            };
+
+            elementLabel.AddToClassList("unity-base-field__label");
+            elementLabel.AddToClassList("unity-property-field__label");
+
+            var elementValue = new Label("Test")
+            {
+                name = "element-value"
+            };
+
+            root.Add(elementLabel);
+            root.Add(elementValue);
+
+            return root;
+        }
+
+        private static void BindSyncListItem(VisualElement element, int index, SyncListField field)
+        {
+            var elementLabel = element.Q<Label>("element-label");
+            var elementValue = element.Q<Label>("element-value");
+
+            elementLabel.text = $"Element {index.ToString(CultureInfo.InvariantCulture)}";
+
+            elementValue.text = field.items[index] != null ? field.items[index].ToString() : "NULL";
+        }
+    }
+}
+#endif // UNITY_2022_2_OR_NEWER

--- a/Assets/Mirage/Editor/NetworkBehaviourInspectorUIToolkit.cs.meta
+++ b/Assets/Mirage/Editor/NetworkBehaviourInspectorUIToolkit.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dc5d652c4ca14394a94aa4921f59762d
+timeCreated: 1672237753

--- a/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs
+++ b/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs
@@ -1,5 +1,13 @@
-﻿using UnityEditor;
+﻿#if UNITY_2022_2_OR_NEWER
+#define USE_UI_TOOLKIT
+#endif // UNITY_2022_2_OR_NEWER
+
+using UnityEditor;
 using UnityEngine;
+#if USE_UI_TOOLKIT
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+#endif // USE_UI_TOOLKIT
 
 namespace Mirage
 {
@@ -17,5 +25,14 @@ namespace Mirage
         {
             return EditorGUI.GetPropertyHeight(property, label, true);
         }
+
+#if USE_UI_TOOLKIT
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var field = new PropertyField(property);
+            field.SetEnabled(false);
+            return field;
+        }
+#endif // USE_UI_TOOLKIT
     }
 }

--- a/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs
+++ b/Assets/Mirage/Editor/ReadOnlyDecoratorDrawer.cs
@@ -1,18 +1,10 @@
-﻿#if UNITY_2022_2_OR_NEWER
-#define USE_UI_TOOLKIT
-#endif // UNITY_2022_2_OR_NEWER
-
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
-#if USE_UI_TOOLKIT
-using UnityEditor.UIElements;
-using UnityEngine.UIElements;
-#endif // USE_UI_TOOLKIT
 
 namespace Mirage
 {
     [CustomPropertyDrawer(typeof(ReadOnlyInspectorAttribute))]
-    public class ReadOnlyDecoratorDrawer : PropertyDrawer
+    public partial class ReadOnlyDecoratorDrawer : PropertyDrawer
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -25,14 +17,5 @@ namespace Mirage
         {
             return EditorGUI.GetPropertyHeight(property, label, true);
         }
-
-#if USE_UI_TOOLKIT
-        public override VisualElement CreatePropertyGUI(SerializedProperty property)
-        {
-            var field = new PropertyField(property);
-            field.SetEnabled(false);
-            return field;
-        }
-#endif // USE_UI_TOOLKIT
     }
 }

--- a/Assets/Mirage/Editor/ReadOnlyDecoratorDrawerUIToolkit.cs
+++ b/Assets/Mirage/Editor/ReadOnlyDecoratorDrawerUIToolkit.cs
@@ -1,0 +1,18 @@
+#if UNITY_2022_2_OR_NEWER
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace Mirage
+{
+    public partial class ReadOnlyDecoratorDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var field = new PropertyField(property);
+            field.SetEnabled(false);
+            return field;
+        }
+    }
+}
+#endif // UNITY_2022_2_OR_NEWER

--- a/Assets/Mirage/Editor/ReadOnlyDecoratorDrawerUIToolkit.cs.meta
+++ b/Assets/Mirage/Editor/ReadOnlyDecoratorDrawerUIToolkit.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3b2f426caf174d3491398a66578dd4b7
+timeCreated: 1672238062

--- a/Assets/Mirage/Editor/SyncVarAttributeDrawer.cs
+++ b/Assets/Mirage/Editor/SyncVarAttributeDrawer.cs
@@ -1,18 +1,10 @@
-#if UNITY_2022_2_OR_NEWER
-#define USE_UI_TOOLKIT
-#endif
-
 using UnityEditor;
 using UnityEngine;
-#if USE_UI_TOOLKIT
-using UnityEditor.UIElements;
-using UnityEngine.UIElements;
-#endif
 
 namespace Mirage
 {
     [CustomPropertyDrawer(typeof(SyncVarAttribute))]
-    public class SyncVarAttributeDrawer : PropertyDrawer
+    public partial class SyncVarAttributeDrawer : PropertyDrawer
     {
         private static readonly GUIContent syncVarIndicatorContent = new GUIContent("SyncVar", "This variable has been marked with the [SyncVar] attribute.");
 
@@ -32,45 +24,5 @@ namespace Mirage
         {
             return EditorGUI.GetPropertyHeight(property);
         }
-
-#if USE_UI_TOOLKIT
-        public override VisualElement CreatePropertyGUI(SerializedProperty property)
-        {
-            var container = new VisualElement()
-            {
-                style =
-                {
-                    flexDirection = FlexDirection.Row
-                }
-            };
-
-            var field = new PropertyField(property)
-            {
-                style =
-                {
-                    flexGrow = 1
-                }
-            };
-            field.BindProperty(property);
-            container.Add(field);
-
-            var label = new Label(syncVarIndicatorContent.text)
-            {
-                tooltip = syncVarIndicatorContent.tooltip,
-                style =
-                {
-                    fontSize = 10,
-                    flexGrow = 0,
-                    unityTextAlign = TextAnchor.MiddleLeft,
-                    marginLeft = 2,
-                    marginRight = 2
-                }
-            };
-
-            container.Add(label);
-
-            return container;
-        }
-#endif // USE_UI_TOOLKIT
     }
 } //namespace

--- a/Assets/Mirage/Editor/SyncVarAttributeDrawer.cs
+++ b/Assets/Mirage/Editor/SyncVarAttributeDrawer.cs
@@ -1,5 +1,13 @@
+#if UNITY_2022_2_OR_NEWER
+#define USE_UI_TOOLKIT
+#endif
+
 using UnityEditor;
 using UnityEngine;
+#if USE_UI_TOOLKIT
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+#endif
 
 namespace Mirage
 {
@@ -24,5 +32,45 @@ namespace Mirage
         {
             return EditorGUI.GetPropertyHeight(property);
         }
+
+#if USE_UI_TOOLKIT
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var container = new VisualElement()
+            {
+                style =
+                {
+                    flexDirection = FlexDirection.Row
+                }
+            };
+
+            var field = new PropertyField(property)
+            {
+                style =
+                {
+                    flexGrow = 1
+                }
+            };
+            field.BindProperty(property);
+            container.Add(field);
+
+            var label = new Label(syncVarIndicatorContent.text)
+            {
+                tooltip = syncVarIndicatorContent.tooltip,
+                style =
+                {
+                    fontSize = 10,
+                    flexGrow = 0,
+                    unityTextAlign = TextAnchor.MiddleLeft,
+                    marginLeft = 2,
+                    marginRight = 2
+                }
+            };
+
+            container.Add(label);
+
+            return container;
+        }
+#endif // USE_UI_TOOLKIT
     }
 } //namespace

--- a/Assets/Mirage/Editor/SyncVarAttributeDrawerUIToolkit.cs
+++ b/Assets/Mirage/Editor/SyncVarAttributeDrawerUIToolkit.cs
@@ -1,0 +1,50 @@
+#if UNITY_2022_2_OR_NEWER
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Mirage
+{
+    public partial class SyncVarAttributeDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var container = new VisualElement()
+            {
+                style =
+                {
+                    flexDirection = FlexDirection.Row
+                }
+            };
+
+            var field = new PropertyField(property)
+            {
+                style =
+                {
+                    flexGrow = 1
+                }
+            };
+            field.BindProperty(property);
+            container.Add(field);
+
+            var label = new Label(syncVarIndicatorContent.text)
+            {
+                tooltip = syncVarIndicatorContent.tooltip,
+                style =
+                {
+                    fontSize = 10,
+                    flexGrow = 0,
+                    unityTextAlign = TextAnchor.MiddleLeft,
+                    marginLeft = 2,
+                    marginRight = 2
+                }
+            };
+
+            container.Add(label);
+
+            return container;
+        }
+    }
+}
+#endif // UNITY_2022_2_OR_NEWER

--- a/Assets/Mirage/Editor/SyncVarAttributeDrawerUIToolkit.cs.meta
+++ b/Assets/Mirage/Editor/SyncVarAttributeDrawerUIToolkit.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 415b525f2f00411f99959c60a068addf
+timeCreated: 1672237994


### PR DESCRIPTION
Starting with Unity 2022.2, Unity now creates inspectors using UI toolkit. Mirage still uses IMGUI for the network behavior inspector which breaks any UI toolkit property drawers. This change adds a UI toolkit editor for network behaviors, along with also adding UI toolkit property drawers to all attributes.

All of the UI toolkit editors go into effect when the user is using Unity 2022.2 or later.