### PR TITLE
fix: authenicator success message wording in NetworkClient

### DIFF
--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -272,8 +272,6 @@ namespace Mirage
 
         private void AuthenticationSuccessCallback(INetworkPlayer _, AuthSuccessMessage message)
         {
-            if (logger.LogEnabled()) logger.Log($"Authentication successful with {message.AuthenticatorName}");
-
             INetworkAuthenticator authenticator = null;
             // only need to check if server sent its name
             if (!string.IsNullOrEmpty(message.AuthenticatorName))
@@ -282,6 +280,12 @@ namespace Mirage
                     throw new InvalidOperationException("Authenticator set on server but not client");
 
                 authenticator = Authenticator.Authenticators.FirstOrDefault(x => x.AuthenticatorName == message.AuthenticatorName);
+                logger.Log($"Authentication was successful with {message.AuthenticatorName}");
+            }
+            else
+            {
+                // Better than a generic 'Client authentication successful with' that is like a sentence fragment
+                logger.Log("Authentication was successful without an authenticator set");
             }
 
             Player.SetAuthentication(new PlayerAuthentication(authenticator, null));


### PR DESCRIPTION
This is a simple fix to stop the NetworkClient emitting a weird line that is "Authentication succcessful with" (where there's nothing past 'with' since `message.AuthenticatorName` is null/empty). This commit now makes it emit either a success message with the name or it was successful w/o an authenticator.

Chance of breaking existing projects? Unlikely.
Will it break existing tests? Checked and didn't see any tests checking the logging being emitted, so (safely?) assuming No.