### PR TITLE
feat: networked prefab attribute

### DIFF
--- a/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawer.cs
+++ b/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawer.cs
@@ -48,14 +48,14 @@ namespace Mirage
 
             var y = position.y;
 
-            // If there's a fix message, show it.
+            // If there's a fix message and there's a target object, show the error.
             var fixMessage = GetFixMessage(_targetObjectHasIdentity, _targetObjectIsRegistered);
-            if (!string.IsNullOrEmpty(fixMessage))
+            if (!string.IsNullOrEmpty(fixMessage) && _currentTargetObject != null)
             {
                 var r = new Rect(position.x, position.y, position.width - 63, HELP_BOX_HEIGHT);
 
                 EditorGUI.HelpBox(r, fixMessage, MessageType.Error);
-                if (GUI.Button(new Rect(r.width + 3, r.y, 60, HELP_BOX_HEIGHT), "Fix"))
+                if (GUI.Button(new Rect(r.width + 21, r.y, 60, HELP_BOX_HEIGHT), "Fix"))
                 {
                     Fix(_currentTargetObject, _targetObjectHasIdentity, _targetObjectIsRegistered);
                 }
@@ -85,9 +85,9 @@ namespace Mirage
             _clientObjects = FindClientObjectManager();
             Validate(property.objectReferenceValue);
 
-            var height = EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            var height = EditorGUIUtility.singleLineHeight;
             // If it has some issue, add the help box height.
-            if (!_targetObjectHasIdentity || !_targetObjectIsRegistered)
+            if ((!_targetObjectHasIdentity || !_targetObjectIsRegistered) && _currentTargetObject != null)
             {
                 height += HELP_BOX_HEIGHT + EditorGUIUtility.standardVerticalSpacing;
             }

--- a/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawer.cs
+++ b/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawer.cs
@@ -1,0 +1,301 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Mirage
+{
+    [CustomPropertyDrawer(typeof(NetworkedPrefabAttribute))]
+    public sealed partial class NetworkedPrefabAttributeDrawer : PropertyDrawer
+    {
+        private bool _targetObjectHasIdentity = false;
+        private bool _targetObjectIsRegistered = false;
+
+        private Object _currentTargetObject;
+
+        private ClientObjectManager[] _clientObjects;
+
+        private const string NOT_OBJECT_REFERENCE_ERROR_FORMAT = "{0} is not a object reference. NetworkedPrefab can only be used on object references";
+        private const string INVALID_TYPE_ERROR = "NetworkedPrefab can only be used on GameObjects and Components";
+
+        private const float HELP_BOX_HEIGHT = 40;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            // It's not an object reference, show an error.
+            if (property.propertyType != SerializedPropertyType.ObjectReference)
+            {
+                var r = new Rect(position.x, position.y, position.width, HELP_BOX_HEIGHT);
+
+                EditorGUI.HelpBox(r, string.Format(NOT_OBJECT_REFERENCE_ERROR_FORMAT, property.name), MessageType.Error);
+                return;
+            }
+
+            // If's not a valid type (GameObject or subclass of component), show an error.
+            if (!IsValidType(fieldInfo.FieldType))
+            {
+                var r = new Rect(position.x, position.y, position.width, HELP_BOX_HEIGHT);
+
+                EditorGUI.HelpBox(r, INVALID_TYPE_ERROR, MessageType.Error);
+                return;
+            }
+
+            // Stop here if client objects are null. They are fetched in GetPropertyHeight.
+            if (_clientObjects == null)
+            {
+                return;
+            }
+
+            var y = position.y;
+
+            // If there's a fix message, show it.
+            var fixMessage = GetFixMessage(_targetObjectHasIdentity, _targetObjectIsRegistered);
+            if (!string.IsNullOrEmpty(fixMessage))
+            {
+                var r = new Rect(position.x, position.y, position.width - 63, HELP_BOX_HEIGHT);
+
+                EditorGUI.HelpBox(r, fixMessage, MessageType.Error);
+                if (GUI.Button(new Rect(r.width + 3, r.y, 60, HELP_BOX_HEIGHT), "Fix"))
+                {
+                    Fix(_currentTargetObject, _targetObjectHasIdentity, _targetObjectIsRegistered);
+                }
+
+                y += HELP_BOX_HEIGHT + EditorGUIUtility.standardVerticalSpacing;
+            }
+
+            // Draw the property.
+            EditorGUI.BeginChangeCheck();
+            EditorGUI.PropertyField(new Rect(position.x, y, position.width, EditorGUIUtility.singleLineHeight), property, label);
+            if (EditorGUI.EndChangeCheck())
+            {
+                // If the property changed, update the target object.
+                Validate(property.objectReferenceValue);
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            // If the type is not an object reference or is not a GameObject or Component, return the height of a help box.
+            if (property.propertyType != SerializedPropertyType.ObjectReference || !IsValidType(fieldInfo.FieldType))
+            {
+                return HELP_BOX_HEIGHT;
+            }
+
+            // Validate the target object to update the bool values.
+            _clientObjects = FindClientObjectManager();
+            Validate(property.objectReferenceValue);
+
+            var height = EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            // If it has some issue, add the help box height.
+            if (!_targetObjectHasIdentity || !_targetObjectIsRegistered)
+            {
+                height += HELP_BOX_HEIGHT + EditorGUIUtility.standardVerticalSpacing;
+            }
+
+            return height;
+        }
+
+        /// <summary>
+        ///     Validates the target object and updates the state about the target object.
+        /// </summary>
+        /// <param name="obj">The object to check.</param>
+        private void Validate(Object obj)
+        {
+            // If the object is null, there's no identity to check. Just set everything to false.
+            if (obj == null)
+            {
+                _targetObjectHasIdentity = false;
+                _targetObjectIsRegistered = false;
+                _currentTargetObject = null;
+                return;
+            }
+
+            NetworkIdentity identity = null;
+
+            // Check for the identity on the object itself.
+            if (obj is GameObject go)
+            {
+                identity = go.GetComponent<NetworkIdentity>();
+            }
+            else if (obj is Component c)
+            {
+                identity = c.GetComponent<NetworkIdentity>();
+            }
+
+            // Update the has identity bool depending on if the identity is null or not.
+            _targetObjectHasIdentity = identity != null;
+
+            // If the identity exists, check if it's been registered on all client object managers.
+            // Else we can just assume it's not registered.
+            if (_targetObjectHasIdentity)
+            {
+                _targetObjectIsRegistered = true;
+
+                for (var i = 0; i < _clientObjects.Length; i++)
+                {
+                    if (!_clientObjects[i].spawnPrefabs.Contains(identity))
+                    {
+                        // The identity is not registered on this client object manager.
+                        // Therefore, the target object is not registered.
+                        _targetObjectIsRegistered = false;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                _targetObjectIsRegistered = false;
+            }
+
+            _currentTargetObject = obj;
+        }
+
+        /// <summary>
+        ///     Fixes the target object by adding a network behavior component and registering it on all found client object
+        ///     managers.
+        /// </summary>
+        /// <param name="targetObject">The object to fix.</param>
+        /// <param name="hasIdentity">Does the object have a network identity already?</param>
+        /// <param name="isRegistered">Is the object registered already?</param>
+        private void Fix(Object targetObject, bool hasIdentity, bool isRegistered)
+        {
+            NetworkIdentity identity = null;
+
+            // If the target object doesn't have a network identity, add one.
+            if (!hasIdentity)
+            {
+                if (targetObject is GameObject go)
+                {
+                    identity = Undo.AddComponent<NetworkIdentity>(go);
+                }
+                else if (targetObject is Component c)
+                {
+                    identity = Undo.AddComponent<NetworkIdentity>(c.gameObject);
+                }
+
+                EditorUtility.SetDirty(identity);
+            }
+            else // Else get the identity.
+            {
+                if (targetObject is GameObject go)
+                {
+                    identity = go.GetComponent<NetworkIdentity>();
+                }
+                else if (targetObject is Component c)
+                {
+                    identity = c.GetComponent<NetworkIdentity>();
+                }
+            }
+
+            // If the identity is null, it couldn't be added or fetched for some reason.
+            if (identity == null)
+            {
+                Debug.LogError($"Could not add NetworkIdentity to object {targetObject}.");
+                return;
+            }
+
+            // If the object is not registered, register it.
+            if (!isRegistered)
+            {
+                // Find all client object managers just to be sure we don't miss any.
+                // Force a search to not use the cache, just to be sure.
+                _clientObjects = FindClientObjectManager(true);
+
+                for (var i = 0; i < _clientObjects.Length; i++)
+                {
+                    // If the object is already registered, skip it.
+                    // It can happen that it is registered on one client object manager but not on another.
+                    if (_clientObjects[i].spawnPrefabs.Contains(identity))
+                    {
+                        continue;
+                    }
+
+                    Undo.RecordObject(_clientObjects[i], "Add networked prefab");
+
+                    // Check if the client object manager is a prefab.
+                    var isPrefab = PrefabUtility.IsPartOfPrefabAsset(_clientObjects[i]) || PrefabUtility.IsPartOfPrefabInstance(_clientObjects[i]);
+
+                    // We need to record prefab modifications if the client object manager is a prefab.
+                    if (isPrefab)
+                    {
+                        PrefabUtility.RecordPrefabInstancePropertyModifications(_clientObjects[i]);
+                    }
+
+                    // Add the prefab to the spawn prefabs list and mark the object manager as dirty.
+                    _clientObjects[i].spawnPrefabs.Add(identity);
+                    EditorUtility.SetDirty(_clientObjects[i]);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Finds all ClientObjectManager instances in the scene or the project.
+        /// </summary>
+        /// <param name="forceSearch">If true, it will not use the cache.</param>
+        /// <returns>All the found client object managers.</returns>
+        private ClientObjectManager[] FindClientObjectManager(bool forceSearch = false)
+        {
+            // If we've already found the client object manager, return it.
+            // But only if we're not forcing a search.
+            if (_clientObjects != null && !forceSearch)
+            {
+                return _clientObjects;
+            }
+
+            // Find the first object manager in the scene.
+#if UNITY_2023_1_OR_NEWER
+			var sceneObjects = Object.FindObjectsByType<ClientObjectManager>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+#else
+            var sceneObjects = Object.FindObjectsOfType<ClientObjectManager>();
+#endif
+
+            // If there is an object manager, return it.
+            if (sceneObjects != null)
+            {
+                return sceneObjects;
+            }
+
+            // There is no object manager in the scene, so find all object managers in the project.
+            var prefabObjects = Resources.FindObjectsOfTypeAll<ClientObjectManager>();
+
+            return prefabObjects;
+        }
+
+        /// <summary>
+        ///     Checks if the type valid for the networked prefab attribute.
+        ///     <para>To be valid it must be of a type GameObject or be a subclass of Component.</para>
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if it's a valid type, otherwise false.</returns>
+        private static bool IsValidType(Type type)
+        {
+            return type == typeof(GameObject) || type.IsSubclassOf(typeof(Component));
+        }
+
+        /// <summary>
+        ///     Returns a proper fix message based on the current state of the target object.
+        /// </summary>
+        /// <param name="hasIdentity">If the object has a network identity.</param>
+        /// <param name="isRegistered">If the object is registered on the network manager.</param>
+        /// <returns>A fix message. Returns an empty string if there's no fix required.</returns>
+        private static string GetFixMessage(bool hasIdentity, bool isRegistered)
+        {
+            if (!hasIdentity && !isRegistered)
+            {
+                return "The object does not have a NetworkIdentity and is not registered in the NetworkManager.";
+            }
+
+            if (!hasIdentity)
+            {
+                return "The object does not have a NetworkIdentity.";
+            }
+
+            if (!isRegistered)
+            {
+                return "The object is not registered in the NetworkManager.";
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawer.cs.meta
+++ b/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f2e12cdad8944d099b14011cc1910630
+timeCreated: 1672688618

--- a/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawerUIToolkit.cs
+++ b/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawerUIToolkit.cs
@@ -1,0 +1,91 @@
+#if UNITY_2022_2_OR_NEWER // Unity uses UI toolkit by default for inspectors in 2022.2 and up.
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace Mirage
+{
+    public partial class NetworkedPrefabAttributeDrawer
+    {
+        private VisualElement _container;
+        private HelpBox _errorBox;
+
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            // Find all the client object managers first.
+            _clientObjects = FindClientObjectManager();
+
+            var root = new VisualElement();
+
+            // It's not an object reference, show an error.
+            if (property.propertyType != SerializedPropertyType.ObjectReference)
+            {
+                root.Add(new HelpBox(string.Format(NOT_OBJECT_REFERENCE_ERROR_FORMAT, property.name), HelpBoxMessageType.Error));
+                return root;
+            }
+
+            // If's not a valid type (GameObject or subclass of component), show an error.
+            if (!IsValidType(fieldInfo.FieldType))
+            {
+                root.Add(new HelpBox(INVALID_TYPE_ERROR, HelpBoxMessageType.Error));
+                return root;
+            }
+
+            _container = new VisualElement { style = { flexDirection = FlexDirection.Row, display = DisplayStyle.None } };
+
+            // Create the error box that will contain the error message.
+            _errorBox = new HelpBox(string.Empty, HelpBoxMessageType.Error) { style = { flexGrow = 1 } };
+            // Create the fix button.
+            var fixButton = new Button(() =>
+            {
+                Fix(_currentTargetObject, _targetObjectHasIdentity, _targetObjectIsRegistered);
+                Validate(_currentTargetObject);
+                OnValidate();
+            }) { text = "Fix", style = { minWidth = 60 } };
+
+            _container.Add(_errorBox);
+            _container.Add(fixButton);
+
+            root.Add(_container);
+
+            // Create the object field.
+            var objField = new ObjectField(property.displayName) { objectType = fieldInfo.FieldType, value = property.objectReferenceValue, allowSceneObjects = false };
+
+            // When the object field changes, validate the new value.
+            objField.RegisterValueChangedCallback(evt =>
+            {
+                Validate(evt.newValue);
+                OnValidate();
+            });
+
+            objField.BindProperty(property);
+            // Add this class to the object field to make sure it gets the proper label width, as all other property fields.
+            objField.AddToClassList("unity-base-field__aligned");
+
+            root.Add(objField);
+
+            return root;
+        }
+
+        /// <summary>
+        ///     Called when the value of the property changes.
+        /// </summary>
+        private void OnValidate()
+        {
+            // If there's no target object, hide the error container with the error message and the fix button.
+            if (_currentTargetObject == null)
+            {
+                _container.style.display = DisplayStyle.None;
+                return;
+            }
+
+            // Get the fix message and apply it to the error box.
+            var message = GetFixMessage(_targetObjectHasIdentity, _targetObjectIsRegistered);
+            _errorBox.text = message;
+
+            // Only show the error box and fix button if there's a fix message.
+            _container.style.display = string.IsNullOrEmpty(message) ? DisplayStyle.None : DisplayStyle.Flex;
+        }
+    }
+}
+#endif // UNITY_2022_2_OR_NEWER

--- a/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawerUIToolkit.cs.meta
+++ b/Assets/Mirage/Editor/NetworkedPrefabAttributeDrawerUIToolkit.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 48ceedced5de48bfa7c1fa924b9cef56
+timeCreated: 1672688709

--- a/Assets/Mirage/Runtime/CustomAttributes.cs
+++ b/Assets/Mirage/Runtime/CustomAttributes.cs
@@ -190,4 +190,11 @@ namespace Mirage
     /// </summary>
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class ReadOnlyInspectorAttribute : PropertyAttribute { }
+
+    /// <summary>
+    /// Forces the user to provide a prefab that has a NetworkIdentity component and is registered.
+    /// Also provides a fix button to fix the prefab if it hasn't been networked.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class NetworkedPrefabAttribute : PropertyAttribute { }
 }


### PR DESCRIPTION
This pr adds a new attribute called `NetworkedPrefab` that prompts the user to fix their prefab if it doesn't have a network identity and/or is not registered on a client object manager.

![image](https://user-images.githubusercontent.com/5569364/210275597-337c9cd9-025e-4265-9130-9c51648f9b29.png)

The property drawer has both an IMGUI and UI Toolkit equivariant to support Unity 2022.2 and newer.

When the fix button is pressed, it first adds a network identity to the target object, finds all the client object managers in the scene, and adds the object to the spawn list. If it doesn't find any objects in the scene, it searches the project for prefabs and adds them there directly instead.

There is no prompt asking the user what they want as it can result in way too many options, for now, I just assume the situation and does what I believe is best, which I described above.