### PR TITLE
feat: adding Client stop group

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -132,7 +132,7 @@ namespace Mirage
             }
         }
 
-        private void OnClientDisconnected(ClientStoppedReason reason)
+        private void OnClientDisconnected(ClientStoppedReason reason, ClientStopReasonGroup group)
         {
             ClearSpawners();
             DestroyAllClientObjects();

--- a/Assets/Mirage/Runtime/ClientStoppedReason.cs
+++ b/Assets/Mirage/Runtime/ClientStoppedReason.cs
@@ -3,6 +3,13 @@ using Mirage.SocketLayer;
 
 namespace Mirage
 {
+    [Serializable]
+    public enum ClientStopReasonGroup
+    {
+        ConnectingFailed,
+        Disconnected,
+        HostMode,
+    }
     /// <summary>
     /// Reason why Client was stopped or disconnected
     /// </summary>

--- a/Assets/Mirage/Runtime/Events/DisconnectAddLateEvent.cs
+++ b/Assets/Mirage/Runtime/Events/DisconnectAddLateEvent.cs
@@ -3,10 +3,10 @@ using UnityEngine.Events;
 
 namespace Mirage.Events
 {
-    [Serializable] public class DisconnectEvent : UnityEvent<ClientStoppedReason> { }
+    [Serializable] public class DisconnectEvent : UnityEvent<ClientStoppedReason, ClientStopReasonGroup> { }
 
     /// <summary>
     /// Event fires from a <see cref="NetworkClient">NetworkClient</see> when it fails to connect to the server
     /// </summary>
-    [Serializable] public class DisconnectAddLateEvent : AddLateEvent<ClientStoppedReason, DisconnectEvent> { }
+    [Serializable] public class DisconnectAddLateEvent : AddLateEvent<ClientStoppedReason, ClientStopReasonGroup, DisconnectEvent> { }
 }

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -72,7 +72,7 @@ namespace Mirage
         /// <summary>
         /// Event fires after the Client has disconnected from its Server and Cleanup has been called.
         /// </summary>
-        public IAddLateEvent<ClientStoppedReason> Disconnected => _disconnected;
+        public IAddLateEvent<ClientStoppedReason, ClientStopReasonGroup> Disconnected => _disconnected;
 
         /// <summary>
         /// The NetworkConnection object this client is using.
@@ -181,7 +181,7 @@ namespace Mirage
         {
             if (logger.LogEnabled()) logger.Log($"Failed to connect to {conn.EndPoint} with reason {reason}");
             Player?.MarkAsDisconnected();
-            _disconnected?.Invoke(reason.ToClientStoppedReason());
+            _disconnected?.Invoke(reason.ToClientStoppedReason(), ClientStopReasonGroup.ConnectingFailed);
             Cleanup();
         }
 
@@ -189,14 +189,14 @@ namespace Mirage
         {
             if (logger.LogEnabled()) logger.Log($"Disconnected from {conn.EndPoint} with reason {reason}");
             Player?.MarkAsDisconnected();
-            _disconnected?.Invoke(reason.ToClientStoppedReason());
+            _disconnected?.Invoke(reason.ToClientStoppedReason(), ClientStopReasonGroup.Disconnected);
             Cleanup();
         }
 
         private void OnHostDisconnected()
         {
             Player?.MarkAsDisconnected();
-            _disconnected?.Invoke(ClientStoppedReason.HostModeStopped);
+            _disconnected?.Invoke(ClientStoppedReason.HostModeStopped, ClientStopReasonGroup.Disconnected);
         }
 
         internal void ConnectHost(NetworkServer server, IDataHandler serverDataHandler)


### PR DESCRIPTION
helps tell why the client was stopped/disconnected

BREAKING CHANGE: Client.Disconnected event now has a second argument