### PR TITLE
fix(ClientObjectManager): add prefab to SpawnHandler when registering

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -301,9 +301,10 @@ namespace Mirage
         /// <param name="unspawnHandler">A method to use as a custom un-spawnhandler on clients.</param>
         public void RegisterSpawnHandler(NetworkIdentity identity, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
         {
-            ThrowIfZeroHash(identity);
             var prefabHash = identity.PrefabHash;
-            RegisterSpawnHandler(prefabHash, spawnHandler, unspawnHandler);
+            ValidateRegisterSpawnHandler(prefabHash, spawnHandler, unspawnHandler);
+            
+            _handlers[prefabHash] = new SpawnHandler(identity, spawnHandler, unspawnHandler);
         }
 
         /// <summary>
@@ -322,9 +323,10 @@ namespace Mirage
 
         public void RegisterSpawnHandler(NetworkIdentity identity, SpawnHandlerAsyncDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
         {
-            ThrowIfZeroHash(identity);
             var prefabHash = identity.PrefabHash;
-            RegisterSpawnHandler(prefabHash, spawnHandler, unspawnHandler);
+            ValidateRegisterSpawnHandler(prefabHash, spawnHandler, unspawnHandler);
+            
+            _handlers[prefabHash] = new SpawnHandler(identity, spawnHandler, unspawnHandler);
         }
 
         public void RegisterSpawnHandler(int prefabHash, SpawnHandlerAsyncDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
@@ -784,8 +786,24 @@ namespace Mirage
             UnspawnHandler = unspawnHandler;
         }
 
+        public SpawnHandler(NetworkIdentity prefab, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
+        {
+            Prefab = prefab ?? throw new ArgumentNullException(nameof(prefab));
+            Handler = spawnHandler ?? throw new ArgumentNullException(nameof(spawnHandler));
+            // unspawn is allowed to be null
+            UnspawnHandler = unspawnHandler;
+        }
+
         public SpawnHandler(SpawnHandlerAsyncDelegate spawnHandlerAsync, UnSpawnDelegate unspawnHandler)
         {
+            HandlerAsync = spawnHandlerAsync ?? throw new ArgumentNullException(nameof(spawnHandlerAsync));
+            // unspawn is allowed to be null
+            UnspawnHandler = unspawnHandler;
+        }
+
+        public SpawnHandler(NetworkIdentity prefab, SpawnHandlerAsyncDelegate spawnHandlerAsync, UnSpawnDelegate unspawnHandler)
+        {
+            Prefab = prefab ?? throw new ArgumentNullException(nameof(prefab));
             HandlerAsync = spawnHandlerAsync ?? throw new ArgumentNullException(nameof(spawnHandlerAsync));
             // unspawn is allowed to be null
             UnspawnHandler = unspawnHandler;


### PR DESCRIPTION
When registering a prefab with the below function, the resulting SpawnHandler has an empty `Prefab`.
```cs
clientObjectManager.RegisterSpawnHandler(prefab, OnClientSpawnCharacter, OnClientUnSpawnCharacter);
```

With a custom spawn handler, the below function fails even with a registered prefab.
```cs
private NetworkIdentity OnClientSpawnCharacter(SpawnMessage msg)
{
    if (!msg.PrefabHash.HasValue)
        return null;
    
    int prefabHash = msg.PrefabHash.Value;
    SpawnHandler handler = clientObjectManager.GetSpawnHandler(prefabHash);
    
    NetworkIdentity prefab = handler.Prefab;
    var pos = msg.SpawnValues.Position ?? prefab.transform.position;
    var rot = msg.SpawnValues.Rotation ?? prefab.transform.rotation;
    
    return Instantiate(prefab, pos, rot);
}
```

This pull request adds the below constructors for SpawnHandler, which add the respective NetworkIdentity into the SpawnHandler so that the prefab can be found during spawn.
```cs
public SpawnHandler(NetworkIdentity prefab, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
public SpawnHandler(NetworkIdentity prefab, SpawnHandlerAsyncDelegate spawnHandlerAsync, UnSpawnDelegate unspawnHandler);
```