### PR TITLE
feat: adding option to pass channel type to socket

### DIFF
--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -142,16 +142,16 @@ namespace Mirage
             if (logger.LogEnabled()) logger.Log($"Client connecting to endpoint: {endPoint}");
 
             var socket = SocketFactory.CreateClientSocket();
-            var maxPacketSize = SocketFactory.MaxPacketSize;
+            var socketInfo = SocketFactory.SocketInfo;
             MessageHandler = new MessageHandler(World, DisconnectOnException, RethrowException);
             var dataHandler = new DataHandler(MessageHandler);
             Metrics = EnablePeerMetrics ? new Metrics(MetricsSize) : null;
 
             var config = PeerConfig ?? new Config();
 
-            NetworkWriterPool.Configure(maxPacketSize);
+            NetworkWriterPool.Configure(socketInfo.MaxSize);
 
-            _peer = new Peer(socket, maxPacketSize, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
+            _peer = new Peer(socket, socketInfo, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
             _peer.OnConnected += Peer_OnConnected;
             _peer.OnConnectionFailed += Peer_OnConnectionFailed;
             _peer.OnDisconnected += Peer_OnDisconnected;

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -260,14 +260,14 @@ namespace Mirage
             // If not, that's okay. Some games use a non-listening server for their single player game mode (Battlefield, Call of Duty...)
             if (Listening)
             {
-                var maxPacketSize = SocketFactory.MaxPacketSize;
-                NetworkWriterPool.Configure(maxPacketSize);
+                var socketInfo = SocketFactory.SocketInfo;
+                NetworkWriterPool.Configure(socketInfo.MaxSize);
 
                 // Create a server specific socket.
                 var socket = SocketFactory.CreateServerSocket();
 
                 // Tell the peer to use that newly created socket.
-                _peer = new Peer(socket, maxPacketSize, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
+                _peer = new Peer(socket, socketInfo, dataHandler, config, LogFactory.GetLogger<Peer>(), Metrics);
                 _peer.OnConnected += Peer_OnConnected;
                 _peer.OnDisconnected += Peer_OnDisconnected;
                 // Bind it to the endpoint.

--- a/Assets/Mirage/Runtime/SocketLayer/ByteBuffer.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/ByteBuffer.cs
@@ -3,7 +3,7 @@ using System;
 namespace Mirage.SocketLayer
 {
     /// <summary>
-    /// Warpper around a byte[] that belongs to a <see cref="Pool{T}"/>
+    /// Wrapper around a byte[] that belongs to a <see cref="Pool{T}"/>
     /// </summary>
     public sealed class ByteBuffer : IDisposable
     {

--- a/Assets/Mirage/Runtime/SocketLayer/Config.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Config.cs
@@ -98,11 +98,6 @@ namespace Mirage.SocketLayer
         /// <para>max value is 255</para>
         /// </summary>
         public int MaxReliableFragments = 50;
-
-        /// <summary>
-        /// Enable if the Socket you are using has its own Reliable layer. For example using Websocket, which is TCP.
-        /// </summary>
-        public bool DisableReliableLayer = false;
         #endregion
     }
 }

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/AckSystem.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/AckSystem.cs
@@ -237,7 +237,7 @@ namespace Mirage.SocketLayer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Send(byte[] final, int length)
         {
-            _connection.SendRaw(final, length);
+            _connection.SendRaw(final, length, SendMode.Unreliable);
             OnSend();
         }
 
@@ -261,7 +261,7 @@ namespace Mirage.SocketLayer
                 ByteUtils.WriteUShort(final.array, ref offset, _latestAckSequence);
                 ByteUtils.WriteULong(final.array, ref offset, _ackMask);
 
-                _connection.SendRaw(final.array, offset);
+                _connection.SendRaw(final.array, offset, SendMode.Unreliable);
                 Send(final.array, offset);
             }
         }

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/Batch.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/Batch.cs
@@ -1,15 +1,18 @@
 using System;
+using UnityEngine;
 
 namespace Mirage.SocketLayer
 {
     public abstract class Batch
     {
         public const int MESSAGE_LENGTH_SIZE = 2;
+        public const int MAX_BATCH_SIZE = ushort.MaxValue;
 
         private readonly int _maxPacketSize;
 
         public Batch(int maxPacketSize)
         {
+
             _maxPacketSize = maxPacketSize;
         }
 
@@ -39,7 +42,7 @@ namespace Mirage.SocketLayer
             AddToBatch(message, offset, length);
         }
 
-        private void AddToBatch(byte[] message, int offset, int length)
+        protected virtual void AddToBatch(byte[] message, int offset, int length)
         {
             var batch = GetBatch();
             ref var batchLength = ref GetBatchLength();
@@ -61,11 +64,13 @@ namespace Mirage.SocketLayer
         private readonly PacketType _packetType;
         private readonly SendMode _sendMode;
         private readonly byte[] _batch;
+        protected readonly ILogger _logger;
         private int _batchLength;
 
-        public ArrayBatch(int maxPacketSize, IRawConnection connection, PacketType reliable, SendMode sendMode)
+        public ArrayBatch(int maxPacketSize, ILogger logger, IRawConnection connection, PacketType reliable, SendMode sendMode)
             : base(maxPacketSize)
         {
+            _logger = logger;
             _batch = new byte[maxPacketSize];
             _connection = connection;
             _packetType = reliable;
@@ -87,6 +92,29 @@ namespace Mirage.SocketLayer
         {
             _connection.SendRaw(_batch, _batchLength, _sendMode);
             _batchLength = 0;
+        }
+
+        protected override void AddToBatch(byte[] message, int offset, int length)
+        {
+            if (length > MAX_BATCH_SIZE)
+            {
+                var batch = GetBatch();
+                ref var batchLength = ref GetBatchLength();
+                _logger.Assert(batchLength == 1, "if length is large, then batch should be new (empty) packet");
+
+                // write zero as flag for large message,
+                // normal message will have atleast 1 length
+                ByteUtils.WriteUShort(batch, ref batchLength, 0);
+                Buffer.BlockCopy(message, offset, batch, batchLength, length);
+                batchLength += length;
+
+                // we can send right away, nothing else will fit in this message
+                SendAndReset();
+            }
+            else
+            {
+                base.AddToBatch(message, offset, length);
+            }
         }
     }
 

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/Batch.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/Batch.cs
@@ -57,18 +57,19 @@ namespace Mirage.SocketLayer
 
     public class ArrayBatch : Batch
     {
-        private readonly Action<byte[], int> _send;
+        private readonly IRawConnection _connection;
         private readonly PacketType _packetType;
-
+        private readonly SendMode _sendMode;
         private readonly byte[] _batch;
         private int _batchLength;
 
-        public ArrayBatch(int maxPacketSize, Action<byte[], int> send, PacketType reliable)
+        public ArrayBatch(int maxPacketSize, IRawConnection connection, PacketType reliable, SendMode sendMode)
             : base(maxPacketSize)
         {
             _batch = new byte[maxPacketSize];
-            _send = send;
+            _connection = connection;
             _packetType = reliable;
+            _sendMode = sendMode;
         }
 
         protected override bool Created => _batchLength > 0;
@@ -84,7 +85,7 @@ namespace Mirage.SocketLayer
 
         protected override void SendAndReset()
         {
-            _send.Invoke(_batch, _batchLength);
+            _connection.SendRaw(_batch, _batchLength, _sendMode);
             _batchLength = 0;
         }
     }

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/Connection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/Connection.cs
@@ -212,14 +212,30 @@ namespace Mirage.SocketLayer
 
         protected void HandleReliableBatched(byte[] array, int offset, int packetLength, PacketType packetType)
         {
+            var firstPacket = true;
             while (offset < packetLength)
             {
-                var length = ByteUtils.ReadUShort(array, ref offset);
+                var length = (int)ByteUtils.ReadUShort(array, ref offset);
+                if (length == 0)// not batched
+                {
+                    if (!firstPacket) 
+                    {
+                        // only first message can be not batched
+                        Disconnect(DisconnectReason.InvalidPacket);
+                        return;
+                    }
+
+                    _logger.Assert(offset == 3);
+                    // set real length
+                    length = packetLength - offset;
+                }
+
                 var message = new ArraySegment<byte>(array, offset, length);
                 offset += length;
 
                 _metrics?.OnReceiveMessage(packetType, length);
                 _dataHandler.ReceiveMessage(this, message);
+                firstPacket = false;
             }
         }
 

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/Connection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/Connection.cs
@@ -4,10 +4,10 @@ using UnityEngine;
 
 namespace Mirage.SocketLayer
 {
-    internal abstract class Connection : IConnection
+    internal abstract class Connection : IConnection, IRawConnection
     {
         protected readonly ILogger _logger;
-        protected readonly int _maxPacketSize;
+        protected readonly SocketInfo _socketInfo;
         protected readonly Peer _peer;
         protected readonly IDataHandler _dataHandler;
 
@@ -55,11 +55,11 @@ namespace Mirage.SocketLayer
 
         public bool Connected => State == ConnectionState.Connected;
 
-        protected Connection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, int maxPacketSize, Time time, ILogger logger, Metrics metrics)
+        protected Connection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, SocketInfo socketInfo, Time time, ILogger logger, Metrics metrics)
         {
             _peer = peer;
             _logger = logger;
-            _maxPacketSize = maxPacketSize;
+            _socketInfo = socketInfo;
 
             EndPoint = endPoint ?? throw new ArgumentNullException(nameof(endPoint));
             _dataHandler = dataHandler ?? throw new ArgumentNullException(nameof(dataHandler));
@@ -71,6 +71,11 @@ namespace Mirage.SocketLayer
             _disconnectedTracker = new DisconnectedTracker(config, time);
 
             _metrics = metrics;
+        }
+
+        void IRawConnection.SendRaw(byte[] packet, int length, SendMode mode)
+        {
+            _peer.Send(this, packet, length, mode);
         }
 
         public override string ToString()

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/IConnection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/IConnection.cs
@@ -11,7 +11,7 @@ namespace Mirage.SocketLayer
         /// <para>packet given to this function as assumed to already have a header</para>
         /// </summary>
         /// <param name="packet">header and messages</param>
-        void SendRaw(byte[] packet, int length);
+        void SendRaw(byte[] packet, int length, SendMode mode);
     }
 
     /// <summary>

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/NoReliableConnection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/NoReliableConnection.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 
 namespace Mirage.SocketLayer
 {
-
     /// <summary>
     /// Connection that does not run its own reliability layer, good for TCP sockets
     /// </summary>
@@ -18,7 +17,7 @@ namespace Mirage.SocketLayer
         {
             Debug.Assert(socketInfo.Reliability == SocketReliability.Reliable);
 
-            _nextBatchReliable = new ArrayBatch(socketInfo.MaxReliableSize, this, PacketType.Reliable, SendMode.Reliable);
+            _nextBatchReliable = new ArrayBatch(socketInfo.MaxReliableSize, logger, this, PacketType.Reliable, SendMode.Reliable);
         }
 
         // just sue SendReliable for unreliable/notify

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/NoReliableConnection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/NoReliableConnection.cs
@@ -3,8 +3,9 @@ using UnityEngine;
 
 namespace Mirage.SocketLayer
 {
+
     /// <summary>
-    /// Connection that does not run its own reliablity layer, good for TCP sockets
+    /// Connection that does not run its own reliability layer, good for TCP sockets
     /// </summary>
     internal sealed class NoReliableConnection : Connection
     {
@@ -12,20 +13,12 @@ namespace Mirage.SocketLayer
 
         private readonly Batch _nextBatchReliable;
 
-        internal NoReliableConnection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, int maxPacketSize, Time time, ILogger logger, Metrics metrics)
-            : base(peer, endPoint, dataHandler, config, maxPacketSize, time, logger, metrics)
+        internal NoReliableConnection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, SocketInfo socketInfo, Time time, ILogger logger, Metrics metrics)
+            : base(peer, endPoint, dataHandler, config, socketInfo, time, logger, metrics)
         {
-            _nextBatchReliable = new ArrayBatch(maxPacketSize, SendBatchInternal, PacketType.Reliable);
+            Debug.Assert(socketInfo.Reliability == SocketReliability.Reliable);
 
-            if (maxPacketSize > ushort.MaxValue)
-            {
-                throw new ArgumentException($"Max package size can not bigger than {ushort.MaxValue}. NoReliableConnection uses 2 bytes for message length, maxPacketSize over that value will mean that message will be incorrectly batched.");
-            }
-        }
-
-        private void SendBatchInternal(byte[] batch, int length)
-        {
-            _peer.Send(this, batch, length);
+            _nextBatchReliable = new ArrayBatch(socketInfo.MaxReliableSize, this, PacketType.Reliable, SendMode.Reliable);
         }
 
         // just sue SendReliable for unreliable/notify
@@ -51,9 +44,9 @@ namespace Mirage.SocketLayer
         {
             ThrowIfNotConnectedOrConnecting();
 
-            if (length + HEADER_SIZE > _maxPacketSize)
+            if (length + HEADER_SIZE > _socketInfo.MaxReliableSize)
             {
-                throw new ArgumentException($"Message is bigger than MTU, size:{length} but max message size is {_maxPacketSize - HEADER_SIZE}");
+                throw new ArgumentException($"Message is bigger than MTU, size:{length} but max message size is {_socketInfo.MaxReliableSize - HEADER_SIZE}");
             }
 
             _nextBatchReliable.AddMessage(message, offset, length);

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/PassthroughConnection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/PassthroughConnection.cs
@@ -1,0 +1,144 @@
+using System;
+using UnityEngine;
+
+namespace Mirage.SocketLayer
+{
+    internal class PassthroughConnection : Connection, IRawConnection
+    {
+        private const int HEADER_SIZE = 1 + Batch.MESSAGE_LENGTH_SIZE;
+
+        private readonly Batch _reliableBatch;
+        private readonly Batch _unreliableBatch;
+        private readonly AckSystem _ackSystem;
+
+        public PassthroughConnection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, SocketInfo socketInfo, Time time, Pool<ByteBuffer> bufferPool, ILogger logger, Metrics metrics)
+            : base(peer, endPoint, dataHandler, config, socketInfo, time, logger, metrics)
+        {
+            _reliableBatch = new ArrayBatch(socketInfo.MaxReliableSize, this, PacketType.Reliable, SendMode.Reliable);
+            _unreliableBatch = new ArrayBatch(socketInfo.MaxUnreliableSize, this, PacketType.Unreliable, SendMode.Unreliable);
+            _ackSystem = new AckSystem(this, config, socketInfo.MaxUnreliableSize, time, bufferPool, logger, metrics);
+        }
+
+        /// <summary>
+        /// single message, batched by AckSystem
+        /// </summary>
+        /// <param name="message"></param>
+        public override void SendReliable(byte[] message, int offset, int length)
+        {
+            ThrowIfNotConnectedOrConnecting();
+
+            if (length + HEADER_SIZE > _socketInfo.MaxReliableSize)
+            {
+                throw new ArgumentException($"Message is bigger than MTU, size:{length} but max message size is {_socketInfo.MaxReliableSize - HEADER_SIZE}");
+            }
+
+            _reliableBatch.AddMessage(message, offset, length);
+            _metrics?.OnSendMessageReliable(length);
+        }
+
+        public override void SendUnreliable(byte[] message, int offset, int length)
+        {
+            ThrowIfNotConnectedOrConnecting();
+
+            if (length + HEADER_SIZE > _socketInfo.MaxUnreliableSize)
+            {
+                throw new ArgumentException($"Message is bigger than MTU, size:{length} but max message size is {_socketInfo.MaxUnreliableSize - HEADER_SIZE}");
+            }
+
+            _unreliableBatch.AddMessage(message, offset, length);
+            _metrics?.OnSendMessageUnreliable(length);
+        }
+
+        /// <summary>
+        /// Use <see cref="INotifyCallBack"/> version for non-alloc
+        /// </summary>
+        public override INotifyToken SendNotify(byte[] packet, int offset, int length)
+        {
+            ThrowIfNotConnectedOrConnecting();
+            var token = _ackSystem.SendNotify(packet, offset, length);
+            _metrics?.OnSendMessageNotify(length);
+            return token;
+        }
+
+        /// <summary>
+        /// Use <see cref="INotifyCallBack"/> version for non-alloc
+        /// </summary>
+        public override void SendNotify(byte[] packet, int offset, int length, INotifyCallBack callBacks)
+        {
+            ThrowIfNotConnectedOrConnecting();
+            _ackSystem.SendNotify(packet, offset, length, callBacks);
+            _metrics?.OnSendMessageNotify(length);
+        }
+
+        internal override void ReceiveUnreliablePacket(Packet packet)
+        {
+            HandleReliableBatched(packet.Buffer.array, 1, packet.Length, PacketType.Unreliable);
+        }
+
+        internal override void ReceiveReliablePacket(Packet packet)
+        {
+            HandleReliableBatched(packet.Buffer.array, 1, packet.Length, PacketType.Reliable);
+        }
+
+        internal override void ReceiveReliableFragment(Packet packet) => throw new NotSupportedException();
+
+        internal override void ReceiveNotifyPacket(Packet packet)
+        {
+            var segment = _ackSystem.ReceiveNotify(packet.Buffer.array, packet.Length);
+            if (segment != default)
+            {
+                _metrics?.OnReceiveMessageNotify(packet.Length);
+                _dataHandler.ReceiveMessage(this, segment);
+            }
+        }
+
+        internal override void ReceiveNotifyAck(Packet packet)
+        {
+            _ackSystem.ReceiveAck(packet.Buffer.array);
+        }
+
+        public override void FlushBatch()
+        {
+            _ackSystem.Update();
+            _reliableBatch.Flush();
+            _unreliableBatch.Flush();
+        }
+
+        internal override bool IsValidSize(Packet packet)
+        {
+            const int minPacketSize = 1;
+
+            var length = packet.Length;
+            if (length < minPacketSize)
+                return false;
+
+            // Min size of message given to Mirage
+            const int minMessageSize = 2;
+
+            const int minCommandSize = 2;
+            const int minUnreliableSize = 1 + minMessageSize;
+
+            switch (packet.Type)
+            {
+                case PacketType.Command:
+                    return length >= minCommandSize;
+
+                case PacketType.Reliable:
+                case PacketType.Unreliable:
+                    return length >= minUnreliableSize;
+
+                case PacketType.Notify:
+                    return length >= AckSystem.NOTIFY_HEADER_SIZE + minMessageSize;
+                case PacketType.Ack:
+                    return length >= AckSystem.ACK_HEADER_SIZE;
+                case PacketType.ReliableFragment:
+                    // not supported
+                    return false;
+
+                default:
+                case PacketType.KeepAlive:
+                    return true;
+            }
+        }
+    }
+}

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/PassthroughConnection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/PassthroughConnection.cs
@@ -14,8 +14,8 @@ namespace Mirage.SocketLayer
         public PassthroughConnection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, SocketInfo socketInfo, Time time, Pool<ByteBuffer> bufferPool, ILogger logger, Metrics metrics)
             : base(peer, endPoint, dataHandler, config, socketInfo, time, logger, metrics)
         {
-            _reliableBatch = new ArrayBatch(socketInfo.MaxReliableSize, this, PacketType.Reliable, SendMode.Reliable);
-            _unreliableBatch = new ArrayBatch(socketInfo.MaxUnreliableSize, this, PacketType.Unreliable, SendMode.Unreliable);
+            _reliableBatch = new ArrayBatch(socketInfo.MaxReliableSize, logger, this, PacketType.Reliable, SendMode.Reliable);
+            _unreliableBatch = new ArrayBatch(socketInfo.MaxUnreliableSize, logger, this, PacketType.Unreliable, SendMode.Unreliable);
             _ackSystem = new AckSystem(this, config, socketInfo.MaxUnreliableSize, time, bufferPool, logger, metrics);
         }
 

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/PassthroughConnection.cs.meta
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/PassthroughConnection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc9c29bb7ffe23349b834ab6a92617c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/ReliableConnection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/ReliableConnection.cs
@@ -15,7 +15,7 @@ namespace Mirage.SocketLayer
             : base(peer, endPoint, dataHandler, config, socketInfo, time, logger, metrics)
         {
             Debug.Assert(socketInfo.Reliability == SocketReliability.Unreliable);
-            _unreliableBatch = new ArrayBatch(socketInfo.MaxUnreliableSize, this, PacketType.Unreliable, SendMode.Unreliable);
+            _unreliableBatch = new ArrayBatch(socketInfo.MaxUnreliableSize, logger, this, PacketType.Unreliable, SendMode.Unreliable);
             _ackSystem = new AckSystem(this, config, socketInfo.MaxUnreliableSize, time, bufferPool, logger, metrics);
         }
 

--- a/Assets/Mirage/Runtime/SocketLayer/Connection/ReliableConnection.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Connection/ReliableConnection.cs
@@ -6,33 +6,22 @@ namespace Mirage.SocketLayer
     /// <summary>
     /// Objects that represents a connection to/from a server/client. Holds state that is needed to update, send, and receive data
     /// </summary>
-    internal sealed class ReliableConnection : Connection, IRawConnection, IDisposable
+    internal sealed class ReliableConnection : Connection, IDisposable
     {
         private readonly AckSystem _ackSystem;
         private readonly Batch _unreliableBatch;
-        private readonly Pool<ByteBuffer> _bufferPool;
 
-        internal ReliableConnection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, int maxPacketSize, Time time, Pool<ByteBuffer> bufferPool, ILogger logger, Metrics metrics)
-            : base(peer, endPoint, dataHandler, config, maxPacketSize, time, logger, metrics)
+        internal ReliableConnection(Peer peer, IEndPoint endPoint, IDataHandler dataHandler, Config config, SocketInfo socketInfo, Time time, Pool<ByteBuffer> bufferPool, ILogger logger, Metrics metrics)
+            : base(peer, endPoint, dataHandler, config, socketInfo, time, logger, metrics)
         {
-            _bufferPool = bufferPool;
-            _unreliableBatch = new ArrayBatch(_maxPacketSize, SendBatchInternal, PacketType.Unreliable);
-            _ackSystem = new AckSystem(this, config, maxPacketSize, time, bufferPool, logger, metrics);
-        }
-
-        private void SendBatchInternal(byte[] batch, int length)
-        {
-            _peer.Send(this, batch, length);
+            Debug.Assert(socketInfo.Reliability == SocketReliability.Unreliable);
+            _unreliableBatch = new ArrayBatch(socketInfo.MaxUnreliableSize, this, PacketType.Unreliable, SendMode.Unreliable);
+            _ackSystem = new AckSystem(this, config, socketInfo.MaxUnreliableSize, time, bufferPool, logger, metrics);
         }
 
         public void Dispose()
         {
             _ackSystem.Dispose();
-        }
-
-        void IRawConnection.SendRaw(byte[] packet, int length)
-        {
-            _peer.Send(this, packet, length);
         }
 
         /// <summary>
@@ -71,9 +60,10 @@ namespace Mirage.SocketLayer
         {
             ThrowIfNotConnectedOrConnecting();
 
-            if (length + 1 > _maxPacketSize)
+            // todo allow message up to MaxUnreliableSize-1, by not batching
+            if (length + 1 + Batch.MESSAGE_LENGTH_SIZE > _socketInfo.MaxUnreliableSize)
             {
-                throw new ArgumentException($"Message is bigger than MTU, size:{length} but max Unreliable message size is {_maxPacketSize - 1}");
+                throw new ArgumentException($"Message is bigger than MTU, size:{length} but max Unreliable message size is {_socketInfo.MaxUnreliableSize - (1 + Batch.MESSAGE_LENGTH_SIZE)}");
             }
 
             _unreliableBatch.AddMessage(packet, offset, length);

--- a/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/ISocket.cs
@@ -37,7 +37,7 @@ namespace Mirage.SocketLayer
         ///     and make sure not to return <paramref name="bytesReceived"/> above that size
         /// </para>
         /// </summary>
-        /// <param name="buffer">buffer to write recevived packet into</param>
+        /// <param name="buffer">buffer to write receive packet into</param>
         /// <param name="endPoint">where packet came from</param>
         /// <returns>length of packet, should not be above <paramref name="buffer"/> length</returns>
         int Receive(byte[] buffer, out IEndPoint endPoint);
@@ -49,7 +49,13 @@ namespace Mirage.SocketLayer
         /// <param name="endPoint">where packet is being sent to</param>
         /// <param name="packet">buffer that contains the packet, starting at index 0</param>
         /// <param name="length">length of the packet</param>
-        void Send(IEndPoint endPoint, byte[] packet, int length);
+        void Send(IEndPoint endPoint, byte[] packet, int length, SendMode sendMode);
+    }
+
+    public enum SendMode
+    {
+        Unreliable = 0,
+        Reliable = 1,
     }
 
     /// <summary>

--- a/Assets/Mirage/Runtime/SocketLayer/Peer.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/Peer.cs
@@ -369,10 +369,18 @@ namespace Mirage.SocketLayer
 
         private void HandleNewConnection(IEndPoint endPoint, Packet packet)
         {
+            // first check if new packet is valid
             // if invalid, then reject without reason
-            if (!Validate(packet)) { return; }
+            // key could be anything, so any message over 2 could be key.
+            var minLength = 2;
+            if (packet.Length < minLength)
+                return;
+            if (packet.Type != PacketType.Command)
+                return;
+            if (packet.Command != Commands.ConnectRequest)
+                return;
 
-
+            // then process other reject reasons
             if (AtMaxConnections())
             {
                 RejectConnectionWithReason(endPoint, RejectReason.ServerFull);
@@ -389,23 +397,6 @@ namespace Mirage.SocketLayer
                 AcceptNewConnection(endPoint);
             }
         }
-
-        private bool Validate(Packet packet)
-        {
-            // key could be anything, so any message over 2 could be key.
-            var minLength = 2;
-            if (packet.Length < minLength)
-                return false;
-
-            if (packet.Type != PacketType.Command)
-                return false;
-
-            if (packet.Command != Commands.ConnectRequest)
-                return false;
-
-            return true;
-        }
-
         private bool AtMaxConnections()
         {
             return _connections.Count >= _config.MaxConnections;

--- a/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/SocketFactory.cs
@@ -32,9 +32,9 @@ namespace Mirage.SocketLayer
     [HelpURL("https://miragenet.github.io/Mirage/docs/general/sockets#changing-a-socket")]
     public abstract class SocketFactory : MonoBehaviour
     {
-        /// <summary>Max size for packets sent to or received from Socket
+        /// <summary>Gets info about the socket being created
         /// <para>Called once when Sockets are created</para></summary>
-        public abstract int MaxPacketSize { get; }
+        public abstract SocketInfo SocketInfo { get; }
 
         /// <summary>Creates a <see cref="ISocket"/> to be used by <see cref="Peer"/> on the server</summary>
         /// <exception cref="NotSupportedException">Throw when Server is not supported on current platform</exception>

--- a/Assets/Mirage/Runtime/SocketLayer/SocketInfo.cs
+++ b/Assets/Mirage/Runtime/SocketLayer/SocketInfo.cs
@@ -1,0 +1,97 @@
+using System;
+
+namespace Mirage.SocketLayer
+{
+    public enum SocketReliability
+    {
+        // note: 0 is unset, it will be used to check if SocketInfo is default or not
+
+        /// <summary>
+        /// all packets are unreliable, eg udp
+        /// </summary>
+        Unreliable = 1,
+
+        /// <summary>
+        /// all packets are reliable, eg tcp or webSockets
+        /// </summary>
+        Reliable = 2,
+
+        /// <summary>
+        /// if socket supports both reliable and unreliable, eg steam or epic relay
+        /// </summary>
+        Both = 3,
+    }
+
+    public readonly struct SocketInfo
+    {
+        /// <summary>
+        /// How the socket handles reliability
+        /// </summary>
+        public readonly SocketReliability Reliability;
+
+        /// <summary>
+        /// If socket supports Reliable, what is the max packet size. This should include max Fragmentation size if socket handles that
+        /// </summary>
+        public readonly int MaxReliableSize;
+
+        /// <summary>
+        /// If socket supports Unreliable, what is the max packet size
+        /// </summary>
+        public readonly int MaxUnreliableSize;
+
+        /// <summary>
+        /// Will the Socket handle Fragmentation for Reliable messages
+        /// <para>if false, Mirage will fragment message before sending them to socket</para>
+        /// </summary>
+        public readonly bool ReliableFragmentation;
+
+        /// <summary>
+        /// Max size required by either reliable or unreliable
+        /// </summary>
+        public readonly int MaxSize;
+
+        public SocketInfo(SocketReliability reliability, int maxReliableSize, int maxUnreliableSize, bool reliableFragmentation)
+        {
+            Reliability = reliability;
+            MaxReliableSize = maxReliableSize;
+            MaxUnreliableSize = maxUnreliableSize;
+            ReliableFragmentation = reliableFragmentation;
+            MaxSize = Math.Max(MaxReliableSize, MaxUnreliableSize);
+
+            // this smallest size that a socket must support to work with Mirage
+            // note: this number is arbitrary, but is a reasonable size, any smaller and too many packets will need to be fragmented and sent
+            const int minMessageSize = 100;
+            switch (reliability)
+            {
+                case SocketReliability.Unreliable:
+                    // Mirage will handle reliability, so max size must be big enough so that header can fit
+                    if (MaxUnreliableSize < AckSystem.MIN_RELIABLE_HEADER_SIZE + minMessageSize)
+                        throw new ArgumentException($"Max unreliable size too small for AckSystem header", nameof(maxUnreliableSize));
+                    break;
+                case SocketReliability.Reliable:
+                    // Mirage will just batch message and send them to socket
+                    if (MaxReliableSize < Batch.MESSAGE_LENGTH_SIZE + minMessageSize)
+                        throw new ArgumentException($"Max reliable size too small for Batch header", nameof(maxUnreliableSize));
+                    break;
+
+                case SocketReliability.Both:
+                    if (MaxUnreliableSize < AckSystem.NOTIFY_HEADER_SIZE + minMessageSize)
+                        throw new ArgumentException($"Max unreliable size too small for Notify header", nameof(maxUnreliableSize));
+
+                    if (MaxReliableSize < Batch.MESSAGE_LENGTH_SIZE + minMessageSize)
+                        throw new ArgumentException($"Max reliable size too small for AckSystem header", nameof(maxUnreliableSize));
+                    break;
+            }
+
+
+            if (MaxReliableSize > ushort.MaxValue)
+            {
+                throw new ArgumentException($"Max package size can not bigger than {ushort.MaxValue}. NoReliableConnection uses 2 bytes for message length, maxPacketSize over that value will mean that message will be incorrectly batched.");
+            }
+            if (MaxUnreliableSize > ushort.MaxValue)
+            {
+                throw new ArgumentException($"Max package size can not bigger than {ushort.MaxValue}. NoReliableConnection uses 2 bytes for message length, maxPacketSize over that value will mean that message will be incorrectly batched.");
+            }
+        }
+    }
+}

--- a/Assets/Mirage/Runtime/SocketLayer/SocketInfo.cs.meta
+++ b/Assets/Mirage/Runtime/SocketLayer/SocketInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66d3e84fcc908234fb336943fdea88ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirage/Runtime/Sockets/Udp/NanoSocket.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/NanoSocket.cs
@@ -6,7 +6,6 @@ using NanoSockets;
 
 namespace Mirage.Sockets.Udp
 {
-
     public sealed class NanoSocket : ISocket, IDisposable
     {
         public static bool Supported => true;
@@ -82,7 +81,7 @@ namespace Mirage.Sockets.Udp
             return count;
         }
 
-        public void Send(IEndPoint endPoint, byte[] packet, int length)
+        public void Send(IEndPoint endPoint, byte[] packet, int length, SendMode _)
         {
             var nanoEndPoint = (NanoEndPoint)endPoint;
             UDP.Send(socket, ref nanoEndPoint.address, packet, length);

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocket.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocket.cs
@@ -94,7 +94,7 @@ namespace Mirage.Sockets.Udp
             return c;
         }
 
-        public void Send(IEndPoint endPoint, byte[] packet, int length)
+        public void Send(IEndPoint endPoint, byte[] packet, int length, SendMode _)
         {
             var netEndPoint = ((EndPointWrapper)endPoint).inner;
             socket.SendTo(packet, length, SocketFlags.None, netEndPoint);

--- a/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
+++ b/Assets/Mirage/Runtime/Sockets/Udp/UdpSocketFactory.cs
@@ -26,8 +26,7 @@ namespace Mirage.Sockets.Udp
         [Header("NanoSocket-specific Options")]
         public int BufferSize = 256 * 1024;
 
-
-        public override int MaxPacketSize => UdpMTU.MaxPacketSize;
+        public override SocketInfo SocketInfo => new SocketInfo(SocketReliability.Unreliable, 0, UdpMTU.MaxPacketSize, false);
 
         // Determines if we can use NanoSockets for socket-level IO. This will be true if either:
         // - We *want* to use native library explicitly.

--- a/Assets/Tests/SocketLayer/AckSystem/NoReliableConnectionTest.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/NoReliableConnectionTest.cs
@@ -5,30 +5,28 @@ using Mirage.SocketLayer.Tests.PeerTests;
 using NSubstitute;
 using NUnit.Framework;
 
-namespace Mirage.SocketLayer.Tests.AckSystemTests
+namespace Mirage.SocketLayer.Tests
 {
     [Category("SocketLayer")]
-    public class NoReliableConnectionTest
+    public abstract class ConnectionTestBase
     {
-        private const int MAX_PACKET_SIZE = 100;
+        protected const int MAX_PACKET_SIZE = 100;
 
-        private IConnection _connection;
-        private byte[] _buffer;
-        private Config _config;
-        private PeerInstance _peerInstance;
-        private Pool<ByteBuffer> _bufferPool;
-        private readonly Random rand = new Random();
-        private byte[] _sentArray;
+        protected IConnection _connection;
+        protected byte[] _buffer;
+        protected Config _config;
+        protected PeerInstance _peerInstance;
+        protected Pool<ByteBuffer> _bufferPool;
+        protected readonly Random rand = new Random();
+        protected List<byte[]> _sentArrays = new List<byte[]>();
 
-        private ISocket Socket => _peerInstance.socket;
+        protected ISocket Socket => _peerInstance.socket;
+        protected abstract Config CreateConfig();
 
         [SetUp]
         public void Setup()
         {
-            _config = new Config
-            {
-                DisableReliableLayer = true,
-            };
+            _config = CreateConfig();
             _peerInstance = new PeerInstance(_config, maxPacketSize: MAX_PACKET_SIZE);
             _bufferPool = new Pool<ByteBuffer>(ByteBuffer.CreateNew, MAX_PACKET_SIZE, 0, 100);
 
@@ -41,14 +39,120 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             }
 
             // clear calls, Connect will have sent one
+            _sentArrays.Clear();
             Socket.ClearReceivedCalls();
             Socket.When(x => x.Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>()))
                 .Do(x =>
                 {
-                    var arg = (byte[])x.Args()[1];
+                    var packet = (byte[])x.Args()[1];
+                    var length = (int)x.Args()[2];
                     // create copy
-                    _sentArray = arg.ToArray();
+                    _sentArrays.Add(packet.Take(length).ToArray());
                 });
+        }
+
+
+        protected void AssertSentPacket(PacketType type, IEnumerable<int> messageLengths)
+        {
+            var totalLength = 1 + (2 * messageLengths.Count()) + messageLengths.Sum();
+
+            // only 1 at any length
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            // but also check we received length
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), totalLength);
+
+            // check packet was correct
+            CheckMessage(type, 0, 1, messageLengths);
+
+            // clear calls after, so we are ready to process next message
+            Socket.ClearReceivedCalls();
+            _sentArrays.Clear();
+        }
+
+        protected void CheckMessage(PacketType type, int sentIndex, int sendCount, IEnumerable<int> messageLengths, int skipHeader = 0)
+        {
+            Assert.That(_sentArrays.Count, Is.EqualTo(sendCount));
+            var packet = _sentArrays[sentIndex];
+            if (packet[0] != (byte)type)
+                Assert.Fail($"First byte should be the packet type, {type}, it was {(PacketType)packet[0]} instead");
+
+            var offset = 1;
+            foreach (var length in messageLengths)
+            {
+                if (skipHeader == 0)
+                {
+                    var ln = ByteUtils.ReadUShort(packet, ref offset);
+                    if (ln != length)
+                        Assert.Fail($"Length at offset {offset - 2} was incorrect.\n  Expected:{length}\n   But war:{ln}");
+
+
+                    for (var i = 0; i < length; i++)
+                    {
+                        if (packet[offset + i] != _buffer[i])
+                            Assert.Fail($"Value at offset {offset + i} was incorrect.\n  Expected:{_buffer[i]}\n   But war:{packet[offset + i]}");
+
+                    }
+                    offset += length;
+                }
+                else
+                {
+                    offset += skipHeader;
+                    for (var i = 0; i < length; i++)
+                    {
+                        if (packet[offset + i] != _buffer[i])
+                            Assert.Fail($"Value at offset {offset + i} was incorrect.\n  Expected:{_buffer[i]}\n   But war:{packet[offset + i]}");
+
+                    }
+                    offset += length;
+                }
+            }
+
+            Assert.That(offset, Is.EqualTo(packet.Length));
+        }
+
+        protected void SendIntoBatch(int length, bool reliable, ref int total, List<int> currentBatch)
+        {
+            // will write length+2
+            var newTotal = total + 2 + length;
+            if (newTotal > MAX_PACKET_SIZE)
+            {
+                Send(reliable, _buffer, length);
+                // was over max, so should have sent
+                AssertSentPacket(reliable ? PacketType.Reliable : PacketType.Unreliable, currentBatch);
+
+                currentBatch.Clear();
+                // new batch
+                total = 1 + 2 + length;
+            }
+            else
+            {
+                Send(reliable, _buffer, length);
+                Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+                total = newTotal;
+            }
+            currentBatch.Add(length);
+        }
+
+        protected void Send(bool reliable, byte[] buffer, int length)
+        {
+            if (reliable)
+                _connection.SendReliable(buffer, 0, length);
+            else
+                _connection.SendUnreliable(buffer, 0, length);
+        }
+    }
+
+    [Category("SocketLayer")]
+    public class NoReliableConnectionTest : ConnectionTestBase
+    {
+        private new Connection _connection => (Connection)base._connection;
+
+        protected override Config CreateConfig()
+        {
+            return new Config
+            {
+                DisableReliableLayer = true,
+            };
         }
 
         [Test]
@@ -72,45 +176,6 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             Assert.That(exception, Has.Message.EqualTo(expected.Message));
         }
 
-        private void AssertSentPacket(IEnumerable<int> messageLengths)
-        {
-            var totalLength = 1 + (2 * messageLengths.Count()) + messageLengths.Sum();
-
-            // only 1 at any length
-            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
-            // but also check we received length
-            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), totalLength);
-
-            // check packet was correct
-            CheckMessage(_sentArray, messageLengths);
-
-            // clear calls after, so we are ready to process next message
-            Socket.ClearReceivedCalls();
-        }
-
-        private void CheckMessage(byte[] packet, IEnumerable<int> messageLengths)
-        {
-            if (packet[0] != (byte)PacketType.Reliable)
-                Assert.Fail($"First byte was not Reliable, it was {packet[0]} instead");
-
-            var offset = 1;
-            foreach (var length in messageLengths)
-            {
-                var ln = ByteUtils.ReadUShort(packet, ref offset);
-                if (ln != length)
-                    Assert.Fail($"Length at offset {offset - 2} was incorrect.\n  Expected:{length}\n   But war:{ln}");
-
-
-                for (var i = 0; i < length; i++)
-                {
-                    if (packet[offset + i] != _buffer[i])
-                        Assert.Fail($"Value at offset {offset + i} was incorrect.\n  Expected:{_buffer[i]}\n   But war:{packet[offset + i]}");
-
-                }
-                offset += length;
-            }
-        }
-
         [Test]
         public void MessageAreBatched()
         {
@@ -130,7 +195,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
 
             // should be 97 in buffer now => 1+(length+2)*3
             _connection.SendReliable(_buffer, 0, overBatch);
-            AssertSentPacket(lessThanBatchLengths);
+            AssertSentPacket(PacketType.Reliable, lessThanBatchLengths);
         }
 
         [Test]
@@ -154,7 +219,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
                 {
                     _connection.SendReliable(_buffer, 0, length);
                     // was over max, so should have sent
-                    AssertSentPacket(currentBatch);
+                    AssertSentPacket(PacketType.Reliable, currentBatch);
 
                     currentBatch.Clear();
                     // new batch
@@ -187,7 +252,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             }
 
             _connection.FlushBatch();
-            AssertSentPacket(lessThanBatchLengths);
+            AssertSentPacket(PacketType.Reliable, lessThanBatchLengths);
         }
 
         [Test]
@@ -241,7 +306,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             _connection.SendUnreliable(_buffer, 0, counts[1]);
             _connection.FlushBatch();
 
-            AssertSentPacket(counts);
+            AssertSentPacket(PacketType.Reliable, counts);
         }
 
         [Test]
@@ -252,7 +317,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             _connection.SendNotify(_buffer, 0, counts[1]);
             _connection.FlushBatch();
 
-            AssertSentPacket(counts);
+            AssertSentPacket(PacketType.Reliable, counts);
         }
         [Test]
         public void SendingToNotifyTokenUsesReliable()
@@ -263,7 +328,7 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             _connection.SendNotify(_buffer, 0, counts[1], token);
             _connection.FlushBatch();
 
-            AssertSentPacket(counts);
+            AssertSentPacket(PacketType.Reliable, counts);
         }
 
         [Test]
@@ -272,6 +337,10 @@ namespace Mirage.SocketLayer.Tests.AckSystemTests
             var counts = new List<int>() { 10, 20 };
             var token = _connection.SendNotify(_buffer, 0, counts[0]);
             Assert.That(token, Is.TypeOf<AutoCompleteToken>());
+
+            var action = Substitute.For<Action>();
+            token.Delivered += action;
+            action.Received(1).Invoke();
         }
 
         [Test]

--- a/Assets/Tests/SocketLayer/AckSystem/NoReliableConnectionTest.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/NoReliableConnectionTest.cs
@@ -10,8 +10,6 @@ namespace Mirage.SocketLayer.Tests
     [Category("SocketLayer")]
     public abstract class ConnectionTestBase
     {
-        protected const int MAX_PACKET_SIZE = 100;
-
         protected IConnection _connection;
         protected byte[] _buffer;
         protected Config _config;
@@ -22,6 +20,7 @@ namespace Mirage.SocketLayer.Tests
 
         protected ISocket Socket => _peerInstance.socket;
         protected abstract Config CreateConfig();
+        protected virtual int MAX_PACKET_SIZE => 100;
 
         [SetUp]
         public void Setup()
@@ -196,6 +195,222 @@ namespace Mirage.SocketLayer.Tests
             // should be 97 in buffer now => 1+(length+2)*3
             _connection.SendReliable(_buffer, 0, overBatch);
             AssertSentPacket(PacketType.Reliable, lessThanBatchLengths);
+        }
+
+        [Test]
+        [Repeat(100)]
+        public void MessageAreBatched_Repeat()
+        {
+            const int messageCount = 10;
+            var lengths = new int[messageCount];
+            for (var i = 0; i < messageCount; i++)
+            {
+                lengths[i] = rand.Next(10, MAX_PACKET_SIZE - 3);
+            }
+            var currentBatch = new List<int>();
+
+            var total = 1;
+            foreach (var length in lengths)
+            {
+                // will write length+2
+                var newTotal = total + 2 + length;
+                if (newTotal > MAX_PACKET_SIZE)
+                {
+                    _connection.SendReliable(_buffer, 0, length);
+                    // was over max, so should have sent
+                    AssertSentPacket(PacketType.Reliable, currentBatch);
+
+                    currentBatch.Clear();
+                    // new batch
+                    total = 1 + 2 + length;
+                }
+                else
+                {
+                    _connection.SendReliable(_buffer, 0, length);
+                    Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+                    total = newTotal;
+                }
+                currentBatch.Add(length);
+            }
+        }
+
+        [Test]
+        public void FlushSendsMessageInBatch()
+        {
+            // max is 100
+
+            var lessThanBatchLengths = new int[]
+            {
+                20, 40
+            };
+
+            foreach (var length in lessThanBatchLengths)
+            {
+                _connection.SendReliable(_buffer, 0, length);
+                Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            }
+
+            _connection.FlushBatch();
+            AssertSentPacket(PacketType.Reliable, lessThanBatchLengths);
+        }
+
+        [Test]
+        public void FlushDoesNotSendEmptyMessage()
+        {
+            _connection.FlushBatch();
+            Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            _connection.FlushBatch();
+            Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+        }
+
+
+        [Test]
+        public void UnbatchesMessageOnReceive()
+        {
+            var receive = _bufferPool.Take();
+            receive.array[0] = (byte)PacketType.Reliable;
+            var offset = 1;
+            AddMessage(receive.array, ref offset, 10);
+            AddMessage(receive.array, ref offset, 30);
+            AddMessage(receive.array, ref offset, 20);
+
+            var segments = new List<ArraySegment<byte>>();
+            _peerInstance.dataHandler
+                .When(x => x.ReceiveMessage(_connection, Arg.Any<ArraySegment<byte>>()))
+                .Do(x => segments.Add(x.ArgAt<ArraySegment<byte>>(1)));
+            ((NoReliableConnection)_connection).ReceiveReliablePacket(new Packet(receive, offset));
+            _peerInstance.dataHandler.Received(3).ReceiveMessage(_connection, Arg.Any<ArraySegment<byte>>());
+
+
+            Assert.That(segments[0].Count, Is.EqualTo(10));
+            Assert.That(segments[1].Count, Is.EqualTo(30));
+            Assert.That(segments[2].Count, Is.EqualTo(20));
+            Assert.That(segments[0].SequenceEqual(new ArraySegment<byte>(_buffer, 0, 10)));
+            Assert.That(segments[1].SequenceEqual(new ArraySegment<byte>(_buffer, 0, 30)));
+            Assert.That(segments[2].SequenceEqual(new ArraySegment<byte>(_buffer, 0, 20)));
+        }
+
+        private void AddMessage(byte[] receive, ref int offset, int size)
+        {
+            ByteUtils.WriteUShort(receive, ref offset, (ushort)size);
+            Buffer.BlockCopy(_buffer, 0, receive, offset, size);
+            offset += size;
+        }
+
+        [Test]
+        public void SendingToUnreliableUsesReliable()
+        {
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendUnreliable(_buffer, 0, counts[0]);
+            _connection.SendUnreliable(_buffer, 0, counts[1]);
+            _connection.FlushBatch();
+
+            AssertSentPacket(PacketType.Reliable, counts);
+        }
+
+        [Test]
+        public void SendingToNotifyUsesReliable()
+        {
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendNotify(_buffer, 0, counts[0]);
+            _connection.SendNotify(_buffer, 0, counts[1]);
+            _connection.FlushBatch();
+
+            AssertSentPacket(PacketType.Reliable, counts);
+        }
+        [Test]
+        public void SendingToNotifyTokenUsesReliable()
+        {
+            var token = Substitute.For<INotifyCallBack>();
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendNotify(_buffer, 0, counts[0], token);
+            _connection.SendNotify(_buffer, 0, counts[1], token);
+            _connection.FlushBatch();
+
+            AssertSentPacket(PacketType.Reliable, counts);
+        }
+
+        [Test]
+        public void NotifyOnDeliveredInvoke()
+        {
+            var counts = new List<int>() { 10, 20 };
+            var token = _connection.SendNotify(_buffer, 0, counts[0]);
+            Assert.That(token, Is.TypeOf<AutoCompleteToken>());
+
+            var action = Substitute.For<Action>();
+            token.Delivered += action;
+            action.Received(1).Invoke();
+        }
+
+        [Test]
+        public void NotifyTokenOnDeliveredInvoke()
+        {
+            var token = Substitute.For<INotifyCallBack>();
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendNotify(_buffer, 0, counts[0], token);
+            token.Received(1).OnDelivered();
+        }
+    }
+
+
+
+    [Category("SocketLayer")]
+    public class LargeMessageOnTest : ConnectionTestBase
+    {
+        private new Connection _connection => (Connection)base._connection;
+        protected override int MAX_PACKET_SIZE => ushort.MaxValue + 5000;
+
+        protected override Config CreateConfig()
+        {
+            return new Config
+            {
+                DisableReliableLayer = true,
+            };
+        }
+
+        [Test]
+        public void ThrowsIfTooBig()
+        {
+            // 3 byte header, so max size is over max
+            var bigBuffer = new byte[MAX_PACKET_SIZE - 2];
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+            {
+                _connection.SendReliable(bigBuffer);
+            });
+
+            var expected = new ArgumentException($"Message is bigger than MTU, size:{bigBuffer.Length} but max message size is {MAX_PACKET_SIZE - 3}");
+            Assert.That(exception, Has.Message.EqualTo(expected.Message));
+        }
+
+        [Test]
+        public void MessageOverUshortAreNotBatched()
+        {
+            var length = ushort.MaxValue + 10;
+
+            _connection.SendReliable(_buffer, 0, length);
+
+            var totalLength = 1 + 2 + length;
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), totalLength);
+
+            // check packet was correct
+            Assert.That(_sentArrays.Count, Is.EqualTo(1));
+            var packet = _sentArrays[0];
+            Assert.That(packet.Length, Is.EqualTo(totalLength));
+            if (packet[0] != (byte)PacketType.Reliable)
+                Assert.Fail($"First byte should be the packet type, {PacketType.Reliable}, it was {(PacketType)packet[0]} instead");
+
+            var offset = 1;
+            var ln = ByteUtils.ReadUShort(packet, ref offset);
+            Assert.That(ln, Is.EqualTo(0), "non-batch message should have length zero");
+            for (var i = 0; i < length; i++)
+            {
+                if (packet[offset + i] != _buffer[i])
+                    Assert.Fail($"Value at offset {offset + i} was incorrect.\n  Expected:{_buffer[i]}\n   But war:{packet[offset + i]}");
+            }
+            offset += length;
+
+            Assert.That(offset, Is.EqualTo(packet.Length));
         }
 
         [Test]

--- a/Assets/Tests/SocketLayer/AckSystem/PassthroughConnectionTest.cs
+++ b/Assets/Tests/SocketLayer/AckSystem/PassthroughConnectionTest.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Mirage.SocketLayer.Tests
+{
+    [Category("SocketLayer")]
+    public class PassthroughConnectionTest : ConnectionTestBase
+    {
+        private new Connection _connection => (Connection)base._connection;
+
+        protected override Config CreateConfig()
+        {
+            return new Config
+            {
+                PassthroughReliableLayer = true,
+            };
+        }
+
+        [Test]
+        public void IsNoReliableConnection()
+        {
+            Assert.That(_connection, Is.TypeOf<PassthroughConnection>());
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ThrowsIfTooBig(bool reliable)
+        {
+            // 3 byte header, so max size is over max
+            var bigBuffer = new byte[MAX_PACKET_SIZE - 2];
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+            {
+                Send(reliable, bigBuffer, bigBuffer.Length);
+            });
+
+            var expected = new ArgumentException($"Message is bigger than MTU, size:{bigBuffer.Length} but max message size is {MAX_PACKET_SIZE - 3}");
+            Assert.That(exception, Has.Message.EqualTo(expected.Message));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void MessageAreBatched(bool reliable)
+        {
+            // max is 100
+
+            var lessThanBatchLengths = new int[]
+            {
+                20, 40, 30
+            };
+            var overBatch = 11;
+
+            foreach (var length in lessThanBatchLengths)
+            {
+                Send(reliable, _buffer, length);
+                Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            }
+
+            // should be 97 in buffer now => 1+(length+2)*3
+            Send(reliable, _buffer, overBatch);
+            AssertSentPacket(reliable ? PacketType.Reliable : PacketType.Unreliable, lessThanBatchLengths);
+        }
+
+        [Test]
+        [Repeat(100)]
+        [TestCase(10)]
+        [TestCase(100)]
+        public void MessageAreBatched_Repeat(int messageCount)
+        {
+            var lengths = new int[messageCount];
+            for (var i = 0; i < messageCount; i++)
+                lengths[i] = rand.Next(10, MAX_PACKET_SIZE - 3);
+
+            var currentBatch_reliable = new List<int>();
+            var currentBatch_unreliable = new List<int>();
+            var total_reliable = 1;
+            var total_unreliable = 1;
+            foreach (var length in lengths)
+            {
+                var reliable = rand.Next(0, 1) == 1;
+                if (reliable)
+                    SendIntoBatch(length, true, ref total_reliable, currentBatch_reliable);
+                else
+                    SendIntoBatch(length, false, ref total_unreliable, currentBatch_unreliable);
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void FlushSendsMessageInBatch(bool reliable)
+        {
+            // max is 100
+
+            var lessThanBatchLengths = new int[]
+            {
+                20, 40
+            };
+
+            foreach (var length in lessThanBatchLengths)
+            {
+                Send(reliable, _buffer, length);
+                Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            }
+
+            _connection.FlushBatch();
+            AssertSentPacket(reliable ? PacketType.Reliable : PacketType.Unreliable, lessThanBatchLengths);
+        }
+
+        [Test]
+        public void FlushSendsMessageInBatch_BothTypes()
+        {
+            // max is 100
+
+            var lessThanBatchLengths_reliable = new int[]
+            {
+                20, 40
+            };
+            var lessThanBatchLengths_unreliable = new int[]
+            {
+                15, 35, 20
+            };
+
+            foreach (var length in lessThanBatchLengths_reliable)
+            {
+                _connection.SendReliable(_buffer, 0, length);
+                Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            }
+            foreach (var length in lessThanBatchLengths_unreliable)
+            {
+                _connection.SendUnreliable(_buffer, 0, length);
+                Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            }
+
+            _connection.FlushBatch();
+
+            var totalLength_reliable = 1 + (2 * lessThanBatchLengths_reliable.Count()) + lessThanBatchLengths_reliable.Sum();
+            var totalLength_unreliable = 1 + (2 * lessThanBatchLengths_unreliable.Count()) + lessThanBatchLengths_unreliable.Sum();
+
+            // only 2 at any length
+            Socket.Received(2).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            // but also check we received length
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), totalLength_reliable);
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), totalLength_unreliable);
+
+            // check packet was correct
+            CheckMessage(PacketType.Reliable, 0, 2, lessThanBatchLengths_reliable);
+            CheckMessage(PacketType.Unreliable, 1, 2, lessThanBatchLengths_unreliable);
+
+            // clear calls after, so we are ready to process next message
+            Socket.ClearReceivedCalls();
+            _sentArrays.Clear();
+        }
+
+        [Test]
+        public void FlushDoesNotSendEmptyMessage()
+        {
+            _connection.FlushBatch();
+            Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            _connection.FlushBatch();
+            Socket.DidNotReceive().Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void UnbatchesMessageOnReceive(bool reliable)
+        {
+            var receive = _bufferPool.Take();
+            receive.array[0] = (byte)(reliable ? PacketType.Reliable : PacketType.Unreliable);
+            var offset = 1;
+            AddMessage(receive.array, ref offset, 10);
+            AddMessage(receive.array, ref offset, 30);
+            AddMessage(receive.array, ref offset, 20);
+
+            var segments = new List<ArraySegment<byte>>();
+            _peerInstance.dataHandler
+                .When(x => x.ReceiveMessage(_connection, Arg.Any<ArraySegment<byte>>()))
+                .Do(x => segments.Add(x.ArgAt<ArraySegment<byte>>(1)));
+            if (reliable)
+                _connection.ReceiveReliablePacket(new Packet(receive, offset));
+            else
+                _connection.ReceiveUnreliablePacket(new Packet(receive, offset));
+            _peerInstance.dataHandler.Received(3).ReceiveMessage(_connection, Arg.Any<ArraySegment<byte>>());
+
+
+            Assert.That(segments[0].Count, Is.EqualTo(10));
+            Assert.That(segments[1].Count, Is.EqualTo(30));
+            Assert.That(segments[2].Count, Is.EqualTo(20));
+            Assert.That(segments[0].SequenceEqual(new ArraySegment<byte>(_buffer, 0, 10)));
+            Assert.That(segments[1].SequenceEqual(new ArraySegment<byte>(_buffer, 0, 30)));
+            Assert.That(segments[2].SequenceEqual(new ArraySegment<byte>(_buffer, 0, 20)));
+        }
+
+        private void AddMessage(byte[] receive, ref int offset, int size)
+        {
+            ByteUtils.WriteUShort(receive, ref offset, (ushort)size);
+            Buffer.BlockCopy(_buffer, 0, receive, offset, size);
+            offset += size;
+        }
+
+        [Test]
+        public void SendingToUnreliableUsesUnreliable()
+        {
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendUnreliable(_buffer, 0, counts[0]);
+            _connection.SendUnreliable(_buffer, 0, counts[1]);
+            _connection.FlushBatch();
+
+            AssertSentPacket(PacketType.Unreliable, counts);
+        }
+
+        [Test]
+        public void SendingToNotifyUsesUnreliable()
+        {
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendNotify(_buffer, 0, counts[0]);
+            _connection.SendNotify(_buffer, 0, counts[1]);
+            _connection.FlushBatch();
+
+            // only 1 at any length
+            Socket.Received(2).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            // but also check we received length
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), AckSystem.NOTIFY_HEADER_SIZE + counts[0]);
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), AckSystem.NOTIFY_HEADER_SIZE + counts[1]);
+
+            // check packet was correct
+            CheckMessage(PacketType.Notify, 0, 2, counts.Take(1), AckSystem.NOTIFY_HEADER_SIZE - 1);
+            CheckMessage(PacketType.Notify, 1, 2, counts.Skip(1).Take(1), AckSystem.NOTIFY_HEADER_SIZE - 1);
+
+            // clear calls after, so we are ready to process next message
+            Socket.ClearReceivedCalls();
+            _sentArrays.Clear();
+        }
+        [Test]
+        public void SendingToNotifyTokenUsesUnreliable()
+        {
+            var token = Substitute.For<INotifyCallBack>();
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendNotify(_buffer, 0, counts[0], token);
+            _connection.SendNotify(_buffer, 0, counts[1], token);
+            _connection.FlushBatch();
+
+            // only 1 at any length
+            Socket.Received(2).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), Arg.Any<int>());
+            // but also check we received length
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), AckSystem.NOTIFY_HEADER_SIZE + counts[0]);
+            Socket.Received(1).Send(Arg.Any<IEndPoint>(), Arg.Any<byte[]>(), AckSystem.NOTIFY_HEADER_SIZE + counts[1]);
+
+            // check packet was correct
+            CheckMessage(PacketType.Notify, 0, 2, counts.Take(1), AckSystem.NOTIFY_HEADER_SIZE - 1);
+            CheckMessage(PacketType.Notify, 1, 2, counts.Skip(1).Take(1), AckSystem.NOTIFY_HEADER_SIZE - 1);
+
+            // clear calls after, so we are ready to process next message
+            Socket.ClearReceivedCalls();
+            _sentArrays.Clear();
+        }
+
+        [Test]
+        [Ignore("Not implemented")]
+        public void NotifyOnDeliveredInvokeAfterReceivingReply()
+        {
+            var counts = new List<int>() { 10, 20 };
+            var token = _connection.SendNotify(_buffer, 0, counts[0]);
+
+            var action = Substitute.For<Action>();
+            token.Delivered += action;
+            action.DidNotReceive().Invoke();
+
+            // todo receive message here, and then check if Delivered is infact called
+        }
+
+        [Test]
+        [Ignore("Not implemented")]
+        public void NotifyTokenOnDeliveredInvokeAfterReceivingReply()
+        {
+            var token = Substitute.For<INotifyCallBack>();
+            var counts = new List<int>() { 10, 20 };
+            _connection.SendNotify(_buffer, 0, counts[0], token);
+            token.DidNotReceive().OnDelivered();
+
+            // todo receive message here, and then check if Delivered is infact called
+        }
+    }
+}

--- a/Assets/Tests/SocketLayer/AckSystem/PassthroughConnectionTest.cs.meta
+++ b/Assets/Tests/SocketLayer/AckSystem/PassthroughConnectionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a78f3f5648f4170458c64f606fa76afd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
useful when using steam or epic relay and you want to use their reliability

Mirage work decide which connection type to use based on the values in SocketInfo. It will then use SendMode to tell the socket which channel it should usee for a message