### PR TITLE
fix: add missing HelpUrl tag to high level classes

### DIFF
--- a/Assets/Mirage/Runtime/CharacterSpawner.cs
+++ b/Assets/Mirage/Runtime/CharacterSpawner.cs
@@ -10,6 +10,7 @@ namespace Mirage
     /// <summary>
     /// Spawns a player as soon as the connection is authenticated
     /// </summary>
+    [HelpURL("https://miragenet.github.io/Mirage/docs/guides/game-objects/spawn-player/")]
     public class CharacterSpawner : MonoBehaviour
     {
         private static readonly ILogger logger = LogFactory.GetLogger(typeof(CharacterSpawner));

--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 namespace Mirage
 {
     [AddComponentMenu("Network/ClientObjectManager")]
+    [HelpURL("https://miragenet.github.io/Mirage/docs/reference/Mirage/ClientObjectManager")]
     [DisallowMultipleComponent]
     public class ClientObjectManager : MonoBehaviour
     {

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -22,6 +22,7 @@ namespace Mirage
     /// <para><see cref="NetworkClient">NetworkClient</see> has an internal update function where it handles events from the transport layer. This includes asynchronous connect events, disconnect events and incoming data from a server.</para>
     /// </summary>
     [AddComponentMenu("Network/NetworkClient")]
+    [HelpURL("https://miragenet.github.io/Mirage/docs/reference/Mirage/NetworkClient")]
     [DisallowMultipleComponent]
     public class NetworkClient : MonoBehaviour, IMessageSender
     {

--- a/Assets/Mirage/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirage/Runtime/NetworkSceneManager.cs
@@ -17,6 +17,7 @@ namespace Mirage
     /// <para>when a client connect NetworkSceneManager will send a message telling the new client to load the scene that is active on the server</para>
     /// </summary>
     [AddComponentMenu("Network/NetworkSceneManager")]
+    [HelpURL("https://miragenet.github.io/Mirage/docs/components/network-scene-manager")]
     [DisallowMultipleComponent]
     public class NetworkSceneManager : MonoBehaviour
     {

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -19,6 +19,7 @@ namespace Mirage
     /// <para>NetworkServer handles remote connections from remote clients, and also has a local connection for a local client.</para>
     /// </remarks>
     [AddComponentMenu("Network/NetworkServer")]
+    [HelpURL("https://miragenet.github.io/Mirage/docs/reference/Mirage/NetworkServer")]
     [DisallowMultipleComponent]
     public class NetworkServer : MonoBehaviour
     {

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -18,6 +18,7 @@ namespace Mirage
     /// Spawned objects are removed automatically when they are destroyed, or than they can be removed from the spawned set by calling ServerObjectManager.UnSpawn() - this does not destroy the object.</para>
     /// </remarks>
     [AddComponentMenu("Network/ServerObjectManager")]
+    [HelpURL("https://miragenet.github.io/Mirage/docs/reference/Mirage/ServerObjectManager")]
     [DisallowMultipleComponent]
     public class ServerObjectManager : MonoBehaviour
     {

--- a/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
@@ -29,6 +29,7 @@ namespace Mirage.SocketLayer
     /// - Show config data to the user using the inspector, and give that data in the form of an <see cref="EndPoint"/>
     /// <para>This is a MonoBehaviour so can be attached in the inspector</para>
     /// </remarks>
+    [HelpURL("https://miragenet.github.io/Mirage/docs/general/sockets#changing-a-socket")]
     public abstract class SocketFactory : MonoBehaviour
     {
         /// <summary>Max size for packets sent to or received from Socket


### PR DESCRIPTION
These high level classes did not have a HelpUrl pointing to Mirage documentation. The others that do exist seem to prefer using Guides > Comps > Class Ref. I tried to stick to that same priority but some are missing. I figured its better to link to a valid Mirage doc instead of letting it error off to a Missing Doc page on unity3d.com