### PR TITLE
feat: storing message for Async spawning and applying them after

### DIFF
--- a/Assets/Mirage/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirage/Runtime/ClientObjectManager.cs
@@ -53,7 +53,7 @@ namespace Mirage
         /// </summary>
         public readonly Dictionary<ulong, NetworkIdentity> spawnableObjects = new Dictionary<ulong, NetworkIdentity>();
 
-        private readonly Dictionary<uint, PendingAsyncSpawn> pendingSpawn = new Dictionary<uint, PendingAsyncSpawn>();
+        internal readonly Dictionary<uint, PendingAsyncSpawn> pendingSpawn = new Dictionary<uint, PendingAsyncSpawn>();
 
         internal void ClientStarted(NetworkClient client)
         {
@@ -947,6 +947,8 @@ namespace Mirage
         /// </summary>
         private List<MessageType> _messageTypes;
         private PooledNetworkWriter _messageBytes;
+
+        public int PendingCount => _messageTypes?.Count ?? 0;
 
         public PendingAsyncSpawn(uint netid)
         {

--- a/Assets/Mirage/Runtime/NetworkClient.cs
+++ b/Assets/Mirage/Runtime/NetworkClient.cs
@@ -103,7 +103,6 @@ namespace Mirage
 
         public NetworkWorld World { get; private set; }
         public SyncVarSender SyncVarSender { get; private set; }
-        private SyncVarReceiver _syncVarReceiver;
         public MessageHandler MessageHandler { get; private set; }
 
         /// <summary>
@@ -136,7 +135,6 @@ namespace Mirage
 
             World = new NetworkWorld();
             SyncVarSender = new SyncVarSender();
-            _syncVarReceiver = new SyncVarReceiver(this, World);
 
             var endPoint = SocketFactory.GetConnectEndPoint(address, port);
             if (logger.LogEnabled()) logger.Log($"Client connecting to endpoint: {endPoint}");
@@ -145,6 +143,7 @@ namespace Mirage
             var maxPacketSize = SocketFactory.MaxPacketSize;
             MessageHandler = new MessageHandler(World, DisconnectOnException, RethrowException);
             var dataHandler = new DataHandler(this, MessageHandler);
+
             Metrics = EnablePeerMetrics ? new Metrics(MetricsSize) : null;
 
             var config = PeerConfig ?? new Config();
@@ -415,7 +414,6 @@ namespace Mirage
             // Clear references to help GC collect
             World = null;
             SyncVarSender = null;
-            _syncVarReceiver = null;
             MessageHandler = null;
             Metrics = null;
         }

--- a/Assets/Mirage/Runtime/NetworkServer.cs
+++ b/Assets/Mirage/Runtime/NetworkServer.cs
@@ -156,7 +156,6 @@ namespace Mirage
         // todo move syncVarsender, it doesn't need to be a public fields on network server any more
         public SyncVarSender SyncVarSender { get; private set; }
 
-        private SyncVarReceiver _syncVarReceiver;
         public MessageHandler MessageHandler { get; private set; }
 
         private Action<INetworkPlayer, AuthenticationResult> _authFallCallback;
@@ -215,7 +214,6 @@ namespace Mirage
             // Clear references to help GC collect
             World = null;
             SyncVarSender = null;
-            _syncVarReceiver = null;
             MessageHandler = null;
             Metrics = null;
 
@@ -257,9 +255,6 @@ namespace Mirage
             LocalClient = localClient;
             MessageHandler = new MessageHandler(World, DisconnectOnException, RethrowException);
             MessageHandler.RegisterHandler<NetworkPingMessage>(World.Time.OnServerPing, allowUnauthenticated: true);
-
-            // create after MessageHandler, SyncVarReceiver uses it 
-            _syncVarReceiver = new SyncVarReceiver(this, World);
 
             var dataHandler = new DataHandler(this, MessageHandler, _connections);
             Metrics = EnablePeerMetrics ? new Metrics(MetricsSize) : null;

--- a/Assets/Mirage/Runtime/RemoteCalls/RpcHandler.cs
+++ b/Assets/Mirage/Runtime/RemoteCalls/RpcHandler.cs
@@ -26,14 +26,18 @@ namespace Mirage.RemoteCalls
         /// </summary>
         private readonly RpcInvokeType _invokeType;
 
-        public RpcHandler(MessageHandler messageHandler, IObjectLocator objectLocator, RpcInvokeType invokeType)
+        public RpcHandler(IObjectLocator objectLocator, RpcInvokeType invokeType)
+        {
+            _objectLocator = objectLocator;
+            _invokeType = invokeType;
+        }
+
+        // note: client handles message in ClientObjectManager
+        public void ServerRegisterHandler(MessageHandler messageHandler)
         {
             messageHandler.RegisterHandler<RpcReply>(OnReply);
             messageHandler.RegisterHandler<RpcMessage>(OnRpcMessage);
             messageHandler.RegisterHandler<RpcWithReplyMessage>(OnRpcWithReplyMessage);
-
-            _objectLocator = objectLocator;
-            _invokeType = invokeType;
         }
 
         /// <summary>
@@ -41,7 +45,7 @@ namespace Mirage.RemoteCalls
         /// </summary>
         /// <param name="player"></param>
         /// <param name="msg"></param>
-        private void OnRpcWithReplyMessage(INetworkPlayer player, RpcWithReplyMessage msg)
+        internal void OnRpcWithReplyMessage(INetworkPlayer player, RpcWithReplyMessage msg)
         {
             HandleRpc(player, msg.NetId, msg.FunctionIndex, msg.Payload, msg.ReplyId);
         }
@@ -133,7 +137,7 @@ namespace Mirage.RemoteCalls
             return (completionSource.Task, newReplyId);
         }
 
-        private void OnReply(INetworkPlayer player, RpcReply reply)
+        internal void OnReply(INetworkPlayer player, RpcReply reply)
         {
             // find the callback that was waiting for this and invoke it.
             if (_callbacks.TryGetValue(reply.ReplyId, out var callbacks))

--- a/Assets/Mirage/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirage/Runtime/ServerObjectManager.cs
@@ -29,6 +29,7 @@ namespace Mirage
         private static List<NetworkIdentity> _spawnCache = new List<NetworkIdentity>();
 
         internal RpcHandler _rpcHandler;
+        private SyncVarReceiver _syncVarReceiver;
 
         private NetworkServer _server;
         public NetworkServer Server => _server;
@@ -50,7 +51,11 @@ namespace Mirage
 
             DefaultVisibility = new AlwaysVisible(server);
 
-            _rpcHandler = new RpcHandler(_server.MessageHandler, _server.World, RpcInvokeType.ServerRpc);
+            _rpcHandler = new RpcHandler(_server.World, RpcInvokeType.ServerRpc);
+            _rpcHandler.ServerRegisterHandler(_server.MessageHandler);
+
+            _syncVarReceiver = new SyncVarReceiver(_server.World);
+            _syncVarReceiver.ServerRegisterHandlers(_server.MessageHandler);
         }
 
         private void OnServerStopped()
@@ -69,6 +74,8 @@ namespace Mirage
             // clear server after stopping
             _server.Stopped.RemoveListener(OnServerStopped);
             _server = null;
+            _rpcHandler = null;
+            _syncVarReceiver = null;
         }
 
         internal void SpawnOrActivate()

--- a/Assets/Mirage/Runtime/SyncVarReceiver.cs
+++ b/Assets/Mirage/Runtime/SyncVarReceiver.cs
@@ -13,38 +13,18 @@ namespace Mirage
 
         private readonly IObjectLocator _objectLocator;
 
-        public SyncVarReceiver(NetworkClient client, IObjectLocator objectLocator)
+        public SyncVarReceiver(IObjectLocator objectLocator)
         {
             _objectLocator = objectLocator;
-            if (client.IsConnected)
-            {
-                AddHandlers(client);
-            }
-            else
-            {
-                // todo replace this with RunOnceEvent
-                client.Connected.AddListener(_ => AddHandlers(client));
-            }
         }
 
-        private void AddHandlers(NetworkClient client)
+        // note: client handles message in ClientObjectManager
+        public void ServerRegisterHandlers(MessageHandler messageHandler)
         {
-            // dont add if host player
-            // server should never sent to host
-            if (!client.IsHost)
-            {
-                client.MessageHandler.RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
-            }
+            messageHandler.RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
         }
 
-        public SyncVarReceiver(NetworkServer server, IObjectLocator objectLocator)
-        {
-            _objectLocator = objectLocator;
-            server.MessageHandler.RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
-        }
-
-
-        private void OnUpdateVarsMessage(INetworkPlayer sender, UpdateVarsMessage msg)
+        internal void OnUpdateVarsMessage(INetworkPlayer sender, UpdateVarsMessage msg)
         {
             if (logger.LogEnabled()) logger.Log("SyncVarReceiver.OnUpdateVarsMessage " + msg.NetId);
 


### PR DESCRIPTION
fixes: https://github.com/MirageNet/Mirage/issues/1186

- adding pending list to avoid spawning twice
- storing incoming message for netid if spawn is spending
- applying pending message in order after async spawn is complete
- (refactor) moving SyncVarReceiver to ObjectManagers