### PR TITLE
fix: ui toolkit list fields not being reorderable

### DIFF
--- a/Assets/Mirage/Editor/NetworkBehaviourInspectorUIToolkit.cs
+++ b/Assets/Mirage/Editor/NetworkBehaviourInspectorUIToolkit.cs
@@ -17,7 +17,6 @@ namespace Mirage
             for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
             {
                 var field = new PropertyField(iterator);
-                field.Bind(serializedObject);
 
                 // Disable the script field.
                 if (iterator.propertyPath == "m_Script")


### PR DESCRIPTION
There's a really weird issue that sometimes happens where lists are not reorderable when the base type is NetworkBehavior. No clue why actually binding property fields causes this. It seems to work fine without binding when you directly assign the property to the field.