### PR TITLE
refactor(NetworkManagerGUI): overhaul the debug controls

### DIFF
--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -216,18 +216,38 @@ namespace Mirage
             }
         }
 
+        internal void CheckNetworkManagerReference()
+        {
+            if (NetworkManager == null)
+            {
+                throw new NullReferenceException("NetworkManager reference is NULL. Fix it, then try again.");
+            }
+        }
+
+        /// <summary>
+        /// Called when user clicks the Host button. It starts Host (Server + Client) mode.
+        /// </summary>
         private void ClickHost()
         {
+            CheckNetworkManagerReference();
             NetworkManager.Server.StartServer(NetworkManager.Client);
         }
 
+        /// <summary>
+        /// Called when user clicks Start Server button. Starts only the server, no server-mode client.
+        /// </summary>
         private void ClickServerOnly()
         {
+            CheckNetworkManagerReference();
             NetworkManager.Server.StartServer();
         }
 
+        /// <summary>
+        /// Called when the user clicks Connect. It connects to the server.
+        /// </summary>
         private void ClickClient()
         {
+            CheckNetworkManagerReference();
             NetworkManager.Client.Connect(NetworkAddress);
         }
 

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -1,9 +1,9 @@
 using System;
-#if !UNITY_WEBGL
+// #if !UNITY_WEBGL
 // This is needed if we want to show the port
 // and we're using the UDP SocketLayer.
-using Mirage.Sockets.Udp;
-#endif
+// using Mirage.Sockets.Udp;
+// #endif
 using UnityEngine;
 
 namespace Mirage
@@ -28,6 +28,10 @@ namespace Mirage
 
         [Tooltip("Select where you want the NetworkManagerGUI elements to be located on the screen.")]
         public TextAnchor GUIAnchor = TextAnchor.UpperLeft;
+
+// #if !UNITY_WEBGL
+//      private UdpSocketFactory udpSocketFactory;
+// #endif
 
         private void Reset()
         {
@@ -68,22 +72,21 @@ namespace Mirage
                 return;
             }
 
+// #if !UNITY_WEBGL
+            // This will only be called one time.
+            // TODO: Maybe remove this weird jank - maybe talk to James about a more elegant solution.
+            // if (udpSocketFactory == null)
+            // {
+            //  if (NetworkManager.Server.SocketFactory is UdpSocketFactory)
+            //  {
+            //      udpSocketFactory = NetworkManager.Server.SocketFactory as UdpSocketFactory;
+            //  }
+            // }
+// #endif
+
             // Draw the window on the screen.
             GUIUtility.ScaleAroundPivot(Vector2.one * Scale, GetPivotFromAnchor(GUIAnchor));
             GUI.Window(WINDOW_ID, GetRectFromAnchor(GUIAnchor, WINDOW_HEIGHT), DrawNetworkManagerWindow, "Mirage Networking");
-
-            /*
-            GUIUtility.ScaleAroundPivot(Vector2.one * Scale, GetPivotFromAnchor(GUIAnchor));
-
-            if (!NetworkManager.Server.Active && !NetworkManager.Client.Active)
-            {
-                StartButtons(GetRectFromAnchor(GUIAnchor, 71));
-            }
-            else
-            {
-                StatusLabels(GetRectFromAnchor(GUIAnchor, 100));
-            }
-            */
         }
 
         private void StartButtons(Rect position)

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -1,4 +1,9 @@
 using System;
+#if !UNITY_WEBGL
+// This is needed if we want to show the port
+// and we're using the UDP SocketLayer.
+using Mirage.Sockets.Udp;
+#endif
 using UnityEngine;
 
 namespace Mirage

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -237,5 +237,21 @@ namespace Mirage
         private const int WINDOW_ID = 0;
         private const int WINDOW_HEIGHT = 240;
         private const int WINDOW_BUTTON_HEIGHT = 30;
+
+        internal void DrawNetworkManagerWindow (int id)
+        {
+            // If the server is active...
+            if (!NetworkManager.Server.Active && !NetworkManager.Client.Active)
+            {
+                DrawIdleControls();
+                // DrawIdleControls(GetRectFromAnchor(GUIAnchor, 71));
+
+                // StartButtons(GetRectFromAnchor(GUIAnchor, 71));
+            }
+            else
+            {
+                //StatusLabels(GetRectFromAnchor(GUIAnchor, 100));
+            }
+        }
     }
 }

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -286,5 +286,15 @@ namespace Mirage
             // Done!
             GUILayout.EndVertical();
         }
+
+        /// <summary>
+        /// Draws controls and labels to give information about
+        /// the server instance that's running.
+        /// </summary>
+        internal void DrawServerControls()
+        {
+            GUILayout.BeginVertical(GUILayout.ExpandHeight(true));
+            GUILayout.EndVertical();
+        }
     }
 }

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -78,6 +78,7 @@ namespace Mirage
             {
                 StatusLabels(GetRectFromAnchor(GUIAnchor, 100));
             }
+            */
         }
 
         private void StartButtons(Rect position)

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -289,21 +289,32 @@ namespace Mirage
             // Begin the idle controls.
             GUILayout.BeginVertical(GUILayout.ExpandHeight(true));
 
-#if !UNITY_WEBGL
             // Server mode controls (not available on WebGL).
+#if !UNITY_WEBGL            
             GUILayout.Label("Server Mode");
-            GUILayout.Button("Server Only", GUILayout.Height(WINDOW_BUTTON_HEIGHT));
-            GUILayout.Button("Host Mode (Server + Client)", GUILayout.Height(WINDOW_BUTTON_HEIGHT));
-#endif
 
+            if (GUILayout.Button("Server Only", GUILayout.Height(WINDOW_BUTTON_HEIGHT)))
+            {
+                ClickServerOnly();
+            }
+
+            if (GUILayout.Button("Host Mode (Server + Client)", GUILayout.Height(WINDOW_BUTTON_HEIGHT)))
+            {
+                ClickHost();
+            }
+#endif
             // Client mode
             GUILayout.Label("Client Mode");
-            
-            NetworkAddress = GUILayout.TextField(NetworkAddress);
-            GUILayout.Button("Connect", GUILayout.Height(WINDOW_BUTTON_HEIGHT));
 
-            // Spacer?
+            NetworkAddress = GUILayout.TextField(NetworkAddress);
+            if (GUILayout.Button("Connect", GUILayout.Height(WINDOW_BUTTON_HEIGHT)))
+            {
+                ClickClient();
+            }
+
+            // Spacer
             GUILayout.FlexibleSpace();
+
             // Misc stuff label
             GUILayout.Label($"Mirage Networking v{Version.Current}\n" +
                 $"Unity v{Application.unityVersion}");
@@ -319,6 +330,29 @@ namespace Mirage
         internal void DrawServerControls()
         {
             GUILayout.BeginVertical(GUILayout.ExpandHeight(true));
+            GUILayout.Label("Server is active.");
+
+            if (NetworkManager.Client.IsConnected)
+            {
+                GUILayout.Label("Host Mode is active.");
+
+                if (GUILayout.Button("Stop Host Client", GUILayout.Height(WINDOW_BUTTON_HEIGHT)))
+                {
+                    NetworkManager.Server.Stop();
+                }
+            }
+
+            if (GUILayout.Button("Stop Server", GUILayout.Height(WINDOW_BUTTON_HEIGHT)))
+            {
+                NetworkManager.Server.Stop();
+            }
+
+            if (NetworkManager.Server.SocketFactory is UdpSocketFactory)
+                GUILayout.Label($"Listen Port: {NetworkManager.Server.SocketFactory}");
+
+            GUILayout.Label($"Backend: {NetworkManager.Server.SocketFactory.GetType().Name}");
+
+
             GUILayout.EndVertical();
         }
     }

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -63,6 +63,11 @@ namespace Mirage
                 return;
             }
 
+            // Draw the window on the screen.
+            GUIUtility.ScaleAroundPivot(Vector2.one * Scale, GetPivotFromAnchor(GUIAnchor));
+            GUI.Window(WINDOW_ID, GetRectFromAnchor(GUIAnchor, WINDOW_HEIGHT), DrawNetworkManagerWindow, "Mirage Networking");
+
+            /*
             GUIUtility.ScaleAroundPivot(Vector2.one * Scale, GetPivotFromAnchor(GUIAnchor));
 
             if (!NetworkManager.Server.Active && !NetworkManager.Client.Active)

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -253,5 +253,37 @@ namespace Mirage
                 //StatusLabels(GetRectFromAnchor(GUIAnchor, 100));
             }
         }
+
+        /// <summary>
+        /// This draws the idle controls. Idle in the sense that
+        /// neither the Server or Client is running.
+        /// </summary>
+        internal void DrawIdleControls()
+        {
+            // Begin the idle controls.
+            GUILayout.BeginVertical(GUILayout.ExpandHeight(true));
+
+#if !UNITY_WEBGL
+            // Server mode controls (not available on WebGL).
+            GUILayout.Label("Server Mode");
+            GUILayout.Button("Server Only", GUILayout.Height(WINDOW_BUTTON_HEIGHT));
+            GUILayout.Button("Host Mode (Server + Client)", GUILayout.Height(WINDOW_BUTTON_HEIGHT));
+#endif
+
+            // Client mode
+            GUILayout.Label("Client Mode");
+            
+            NetworkAddress = GUILayout.TextField(NetworkAddress);
+            GUILayout.Button("Connect", GUILayout.Height(WINDOW_BUTTON_HEIGHT));
+
+            // Spacer?
+            GUILayout.FlexibleSpace();
+            // Misc stuff label
+            GUILayout.Label($"Mirage Networking v{Version.Current}\n" +
+                $"Unity v{Application.unityVersion}");
+
+            // Done!
+            GUILayout.EndVertical();
+        }
     }
 }

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -282,7 +282,7 @@ namespace Mirage
                 if (GUILayout.Button("Stop Client", GUILayout.Height(WINDOW_BUTTON_HEIGHT)))
                 {
                     NetworkManager.Client.Disconnect();
-                }                
+                }
 
                 if (NetworkManager.Client.SocketFactory is IHasAddress hasAddress)
                     GUILayout.Label($"Server: {hasAddress.Address}");

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -32,7 +32,6 @@ namespace Mirage
 
         private void Awake()
         {
-            // Coburn, 2023-02-02: 
             // If automatic configuration of NetworkManager is enabled, then attempt to grab the
             // NetworkManager that this script is attached to.
             if (AutoConfigureNetworkManager)
@@ -57,9 +56,8 @@ namespace Mirage
 
         private void OnGUI()
         {
-            // Coburn, 2023-02-02: Apparently NMGUI can/may lose reference to NetworkManager for reasons unknown
-            // (maybe due to being in and out of DDOL and scene changes?). To prevent a NRE being spewed every OnGUI
-            // update, short-circuit here to prevent log spam.
+            // Depending how the scene is set up, references can be broken. If the NM reference is null/missing, then
+            // short-circuit here to prevent log spam.
             if (NetworkManager == null)
             {
                 return;

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -233,5 +233,9 @@ namespace Mirage
         private const int WIDTH = 200;
         private const int PADDING_X = 10;
         private const int PADDING_Y = 10;
+
+        private const int WINDOW_ID = 0;
+        private const int WINDOW_HEIGHT = 240;
+        private const int WINDOW_BUTTON_HEIGHT = 30;
     }
 }

--- a/Assets/Mirage/Components/NetworkManagerGUI.cs
+++ b/Assets/Mirage/Components/NetworkManagerGUI.cs
@@ -264,7 +264,7 @@ namespace Mirage
         private const int WINDOW_HEIGHT = 240;
         private const int WINDOW_BUTTON_HEIGHT = 30;
 
-        internal void DrawNetworkManagerWindow (int id)
+        internal void DrawNetworkManagerWindow(int id)
         {
             // If the server is active...
             if (!NetworkManager.Server.Active && !NetworkManager.Client.Active)


### PR DESCRIPTION
The current NetworkManagerGUI that is used by Mirage is rather outdated. Buttons are hard to click on if you have a touch screen, the white text blends in with the scene, etc. Overall, it was begging for an update.

This PR introduces an almost-completely refactored NetworkManagerGUI that is using the `GUI.Window` functionality to give it a nice background and title. In the future, one could turn it into a draggable GUI Window, but for now it's more elegant but keeping things simple.

Empty space will be used in later updates (current connection count, etc).

**Screenshots**
![image](https://github.com/MirageNet/Mirage/assets/1762115/e67286c5-d381-4e8a-8775-1c7827ac5299) ![image](https://github.com/MirageNet/Mirage/assets/1762115/ba4e033f-730d-4ce4-8375-a48812fe5cee) ![image](https://github.com/MirageNet/Mirage/assets/1762115/e39c0c93-d8b5-48dd-b31d-f08974ad2e6f)
